### PR TITLE
fix: rules error feedback, collection requests, request status UX

### DIFF
--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -60,6 +60,7 @@
   "status.searching_long": "Searching...",
   "status.partially_available": "Partially available",
   "status.already_requested": "Already requested",
+  "status.request_sent": "Request sent!",
   "status.downloading_long": "Downloading...",
   "status.connected": "Connected",
   "status.connection_failed": "Connection failed",
@@ -197,6 +198,7 @@
   "media.season_one": "{{count}} season",
   "media.season_other": "{{count}} seasons",
   "media.collection_complete": "Collection complete",
+  "media.collection_in_progress": "Collection in progress...",
   "media.complete_collection": "Complete collection ({{count}} missing)",
   "media.request_collection": "Request entire collection",
   "media.requested_count": "{{requested}} requested, {{skipped}} skipped",
@@ -347,6 +349,7 @@
   "admin.paths.duplicate": "Duplicate",
   "admin.paths.confirm_delete_title": "Delete this rule?",
   "admin.paths.confirm_delete_desc": "This action cannot be undone. The routing rule will be permanently deleted.",
+  "admin.paths.services_unreachable": "Unable to reach: {{services}}. Check your configuration in the Services tab.",
 
   "admin.notifications.event.request_new": "New request",
   "admin.notifications.event.request_approved": "Request approved",

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -60,6 +60,7 @@
   "status.searching_long": "Recherche en cours",
   "status.partially_available": "Partiellement disponible",
   "status.already_requested": "Déjà demandé",
+  "status.request_sent": "Demande envoyée !",
   "status.downloading_long": "Téléchargement en cours",
   "status.connected": "Connecté",
   "status.connection_failed": "Connexion échouée",
@@ -197,6 +198,7 @@
   "media.season_one": "{{count}} saison",
   "media.season_other": "{{count}} saisons",
   "media.collection_complete": "Collection complète",
+  "media.collection_in_progress": "Collection en cours...",
   "media.complete_collection": "Compléter la collection ({{count}} manquants)",
   "media.request_collection": "Demander toute la collection",
   "media.requested_count": "{{requested}} demandés, {{skipped}} ignorés",
@@ -347,6 +349,7 @@
   "admin.paths.duplicate": "Dupliquer",
   "admin.paths.confirm_delete_title": "Supprimer cette règle ?",
   "admin.paths.confirm_delete_desc": "Cette action est irréversible. La règle de routage sera définitivement supprimée.",
+  "admin.paths.services_unreachable": "Impossible de joindre : {{services}}. Vérifiez la configuration dans l'onglet Services.",
 
   "admin.notifications.event.request_new": "Nouvelle demande",
   "admin.notifications.event.request_approved": "Demande approuvée",

--- a/packages/frontend/src/pages/MediaDetailPage.tsx
+++ b/packages/frontend/src/pages/MediaDetailPage.tsx
@@ -45,6 +45,7 @@ export default function MediaDetailPage({ type }: Props) {
   const [recommendations, setRecommendations] = useState<TmdbMedia[]>([]);
   const [loading, setLoading] = useState(true);
   const [requesting, setRequesting] = useState(false);
+  const [justRequested, setJustRequested] = useState(false);
   const [selectedSeasons, setSelectedSeasons] = useState<number[]>([]);
   const [scrollOpacity, setScrollOpacity] = useState(0);
   const [qualityOptions, setQualityOptions] = useState<{ id: number; label: string; position: number }[]>([]);
@@ -98,6 +99,7 @@ export default function MediaDetailPage({ type }: Props) {
     setSubtitleLanguages([]);
     setRevealed(false);
     setShowNsfwModal(false);
+    setJustRequested(false);
 
     async function fetchData() {
       try {
@@ -137,6 +139,7 @@ export default function MediaDetailPage({ type }: Props) {
         body.qualityOptionId = selectedQuality;
       }
       await api.post('/requests', body);
+      setJustRequested(true);
       invalidateMediaStatus(media.id, type);
       const { data } = await api.get(`/media/tmdb/${id}/${type}`);
       applyDbData(data);
@@ -224,7 +227,7 @@ export default function MediaDetailPage({ type }: Props) {
   const isSearching = dbMedia?.status === 'searching';
   const isDownloading = !!download;
   const activeRequests = dbMedia?.requests?.filter(
-    (r) => ['pending', 'approved', 'processing', 'available'].includes(r.status)
+    (r) => ['pending', 'approved', 'processing'].includes(r.status)
   ) || [];
   const takenQualityIds = new Set<number>([
     ...activeRequests.map(r => r.qualityOptionId).filter(Boolean) as number[],
@@ -447,7 +450,7 @@ export default function MediaDetailPage({ type }: Props) {
               ) : userHasRequest && !canRequestNewQuality && !isPartiallyAvailable ? (
                 <button disabled className="btn-success flex items-center gap-2 cursor-default">
                   <Check className="w-4 h-4" />
-                  {t('status.already_requested')}
+                  {justRequested ? t('status.request_sent') : t('status.already_requested')}
                 </button>
               ) : isPartiallyAvailable ? (
                 searchMissingState === 'searching' ? (
@@ -894,16 +897,23 @@ function CollectionSection({ collection }: { collection: { id: number; name: str
   };
 
   const availableCount = parts.filter((p) => statuses[`movie:${p.id}`]?.status === 'available').length;
+  const handledCount = parts.filter((p) => {
+    const s = statuses[`movie:${p.id}`];
+    return s?.status === 'available' || (s?.requestStatus && ['pending', 'approved', 'processing'].includes(s.requestStatus));
+  }).length;
   const totalCount = parts.length;
+  const allHandled = totalCount > 0 && handledCount === totalCount;
   const allAvailable = totalCount > 0 && availableCount === totalCount;
-  const someAvailable = availableCount > 0 && availableCount < totalCount;
+  const someHandled = handledCount > 0 && handledCount < totalCount;
 
   const buttonLabel = result
     ? t('media.requested_count', { requested: result.requested, skipped: result.skipped })
     : allAvailable
     ? t('media.collection_complete')
-    : someAvailable
-    ? t('media.complete_collection', { count: totalCount - availableCount })
+    : allHandled
+    ? t('media.collection_in_progress')
+    : someHandled
+    ? t('media.complete_collection', { count: totalCount - handledCount })
     : t('media.request_collection');
 
   return (
@@ -912,15 +922,15 @@ function CollectionSection({ collection }: { collection: { id: number; name: str
         <div className="flex items-center gap-3 min-w-0">
           <h3 className="text-lg font-bold text-ndp-text truncate">{collection.name}</h3>
           {!loading && (
-            <span className="text-xs text-ndp-text-dim flex-shrink-0">{availableCount}/{totalCount}</span>
+            <span className="text-xs text-ndp-text-dim flex-shrink-0">{handledCount}/{totalCount}</span>
           )}
         </div>
         {!allAvailable && (
-          <button onClick={requestAll} disabled={requesting || !!result || allAvailable}
+          <button onClick={requestAll} disabled={requesting || !!result || allHandled}
             className={clsx('text-sm flex items-center gap-2 flex-shrink-0',
-              result ? 'btn-success cursor-default' : someAvailable ? 'btn-secondary' : 'btn-primary'
+              allHandled ? 'btn-secondary opacity-60 cursor-default' : result ? 'btn-success cursor-default' : someHandled ? 'btn-secondary' : 'btn-primary'
             )}>
-            {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : result ? <Check className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+            {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : result ? <Check className="w-4 h-4" /> : allHandled ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
             {buttonLabel}
           </button>
         )}
@@ -935,11 +945,12 @@ function CollectionSection({ collection }: { collection: { id: number; name: str
           {parts.map((movie) => {
             const status = statuses[`movie:${movie.id}`];
             const isAvail = status?.status === 'available';
+            const isRequested = !isAvail && status?.requestStatus && ['pending', 'approved', 'processing'].includes(status.requestStatus);
             return (
               <Link key={movie.id} to={`/movie/${movie.id}`} className="flex-shrink-0 w-[120px] group">
                 <div className="aspect-[2/3] rounded-xl overflow-hidden bg-ndp-surface-light mb-1.5 relative">
                   {movie.poster_path ? (
-                    <img src={posterUrl(movie.poster_path, 'w185')} alt="" className={clsx('w-full h-full object-cover group-hover:scale-105 transition-transform', !isAvail && status && 'opacity-50')} />
+                    <img src={posterUrl(movie.poster_path, 'w185')} alt="" className={clsx('w-full h-full object-cover group-hover:scale-105 transition-transform', !isAvail && !isRequested && status && 'opacity-50')} />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center"><Film className="w-6 h-6 text-ndp-text-dim" /></div>
                   )}
@@ -948,7 +959,12 @@ function CollectionSection({ collection }: { collection: { id: number; name: str
                       <Check className="w-3 h-3 text-white" />
                     </div>
                   )}
-                  {status && !isAvail && status.status !== 'unknown' && (
+                  {isRequested && (
+                    <div className="absolute top-1.5 right-1.5 bg-ndp-accent/80 rounded-full p-0.5">
+                      <Loader2 className="w-3 h-3 text-white" />
+                    </div>
+                  )}
+                  {status && !isAvail && !isRequested && status.status !== 'unknown' && (
                     <div className="absolute top-1.5 right-1.5 bg-ndp-warning/80 rounded-full p-0.5">
                       <Plus className="w-3 h-3 text-white" />
                     </div>

--- a/packages/frontend/src/pages/admin/RoutingRulesTab.tsx
+++ b/packages/frontend/src/pages/admin/RoutingRulesTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus, Trash2, XCircle, Pencil, Copy, Power, GripVertical } from 'lucide-react';
+import { Plus, Trash2, XCircle, Pencil, Copy, Power, GripVertical, AlertTriangle } from 'lucide-react';
 import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import type { RootFolder } from '@/types';
@@ -38,6 +38,7 @@ export function RoutingRulesTab() {
   const [defaultMovieFolder, setDefaultMovieFolder] = useState('');
   const [defaultTvFolder, setDefaultTvFolder] = useState('');
   const [loading, setLoading] = useState(true);
+  const [unreachableServices, setUnreachableServices] = useState<string[]>([]);
 
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
@@ -79,16 +80,23 @@ export function RoutingRulesTab() {
 
         // Fetch rootfolders from each Radarr/Sonarr service instance
         const folders: { path: string; label: string; serviceId: number | null }[] = [];
+        const failed: string[] = [];
         const folderResults = await Promise.all(
-          arrServices.map(s => api.get(`/admin/services/${s.id}/rootfolders`).catch(() => ({ data: [] })))
+          arrServices.map(s => api.get(`/admin/services/${s.id}/rootfolders`).catch(() => ({ data: [], _failed: true })))
         );
         arrServices.forEach((svc, i) => {
+          const res = folderResults[i] as { data: RootFolder[]; _failed?: boolean };
+          if (res._failed || res.data.length === 0) {
+            failed.push(svc.name);
+            return;
+          }
           const url = svc.config?.url || '';
-          for (const f of (folderResults[i].data as RootFolder[])) {
+          for (const f of res.data) {
             folders.push({ path: f.path, label: `${f.path} — ${svc.name}${url ? ` (${url})` : ''}`, serviceId: svc.id });
           }
         });
         setLabeledFolders(folders);
+        setUnreachableServices(failed);
       } catch (err) { console.error(err); }
       finally { setLoading(false); }
     }
@@ -199,6 +207,15 @@ export function RoutingRulesTab() {
         </button>
       </div>
       <p className="text-xs text-ndp-text-dim mb-4">{t('admin.paths.rules_help')}</p>
+
+      {unreachableServices.length > 0 && (
+        <div className="flex items-center gap-3 p-3 rounded-xl bg-ndp-warning/10 border border-ndp-warning/20 mb-4">
+          <AlertTriangle className="w-4 h-4 text-ndp-warning flex-shrink-0" />
+          <p className="text-sm text-ndp-warning">
+            {t('admin.paths.services_unreachable', { services: unreachableServices.join(', ') })}
+          </p>
+        </div>
+      )}
 
       <div className="space-y-3">
         {/* Rules */}


### PR DESCRIPTION
## Summary

- **#58**: Show inline warning in Rules tab when Radarr/Sonarr services are unreachable, with service names to help troubleshoot
- **#60**: Collection "complete" button now accounts for already requested movies — 3 states: complete (all available), in progress (all handled but not all downloaded), and missing (needs requests). Requested movies show a loader badge and are not grayed out
- **#48**: Show "Demande envoyée !" confirmation after requesting instead of jumping straight to "Déjà demandé". Align frontend active request filter with backend (exclude `available` status so users can re-request in different quality)

## Test plan

- [ ] Rules tab: disconnect a Radarr/Sonarr service → warning banner appears with service name
- [ ] Collection: request a movie in a saga → button shows "Collection en cours..." (disabled) not "Collection complète"
- [ ] Request: click "Demander" on a new movie → button shows "Demande envoyée !" then transitions to download status
- [ ] Request: movie already available from previous request → can still request in different quality

Closes #58, closes #60, closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)