### PR TITLE
perf: scroll optimizations, memo components, navbar border fix

### DIFF
--- a/packages/frontend/src/components/GenreRow.tsx
+++ b/packages/frontend/src/components/GenreRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, memo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -83,7 +83,7 @@ export const ALL_GENRES: GenreItem[] = [
   { id: 37, nameKey: 'genre.western', mediaType: 'movie' },
 ];
 
-export default function GenreRow() {
+function GenreRow() {
   const { t } = useTranslation();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [backdrops, setBackdrops] = useState<Record<number, string | null>>({});
@@ -94,12 +94,6 @@ export default function GenreRow() {
       .then(({ data }) => {
         if (cancelled) return;
         setBackdrops(data);
-        for (const path of Object.values(data)) {
-          if (path) {
-            const img = new Image();
-            img.src = backdropUrl(path, 'w780');
-          }
-        }
       })
       .catch(() => {});
     return () => { cancelled = true; };
@@ -115,7 +109,7 @@ export default function GenreRow() {
   };
 
   return (
-    <section className="relative group/row">
+    <section className="relative group/row" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 160px' }}>
       <h2 className="text-xl font-bold text-ndp-text mb-4 px-4 sm:px-8">{t('genre.title')}</h2>
 
       <div className="relative">
@@ -147,7 +141,7 @@ export default function GenreRow() {
                 className="flex-shrink-0 group/card"
               >
                 <div
-                  className={`w-[180px] sm:w-[200px] h-[100px] sm:h-[110px] rounded-xl bg-gradient-to-br ${gradient} flex items-center justify-center relative overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl`}
+                  className={`w-[180px] sm:w-[200px] h-[100px] sm:h-[110px] rounded-xl bg-gradient-to-br ${gradient} flex items-center justify-center relative overflow-hidden will-change-transform transition-[transform,box-shadow] duration-300 hover:scale-105 hover:shadow-xl`}
                 >
                   {bdPath && (
                     <>
@@ -177,3 +171,5 @@ export default function GenreRow() {
     </section>
   );
 }
+
+export default memo(GenreRow);

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -161,8 +161,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
       <nav
         className={clsx(
-          'fixed left-0 right-0 z-50 transition-all duration-300',
-          scrolled ? 'glass border-none' : 'bg-transparent',
+          'fixed left-0 right-0 z-50 transition-[background-color,backdrop-filter] duration-300',
+          scrolled ? 'bg-ndp-surface/80 backdrop-blur-xl' : 'bg-transparent',
         )}
         style={{ top: `${topOffset * 4}px` }}
       >

--- a/packages/frontend/src/components/MediaCard.tsx
+++ b/packages/frontend/src/components/MediaCard.tsx
@@ -53,7 +53,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
     <Link
       to={link}
       className={clsx(
-        'group relative flex-shrink-0 rounded-xl overflow-hidden transition-all duration-300 hover:scale-105 hover:z-10 hover:shadow-2xl hover:shadow-black/50',
+        'group relative flex-shrink-0 rounded-xl overflow-hidden will-change-transform transition-[transform,box-shadow] duration-300 hover:scale-105 hover:z-10 hover:shadow-2xl hover:shadow-black/50',
         className
       )}
     >
@@ -64,7 +64,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
             src={posterUrl(media.poster_path, 'w342')}
             alt={title}
             className={clsx(
-              'w-full h-full object-cover transition-all duration-500 ease-out',
+              'w-full h-full object-cover transition-opacity duration-500 ease-out',
               loaded ? 'opacity-100' : 'opacity-0',
               nsfw && 'blur-xl scale-110',
             )}
@@ -82,7 +82,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); setRevealed(true); }}
             className="absolute inset-0 flex items-center justify-center cursor-pointer group/nsfw"
           >
-            <div className="p-2 rounded-full bg-black/30 backdrop-blur-sm shadow-lg shadow-black/30 group-hover/nsfw:bg-black/50 transition-colors">
+            <div className="p-2 rounded-full bg-black/50 shadow-lg shadow-black/30 group-hover/nsfw:bg-black/70 transition-colors">
               <EyeOff className="w-5 h-5 text-white/80 group-hover/nsfw:text-white transition-colors" />
             </div>
           </button>
@@ -124,7 +124,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
       </div>
 
       {/* Top-left: media type badge (hidden on hover) */}
-      <div className="absolute top-2 left-2 bg-black/60 backdrop-blur-sm rounded-md p-1 transition-opacity duration-300 group-hover:opacity-0">
+      <div className="absolute top-2 left-2 bg-black/75 rounded-md p-1 transition-opacity duration-300 group-hover:opacity-0">
         {type === 'movie' ? (
           <Film className="w-3 h-3 text-white/80" />
         ) : (
@@ -134,7 +134,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
 
       {/* Top-right: rating (hidden on hover) */}
       {media.vote_average > 0 && (
-        <div className="absolute top-2 right-2 flex items-center gap-1 bg-black/60 backdrop-blur-sm px-1.5 py-0.5 rounded-md transition-opacity duration-300 group-hover:opacity-0">
+        <div className="absolute top-2 right-2 flex items-center gap-1 bg-black/75 px-1.5 py-0.5 rounded-md transition-opacity duration-300 group-hover:opacity-0">
           <Star className="w-3 h-3 fill-ndp-gold text-ndp-gold" />
           <span className="text-xs font-medium text-white">{media.vote_average.toFixed(1)}</span>
         </div>
@@ -142,7 +142,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
 
       {/* Bottom-left: latest episode badge for TV */}
       {media.lastEpisodeInfo && type === 'tv' && (
-        <div className="absolute bottom-2 left-2 px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-black/60 text-white backdrop-blur-sm transition-opacity duration-300 group-hover:opacity-0">
+        <div className="absolute bottom-2 left-2 px-1.5 py-0.5 rounded-md text-[10px] font-semibold bg-black/75 text-white transition-opacity duration-300 group-hover:opacity-0">
           S{String(media.lastEpisodeInfo.season).padStart(2, '0')}E{String(media.lastEpisodeInfo.episode).padStart(2, '0')}
         </div>
       )}
@@ -150,7 +150,7 @@ export default function MediaCard({ media, className, availability, index = 0 }:
       {/* Bottom-right: availability status (hidden on hover) */}
       {statusBadge && (
         <div className={clsx(
-          'absolute bottom-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-semibold backdrop-blur-sm transition-opacity duration-300 group-hover:opacity-0',
+          'absolute bottom-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-semibold transition-opacity duration-300 group-hover:opacity-0',
           statusBadge.bgClass
         )}>
           <statusBadge.icon className="w-3 h-3" />

--- a/packages/frontend/src/components/MediaRow.tsx
+++ b/packages/frontend/src/components/MediaRow.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, memo } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
 import MediaCard, { MediaCardSkeleton } from './MediaCard';
@@ -18,7 +18,7 @@ const SIZE_CLASSES = {
   large: 'w-[180px] sm:w-[210px] lg:w-[240px]',
 };
 
-export default function MediaRow({ title, media, loading, href, size = 'default' }: MediaRowProps) {
+function MediaRow({ title, media, loading, href, size = 'default' }: MediaRowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const statuses = useMediaStatus(media);
 
@@ -32,7 +32,7 @@ export default function MediaRow({ title, media, loading, href, size = 'default'
   };
 
   return (
-    <section className="relative group/row">
+    <section className="relative group/row" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 300px' }}>
       <div className="flex items-center gap-2 mb-4 px-4 sm:px-8">
         <h2 className="text-xl font-bold text-ndp-text">{title}</h2>
         {href && (
@@ -86,3 +86,5 @@ export default function MediaRow({ title, media, loading, href, size = 'default'
     </section>
   );
 }
+
+export default memo(MediaRow);

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -21,14 +21,14 @@ export default function HomePage() {
   const [heroIndex, setHeroIndex] = useState(0);
   const [heroVisible, setHeroVisible] = useState(true);
   const prevHeroRef = useRef(0);
-  const [scrollOpacity, setScrollOpacity] = useState(0);
+  const scrollFadeRef = useRef<HTMLDivElement>(null);
 
   const handleScroll = useCallback(() => {
     const scrollY = window.scrollY;
     const fadeStart = 100;
     const fadeEnd = 500;
     const opacity = Math.min(1, Math.max(0, (scrollY - fadeStart) / (fadeEnd - fadeStart)));
-    setScrollOpacity(opacity);
+    if (scrollFadeRef.current) scrollFadeRef.current.style.opacity = String(opacity);
   }, []);
 
   useEffect(() => {
@@ -130,8 +130,9 @@ export default function HomePage() {
         )}
         {/* Scroll-driven fade to bg color */}
         <div
+          ref={scrollFadeRef}
           className="absolute inset-0 bg-ndp-bg transition-none"
-          style={{ opacity: scrollOpacity }}
+          style={{ opacity: 0 }}
         />
       </div>
 


### PR DESCRIPTION
## Summary

Follow-up performance and UI fixes after #72.

### Scroll optimizations
- `content-visibility: auto` on MediaRow and GenreRow — browser skips rendering off-screen sections
- Replace `backdrop-blur-sm` with solid opacity on MediaCard badges — eliminates 320 compositing layers (Safari)
- Targeted `transition-[transform,box-shadow]` instead of `transition-all` on MediaCard
- `will-change: transform` on MediaCard for GPU compositing
- Remove eager backdrop image preloading in GenreRow

### React re-render fixes
- `React.memo()` on MediaRow and GenreRow — hero auto-rotate no longer re-renders all rows
- Replace `useState` scroll opacity with `useRef` + direct DOM — no React re-render on scroll

### UI fix
- Fix navbar border flash on scroll: `transition-all` was interpolating the glass border during state change. Now only transition `background-color` and `backdrop-filter`, and inline the glass styles without border.

## Test plan

- [ ] Homepage scroll smooth on Chrome
- [ ] No border flash on navbar when scrolling up/down
- [ ] No visual regression on MediaCard badges
- [ ] Hero carousel doesn't cause visible lag in rows below

Partially addresses #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)