### PR TITLE
feat: instance language config with locale-aware content rating

### DIFF
--- a/packages/backend/prisma/migrations/20260405200000_add_instance_languages/migration.sql
+++ b/packages/backend/prisma/migrations/20260405200000_add_instance_languages/migration.sql
@@ -1,0 +1,2 @@
+-- Add instance languages configuration
+ALTER TABLE "AppSettings" ADD COLUMN "instanceLanguages" TEXT NOT NULL DEFAULT '["en"]';

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -159,6 +159,7 @@ model AppSettings {
   siteName              String    @default("Oscarr")
   registrationEnabled   Boolean   @default(true)
   missingSearchCooldownMin Int   @default(60) // Minutes before allowing another missing search
+  instanceLanguages     String    @default("[\"en\"]") // JSON array of ISO 639-1 codes, e.g. ["fr","en"]
   updatedAt             DateTime  @updatedAt
 }
 

--- a/packages/backend/src/routes/admin.ts
+++ b/packages/backend/src/routes/admin.ts
@@ -55,7 +55,10 @@ export async function adminRoutes(app: FastifyInstance) {
         data: { id: 1, updatedAt: new Date() },
       });
     }
-    return settings;
+    return {
+      ...settings,
+      instanceLanguages: JSON.parse(settings.instanceLanguages),
+    };
   });
 
   app.put('/settings', {
@@ -76,6 +79,7 @@ export async function adminRoutes(app: FastifyInstance) {
           supportEnabled: { type: 'boolean', description: 'Enable the support/ticket system' },
           calendarEnabled: { type: 'boolean', description: 'Enable the calendar feature' },
           siteName: { type: 'string', description: 'Custom site name' },
+          instanceLanguages: { type: 'array', items: { type: 'string' }, description: 'Instance languages (ISO 639-1 codes)' },
         },
       },
     },
@@ -95,6 +99,7 @@ export async function adminRoutes(app: FastifyInstance) {
       supportEnabled?: boolean;
       calendarEnabled?: boolean;
       siteName?: string;
+      instanceLanguages?: string[];
     };
 
     const settings = await prisma.appSettings.upsert({
@@ -113,6 +118,7 @@ export async function adminRoutes(app: FastifyInstance) {
         supportEnabled: body.supportEnabled ?? undefined,
         calendarEnabled: body.calendarEnabled ?? undefined,
         siteName: body.siteName ?? undefined,
+        instanceLanguages: body.instanceLanguages ? JSON.stringify(body.instanceLanguages) : undefined,
       },
       create: {
         id: 1,
@@ -129,6 +135,7 @@ export async function adminRoutes(app: FastifyInstance) {
         supportEnabled: body.supportEnabled,
         calendarEnabled: body.calendarEnabled,
         siteName: body.siteName,
+        instanceLanguages: body.instanceLanguages ? JSON.stringify(body.instanceLanguages) : undefined,
         updatedAt: new Date(),
       },
     });

--- a/packages/backend/src/routes/media.ts
+++ b/packages/backend/src/routes/media.ts
@@ -143,12 +143,12 @@ export async function mediaRoutes(app: FastifyInstance) {
           liveAvailable = true;
           const mi = radarrMovie.movieFile?.mediaInfo;
           if (mi?.audioLanguages) {
-            audioLanguages = mi.audioLanguages.split(' / ').map((s) => s.trim()).filter(Boolean);
+            audioLanguages = mi.audioLanguages.split('/').map((s) => s.trim()).filter(Boolean);
           } else if (radarrMovie.movieFile?.languages?.length) {
             audioLanguages = radarrMovie.movieFile.languages.map((l) => l.name);
           }
           if (mi?.subtitles) {
-            subtitleLanguages = mi.subtitles.split(' / ').map((s) => s.trim()).filter(Boolean);
+            subtitleLanguages = mi.subtitles.split('/').map((s) => s.trim()).filter(Boolean);
           }
         }
       } else if (mediaType === 'tv') {
@@ -188,7 +188,7 @@ export async function mediaRoutes(app: FastifyInstance) {
                 for (const f of files) {
                   if (f.mediaInfo?.audioLanguages) {
                     const seen = new Set<string>();
-                    for (const l of f.mediaInfo.audioLanguages.split(' / ')) {
+                    for (const l of f.mediaInfo.audioLanguages.split('/')) {
                       const t = l.trim();
                       if (t && !seen.has(t)) { seen.add(t); audioCounts.set(t, (audioCounts.get(t) || 0) + 1); }
                     }

--- a/packages/backend/src/services/tmdb.ts
+++ b/packages/backend/src/services/tmdb.ts
@@ -5,18 +5,45 @@ const TMDB_BASE = 'https://api.themoviedb.org/3';
 const TMDB_DEFAULT_KEY = 'db55323b8d3e4154498498a75642b381';
 const TMDB_API_KEY = process.env.TMDB_API_KEY || TMDB_DEFAULT_KEY;
 
-const SUPPORTED_LANGS = ['en', 'fr'];
+import { prisma } from '../utils/prisma.js';
+
 const DEFAULT_LANG = 'en';
 
-function normalizeLang(lang?: string): string {
-  if (!lang) return DEFAULT_LANG;
-  const short = lang.split('-')[0].toLowerCase();
-  return SUPPORTED_LANGS.includes(short) ? short : DEFAULT_LANG;
+/** Get instance languages from AppSettings, cached for 5 min */
+let _cachedLangs: string[] | null = null;
+let _cachedAt = 0;
+export async function getInstanceLanguages(): Promise<string[]> {
+  if (_cachedLangs && Date.now() - _cachedAt < 300_000) return _cachedLangs;
+  const settings = await prisma.appSettings.findUnique({ where: { id: 1 }, select: { instanceLanguages: true } });
+  const parsed: string[] = settings?.instanceLanguages ? JSON.parse(settings.instanceLanguages) : ['en'];
+  _cachedLangs = parsed.includes('en') ? parsed : [...parsed, 'en'];
+  _cachedAt = Date.now();
+  return _cachedLangs!;
 }
 
+function normalizeLang(lang?: string): string {
+  const supported = _cachedLangs || ['en'];
+  if (!lang) return supported[0] || DEFAULT_LANG;
+  const short = lang.split('-')[0].toLowerCase();
+  return supported.includes(short) ? short : supported[0] || DEFAULT_LANG;
+}
+
+const LANG_TO_LOCALE: Record<string, string> = {
+  en: 'en-US', fr: 'fr-FR', de: 'de-DE', es: 'es-ES', it: 'it-IT',
+  pt: 'pt-BR', ru: 'ru-RU', ja: 'ja-JP', ko: 'ko-KR', zh: 'zh-CN',
+  nl: 'nl-NL', sv: 'sv-SE', da: 'da-DK', no: 'nb-NO', fi: 'fi-FI',
+  pl: 'pl-PL', tr: 'tr-TR', ar: 'ar-SA', hi: 'hi-IN', th: 'th-TH',
+};
+
+const LANG_TO_COUNTRY: Record<string, string> = {
+  en: 'US', fr: 'FR', de: 'DE', es: 'ES', it: 'IT', pt: 'BR',
+  ru: 'RU', ja: 'JP', ko: 'KR', zh: 'CN', nl: 'NL', sv: 'SE',
+  da: 'DK', no: 'NO', fi: 'FI', pl: 'PL', tr: 'TR', ar: 'SA',
+  hi: 'IN', th: 'TH',
+};
+
 function toTmdbLocale(lang: string): string {
-  const map: Record<string, string> = { en: 'en-US', fr: 'fr-FR' };
-  return map[lang] || 'en-US';
+  return LANG_TO_LOCALE[lang] || 'en-US';
 }
 
 function getTmdbApi(lang = DEFAULT_LANG) {
@@ -118,8 +145,14 @@ const MATURE_RATINGS = new Set([
 /** Non-informative ratings to skip when extracting */
 const SKIP_RATINGS = new Set(['NR', 'Not Rated', '']);
 
-/** Priority list of countries to check for content rating */
-const RATING_COUNTRIES = ['US', 'FR', 'DE', 'BR', 'RU', 'IT'];
+/** Build country priority list: instance languages first, then fallback */
+function getRatingCountries(): string[] {
+  const langs = _cachedLangs || ['en'];
+  const instanceCountries = langs.map(l => LANG_TO_COUNTRY[l]).filter(Boolean);
+  const fallback = ['US', 'FR', 'DE', 'BR', 'RU', 'IT'];
+  // Instance countries first, then remaining fallbacks (deduplicated)
+  return [...new Set([...instanceCountries, ...fallback])];
+}
 
 /** Extract the most relevant content rating from movie or TV details */
 export function extractContentRating(details: TmdbMovie | TmdbTv): string | null {
@@ -127,8 +160,9 @@ export function extractContentRating(details: TmdbMovie | TmdbTv): string | null
   const tv = details as TmdbTv;
 
   // TV: content_ratings
+  const ratingCountries = getRatingCountries();
   if (tv.content_ratings?.results?.length) {
-    for (const country of RATING_COUNTRIES) {
+    for (const country of ratingCountries) {
       const match = tv.content_ratings.results.find((r) => r.iso_3166_1 === country);
       if (match?.rating && !SKIP_RATINGS.has(match.rating)) return match.rating;
     }
@@ -139,7 +173,7 @@ export function extractContentRating(details: TmdbMovie | TmdbTv): string | null
 
   // Movie: release_dates (certifications)
   if (movie.release_dates?.results?.length) {
-    for (const country of RATING_COUNTRIES) {
+    for (const country of ratingCountries) {
       const countryData = movie.release_dates.results.find((r) => r.iso_3166_1 === country);
       if (countryData) {
         const cert = countryData.release_dates.find((rd) => rd.certification && !SKIP_RATINGS.has(rd.certification))?.certification;

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -413,6 +413,8 @@
 
   "admin.general.oscarr": "Oscarr",
   "admin.general.site_name": "Site name",
+  "admin.general.instance_languages": "Instance language",
+  "admin.general.instance_languages_desc": "Primary language for this instance. Affects TMDB metadata and content rating.",
   "admin.general.site_name_desc": "Displayed in the browser tab and on the login page",
   "admin.general.current_version": "Current version:",
   "admin.general.update_available": "v{{version}} available",

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -413,6 +413,8 @@
 
   "admin.general.oscarr": "Oscarr",
   "admin.general.site_name": "Nom du site",
+  "admin.general.instance_languages": "Langue de l'instance",
+  "admin.general.instance_languages_desc": "La langue principale de cette instance. Affecte les métadonnées TMDB et le classement du contenu.",
   "admin.general.site_name_desc": "Affiché dans l'onglet du navigateur et sur la page de connexion",
   "admin.general.current_version": "Version actuelle :",
   "admin.general.update_available": "v{{version}} disponible",

--- a/packages/frontend/src/pages/admin/GeneralTab.tsx
+++ b/packages/frontend/src/pages/admin/GeneralTab.tsx
@@ -8,6 +8,27 @@ import { useFeatures } from '@/context/FeaturesContext';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 
+const AVAILABLE_LANGUAGES = [
+  { code: 'fr', label: 'Français' },
+  { code: 'en', label: 'English' },
+  { code: 'de', label: 'Deutsch' },
+  { code: 'es', label: 'Español' },
+  { code: 'it', label: 'Italiano' },
+  { code: 'pt', label: 'Português' },
+  { code: 'nl', label: 'Nederlands' },
+  { code: 'ja', label: '日本語' },
+  { code: 'ko', label: '한국어' },
+  { code: 'zh', label: '中文' },
+  { code: 'ru', label: 'Русский' },
+  { code: 'ar', label: 'العربية' },
+  { code: 'pl', label: 'Polski' },
+  { code: 'tr', label: 'Türkçe' },
+  { code: 'sv', label: 'Svenska' },
+  { code: 'da', label: 'Dansk' },
+  { code: 'no', label: 'Norsk' },
+  { code: 'fi', label: 'Suomi' },
+];
+
 export function GeneralTab() {
   const { t } = useTranslation();
   const { refreshFeatures } = useFeatures();
@@ -20,6 +41,7 @@ export function GeneralTab() {
   const [calendarEnabled, setCalendarEnabled] = useState(true);
   const [missingSearchCooldownMin, setMissingSearchCooldownMin] = useState(60);
   const [siteName, setSiteName] = useState('Oscarr');
+  const [instanceLanguage, setInstanceLanguage] = useState('en');
   const [bannerText, setBannerText] = useState('');
   const [loading, setLoading] = useState(true);
   const [versionInfo, setVersionInfo] = useState<{ current: string; latest?: string; updateAvailable?: boolean; releaseUrl?: string } | null>(null);
@@ -34,6 +56,7 @@ export function GeneralTab() {
         setCalendarEnabled(data.calendarEnabled ?? true);
         setMissingSearchCooldownMin(data.missingSearchCooldownMin ?? 60);
         setSiteName(data.siteName ?? 'Oscarr');
+        setInstanceLanguage(data.instanceLanguages?.[0] ?? 'en');
       }),
       api.get('/app/banner').then(({ data }) => setBannerText(data.banner || '')),
       api.get('/app/version').then(({ data }) => setVersionInfo(data)),
@@ -52,6 +75,7 @@ export function GeneralTab() {
           calendarEnabled,
           missingSearchCooldownMin,
           siteName: siteName.trim() || 'Oscarr',
+          instanceLanguages: [instanceLanguage],
         }),
         api.put('/admin/banner', { banner: bannerText.trim() || null }),
       ]);
@@ -121,6 +145,21 @@ export function GeneralTab() {
             placeholder="Oscarr"
             className="input w-full text-sm"
           />
+        </div>
+        <div className="card p-4">
+          <div className="mb-2">
+            <span className="text-sm font-medium text-ndp-text">{t('admin.general.instance_languages')}</span>
+            <span className="text-xs text-ndp-text-dim ml-2">{t('admin.general.instance_languages_desc')}</span>
+          </div>
+          <select
+            value={instanceLanguage}
+            onChange={(e) => setInstanceLanguage(e.target.value)}
+            className="input text-sm w-full"
+          >
+            {AVAILABLE_LANGUAGES.map(({ code, label }) => (
+              <option key={code} value={code}>{label}</option>
+            ))}
+          </select>
         </div>
         <div className="card p-4">
           <div className="mb-2">


### PR DESCRIPTION
## Summary

- Add configurable **instance language** in admin General tab (single dropdown, 18 languages)
- Content rating now **prioritizes the instance's country** — a French instance checks FR rating first (e.g. `12`) instead of US (`TV-MA`), preventing false NSFW blurs
- TMDB metadata fetched in the instance language with automatic English fallback
- Fix audio language parsing: Sonarr uses compact format (`fre/eng`) not spaced (`fre / eng`)

## Changes

- **Schema**: `instanceLanguages` field on AppSettings (JSON array, default `["en"]`)
- **Backend**: Dynamic `RATING_COUNTRIES` priority based on instance locale, cached 5min
- **Backend**: Unified `/` split for audio and subtitle languages (fixes missing audio on multi-language files)
- **Frontend**: Language dropdown in General tab with 18 languages
- **i18n**: FR/EN translations

## Test plan

- [ ] Set instance language to Français → "For All Mankind" should NOT be blurred (FR rating is `12`)
- [ ] Set instance language to English → "For All Mankind" SHOULD be blurred (US rating is `TV-MA`)
- [ ] Check audio/subtitle badges on a multi-language series → both languages should appear
- [ ] Verify TMDB metadata loads in the configured language

Closes #63, closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)