### PR TITLE
feat: trending anime row on home page

### DIFF
--- a/packages/backend/src/routes/tmdb.ts
+++ b/packages/backend/src/routes/tmdb.ts
@@ -4,6 +4,7 @@ import {
   getPopularMovies,
   getPopularTv,
   getUpcomingMovies,
+  getTrendingAnime,
   searchMulti,
   getMovieDetails,
   getTvDetails,
@@ -56,6 +57,14 @@ export async function tmdbRoutes(app: FastifyInstance) {
   }, async (request) => {
     const { page } = request.query as { page?: string };
     return getPopularTv(parsePage(page), getLang(request));
+  });
+
+  app.get('/tv/trending-anime', {
+    schema: { querystring: pageQuerySchema },
+    preHandler: [app.authenticate],
+  }, async (request) => {
+    const { page } = request.query as { page?: string };
+    return getTrendingAnime(parsePage(page), getLang(request));
   });
 
   app.get('/movies/upcoming', {

--- a/packages/backend/src/services/tmdb.ts
+++ b/packages/backend/src/services/tmdb.ts
@@ -164,6 +164,22 @@ export async function getPopularTv(page = 1, lang?: string) {
   }, 6);
 }
 
+const ANIME_KEYWORD_ID = 210024; // TMDB keyword "anime"
+
+export async function getTrendingAnime(page = 1, lang?: string) {
+  const l = normalizeLang(lang);
+  return cachedRequest(`trending:anime:${page}:${l}`, async () => {
+    const { data } = await getTmdbApi(l).get('/discover/tv', {
+      params: {
+        with_keywords: ANIME_KEYWORD_ID,
+        sort_by: 'popularity.desc',
+        page,
+      },
+    });
+    return data;
+  }, 6);
+}
+
 export async function getUpcomingMovies(page = 1, lang?: string) {
   const l = normalizeLang(lang);
   return cachedRequest(`upcoming:movies:${page}:${l}`, async () => {

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -87,6 +87,7 @@
   "home.trending_week": "Trending this week",
   "home.popular_movies": "Popular movies",
   "home.popular_series": "Popular series",
+  "home.trending_anime": "Trending anime",
   "home.coming_soon": "Coming soon in theaters",
 
   "login.title": "Sign in with your Plex account",
@@ -184,6 +185,7 @@
   "category.trending": "Trending this week",
   "category.popular_movies": "Popular movies",
   "category.popular_series": "Popular series",
+  "category.trending_anime": "Trending anime",
   "category.coming_soon": "Coming soon in theaters",
 
   "messages.title": "Support",

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -87,6 +87,7 @@
   "home.trending_week": "Tendances de la semaine",
   "home.popular_movies": "Films populaires",
   "home.popular_series": "Séries populaires",
+  "home.trending_anime": "Animés du moment",
   "home.coming_soon": "Prochainement au cinéma",
 
   "login.title": "Connectez-vous avec votre compte Plex",
@@ -184,6 +185,7 @@
   "category.trending": "Tendances de la semaine",
   "category.popular_movies": "Films populaires",
   "category.popular_series": "Séries populaires",
+  "category.trending_anime": "Animés du moment",
   "category.coming_soon": "Prochainement au cinéma",
 
   "messages.title": "Support",

--- a/packages/frontend/src/pages/CategoryPage.tsx
+++ b/packages/frontend/src/pages/CategoryPage.tsx
@@ -27,6 +27,11 @@ const CATEGORIES: Record<string, { titleKey: string; endpoint: string; mediaType
     endpoint: '/tmdb/movies/upcoming',
     mediaType: 'movie',
   },
+  'anime-trending': {
+    titleKey: 'category.trending_anime',
+    endpoint: '/tmdb/tv/trending-anime',
+    mediaType: 'tv',
+  },
 };
 
 export default function CategoryPage() {
@@ -46,9 +51,12 @@ export default function CategoryPage() {
     setResults([]);
     setPage(1);
     setLoading(true);
-    seenIds.current.clear();
+    seenIds.current = new Set();
 
+    const currentSlug = slug;
     api.get(`${category.endpoint}?page=1`).then(({ data }) => {
+      if (currentSlug !== slug) return; // stale request
+      seenIds.current = new Set();
       const items = dedup(data.results.map((r: TmdbMedia) => ({
         ...r,
         media_type: r.media_type || category.mediaType || (r.title ? 'movie' : 'tv'),

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -15,6 +15,7 @@ export default function HomePage() {
   const [popularMovies, setPopularMovies] = useState<TmdbMedia[]>([]);
   const [popularTv, setPopularTv] = useState<TmdbMedia[]>([]);
   const [upcoming, setUpcoming] = useState<TmdbMedia[]>([]);
+  const [trendingAnime, setTrendingAnime] = useState<TmdbMedia[]>([]);
   const [loading, setLoading] = useState(true);
   const [heroIndex, setHeroIndex] = useState(0);
   const [heroVisible, setHeroVisible] = useState(true);
@@ -37,12 +38,13 @@ export default function HomePage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const [recentRes, trendingRes, moviesRes, tvRes, upcomingRes] = await Promise.all([
+        const [recentRes, trendingRes, moviesRes, tvRes, upcomingRes, animeRes] = await Promise.all([
           api.get('/media/recent?limit=20'),
           api.get('/tmdb/trending'),
           api.get('/tmdb/movies/popular'),
           api.get('/tmdb/tv/popular'),
           api.get('/tmdb/movies/upcoming'),
+          api.get('/tmdb/tv/trending-anime'),
         ]);
         // Map DB media to TmdbMedia shape for MediaRow
         setRecentlyAdded(recentRes.data.map((m: { tmdbId: number; mediaType: string; title: string; posterPath: string | null; backdropPath: string | null; releaseDate: string | null; voteAverage: number | null }) => ({
@@ -62,6 +64,7 @@ export default function HomePage() {
         setPopularMovies(moviesRes.data.results);
         setPopularTv(tvRes.data.results);
         setUpcoming(upcomingRes.data.results);
+        setTrendingAnime(animeRes.data.results);
       } catch (err) {
         console.error('Failed to fetch homepage data', err);
       } finally {
@@ -210,6 +213,7 @@ export default function HomePage() {
           <MediaRow title={t('home.trending_week')} media={trending} loading={loading} href="/category/trending" size="large" />
           <MediaRow title={t('home.popular_movies')} media={popularMovies.map(m => ({ ...m, media_type: 'movie' }))} loading={loading} href="/category/movies-popular" />
           <MediaRow title={t('home.popular_series')} media={popularTv.map(m => ({ ...m, media_type: 'tv' }))} loading={loading} href="/category/tv-popular" />
+          <MediaRow title={t('home.trending_anime')} media={trendingAnime.map(m => ({ ...m, media_type: 'tv' }))} loading={loading} href="/category/anime-trending" />
           <GenreRow />
           <MediaRow title={t('home.coming_soon')} media={upcoming.map(m => ({ ...m, media_type: 'movie' }))} loading={loading} href="/category/movies-upcoming" />
         </div>


### PR DESCRIPTION
## Summary

- Add "Animés du moment" / "Trending anime" row on home page using TMDB discover with keyword 210024
- New backend endpoint `GET /api/tmdb/tv/trending-anime` with 6h cache
- New category page `/category/anime-trending` with infinite scroll
- Fix StrictMode dedup bug in CategoryPage that caused incorrect results on all category pages

## Test plan

- [ ] Home page shows "Animés du moment" row with anime series
- [ ] Click arrow → navigates to `/category/anime-trending` with full grid
- [ ] Home page and category page show the same results in the same order
- [ ] Infinite scroll loads more pages on category page
- [ ] Other category pages (trending, movies, series) also display correctly