### PR TITLE
fix: NSFW blur too aggressive + admin toggle

### DIFF
--- a/packages/backend/prisma/migrations/20260409101718_add_nsfw_blur_toggle/migration.sql
+++ b/packages/backend/prisma/migrations/20260409101718_add_nsfw_blur_toggle/migration.sql
@@ -1,0 +1,33 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_AppSettings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT DEFAULT 1,
+    "defaultQualityProfile" INTEGER,
+    "defaultMovieFolder" TEXT,
+    "defaultTvFolder" TEXT,
+    "defaultAnimeFolder" TEXT,
+    "plexMachineId" TEXT,
+    "lastRadarrSync" DATETIME,
+    "lastSonarrSync" DATETIME,
+    "syncIntervalHours" INTEGER NOT NULL DEFAULT 6,
+    "notificationMatrix" TEXT,
+    "incidentBanner" TEXT,
+    "autoApproveRequests" BOOLEAN NOT NULL DEFAULT false,
+    "requestsEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "supportEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "calendarEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "siteName" TEXT NOT NULL DEFAULT 'Oscarr',
+    "registrationEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "nsfwBlurEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "missingSearchCooldownMin" INTEGER NOT NULL DEFAULT 60,
+    "instanceLanguages" TEXT NOT NULL DEFAULT '["en"]',
+    "siteUrl" TEXT,
+    "apiKey" TEXT,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_AppSettings" ("apiKey", "autoApproveRequests", "calendarEnabled", "defaultAnimeFolder", "defaultMovieFolder", "defaultQualityProfile", "defaultTvFolder", "id", "incidentBanner", "instanceLanguages", "lastRadarrSync", "lastSonarrSync", "missingSearchCooldownMin", "notificationMatrix", "plexMachineId", "registrationEnabled", "requestsEnabled", "siteName", "siteUrl", "supportEnabled", "syncIntervalHours", "updatedAt") SELECT "apiKey", "autoApproveRequests", "calendarEnabled", "defaultAnimeFolder", "defaultMovieFolder", "defaultQualityProfile", "defaultTvFolder", "id", "incidentBanner", "instanceLanguages", "lastRadarrSync", "lastSonarrSync", "missingSearchCooldownMin", "notificationMatrix", "plexMachineId", "registrationEnabled", "requestsEnabled", "siteName", "siteUrl", "supportEnabled", "syncIntervalHours", "updatedAt" FROM "AppSettings";
+DROP TABLE "AppSettings";
+ALTER TABLE "new_AppSettings" RENAME TO "AppSettings";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -162,6 +162,7 @@ model AppSettings {
   calendarEnabled       Boolean   @default(true)
   siteName              String    @default("Oscarr")
   registrationEnabled   Boolean   @default(true)
+  nsfwBlurEnabled       Boolean   @default(true)
   missingSearchCooldownMin Int   @default(60) // Minutes before allowing another missing search
   instanceLanguages     String    @default("[\"en\"]") // JSON array of ISO 639-1 codes, e.g. ["fr","en"]
   siteUrl               String?   // Public URL of the instance (e.g. https://oscarr.example.com) for notification links

--- a/packages/backend/src/routes/admin/settings.ts
+++ b/packages/backend/src/routes/admin/settings.ts
@@ -70,6 +70,7 @@ export async function settingsRoutes(app: FastifyInstance) {
           registrationEnabled: { type: 'boolean', description: 'Allow new account registration' },
           missingSearchCooldownMin: { type: 'number', description: 'Cooldown in minutes before allowing another missing search' },
           requestsEnabled: { type: 'boolean', description: 'Enable the request system' },
+          nsfwBlurEnabled: { type: 'boolean', description: 'Enable NSFW content blur' },
           supportEnabled: { type: 'boolean', description: 'Enable the support/ticket system' },
           calendarEnabled: { type: 'boolean', description: 'Enable the calendar feature' },
           siteName: { type: 'string', description: 'Custom site name' },
@@ -91,6 +92,7 @@ export async function settingsRoutes(app: FastifyInstance) {
       registrationEnabled?: boolean;
       missingSearchCooldownMin?: number;
       requestsEnabled?: boolean;
+      nsfwBlurEnabled?: boolean;
       supportEnabled?: boolean;
       calendarEnabled?: boolean;
       siteName?: string;
@@ -111,6 +113,7 @@ export async function settingsRoutes(app: FastifyInstance) {
         registrationEnabled: body.registrationEnabled ?? undefined,
         missingSearchCooldownMin: body.missingSearchCooldownMin ?? undefined,
         requestsEnabled: body.requestsEnabled ?? undefined,
+        nsfwBlurEnabled: body.nsfwBlurEnabled ?? undefined,
         supportEnabled: body.supportEnabled ?? undefined,
         calendarEnabled: body.calendarEnabled ?? undefined,
         siteName: body.siteName ?? undefined,

--- a/packages/backend/src/routes/app.ts
+++ b/packages/backend/src/routes/app.ts
@@ -99,6 +99,7 @@ export async function appRoutes(app: FastifyInstance) {
       calendarEnabled: settings?.calendarEnabled ?? true,
       siteName: settings?.siteName ?? 'Oscarr',
       registrationEnabled: settings?.registrationEnabled ?? true,
+      nsfwBlurEnabled: settings?.nsfwBlurEnabled ?? true,
       ...pluginFeatures,
     };
   });

--- a/packages/backend/src/routes/tmdb.ts
+++ b/packages/backend/src/routes/tmdb.ts
@@ -80,7 +80,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
 
   }, async (request) => {
     const { page } = request.query as { page?: string };
-    return getTrending(parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await getTrending(parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/movies/popular', {
@@ -88,7 +91,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
 
   }, async (request) => {
     const { page } = request.query as { page?: string };
-    return getPopularMovies(parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await getPopularMovies(parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/tv/popular', {
@@ -96,7 +102,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
 
   }, async (request) => {
     const { page } = request.query as { page?: string };
-    return getPopularTv(parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await getPopularTv(parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'tv', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/tv/trending-anime', {
@@ -104,7 +113,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
 
   }, async (request) => {
     const { page } = request.query as { page?: string };
-    return getTrendingAnime(parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await getTrendingAnime(parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'tv', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/movies/upcoming', {
@@ -112,7 +124,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
 
   }, async (request) => {
     const { page } = request.query as { page?: string };
-    return getUpcomingMovies(parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await getUpcomingMovies(parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/search', {
@@ -132,7 +147,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
     if (!q || q.trim().length === 0) {
       return { results: [], total_pages: 0, total_results: 0 };
     }
-    return searchMulti(q.trim(), parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await searchMulti(q.trim(), parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/movie/:id', {
@@ -168,7 +186,7 @@ export async function tmdbRoutes(app: FastifyInstance) {
     if (!movieId) return reply.status(400).send({ error: 'Invalid ID' });
     const lang = getLang(request);
     const data = await getMovieRecommendations(movieId, lang);
-    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'movie', lang).catch(() => []);
     return { ...data, nsfwTmdbIds };
   });
 
@@ -181,7 +199,7 @@ export async function tmdbRoutes(app: FastifyInstance) {
     if (!tvId) return reply.status(400).send({ error: 'Invalid ID' });
     const lang = getLang(request);
     const data = await getTvRecommendations(tvId, lang);
-    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'tv', lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], 'tv', lang).catch(() => []);
     return { ...data, nsfwTmdbIds };
   });
 
@@ -216,7 +234,10 @@ export async function tmdbRoutes(app: FastifyInstance) {
     }
     const gid = parseId(genreId);
     if (!gid) return reply.status(400).send({ error: 'Invalid genreId' });
-    return discoverByGenre(mediaType, gid, parsePage(page), getLang(request));
+    const lang = getLang(request);
+    const data = await discoverByGenre(mediaType, gid, parsePage(page), lang);
+    const nsfwTmdbIds = await trackAndFlagNsfw(data.results || [], mediaType, lang).catch(() => []);
+    return { ...data, nsfwTmdbIds };
   });
 
   app.get('/genre-backdrops', async () => {

--- a/packages/backend/src/services/sync/keywordSync.ts
+++ b/packages/backend/src/services/sync/keywordSync.ts
@@ -6,16 +6,23 @@ const BATCH_SIZE = 20;
 const BATCH_DELAY_MS = 1000;
 
 /** Upsert keywords into the Keyword table and store IDs + content rating on the media row */
+/** Keywords auto-tagged as NSFW when first seen */
+const AUTO_NSFW_KEYWORDS = new Set([
+  'hentai', 'softcore', 'sexploitation',
+  'pornography', 'pornographic video', 'adult animation',
+]);
+
 async function upsertKeywordsAndRating(
   mediaId: number,
   keywords: { id: number; name: string }[],
   contentRating: string | null,
 ): Promise<void> {
   for (const kw of keywords) {
+    const autoTag = AUTO_NSFW_KEYWORDS.has(kw.name.toLowerCase()) ? 'nsfw' : undefined;
     await prisma.keyword.upsert({
       where: { tmdbId: kw.id },
       update: { name: kw.name },
-      create: { tmdbId: kw.id, name: kw.name },
+      create: { tmdbId: kw.id, name: kw.name, ...(autoTag ? { tag: autoTag } : {}) },
     });
   }
 
@@ -88,10 +95,11 @@ export async function trackKeywordsFromDetails(
   const contentRating = await extractContentRating(details);
 
   for (const kw of keywords) {
+    const autoTag = AUTO_NSFW_KEYWORDS.has(kw.name.toLowerCase()) ? 'nsfw' : undefined;
     await prisma.keyword.upsert({
       where: { tmdbId: kw.id },
       update: { name: kw.name },
-      create: { tmdbId: kw.id, name: kw.name },
+      create: { tmdbId: kw.id, name: kw.name, ...(autoTag ? { tag: autoTag } : {}) },
     });
   }
 

--- a/packages/backend/src/services/tmdb.ts
+++ b/packages/backend/src/services/tmdb.ts
@@ -146,10 +146,10 @@ export function extractKeywords(details: TmdbMovie | TmdbTv): { id: number; name
   return movie.keywords?.keywords ?? tv.keywords?.results ?? [];
 }
 
-/** Ratings considered mature/NSFW */
+/** Ratings considered explicitly adult/NSFW (not just age-restricted) */
 const MATURE_RATINGS = new Set([
-  'NC-17', 'TV-MA', 'X',       // US
-  '18', '18+', 'VM18',         // FR, DE, BR, RU, IT
+  'NC-17', 'X', 'XXX',         // US explicit
+  'VM18',                       // IT explicit
 ]);
 
 /** Non-informative ratings to skip when extracting */

--- a/packages/frontend/src/hooks/useNsfwFilter.ts
+++ b/packages/frontend/src/hooks/useNsfwFilter.ts
@@ -1,5 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import api from '@/lib/api';
+import { registerNsfwHandler } from '@/lib/api';
+import { useFeatures } from '@/context/FeaturesContext';
 
 const STORAGE_KEY = 'nsfw-show-all';
 
@@ -24,6 +26,8 @@ export function useNsfwFilter() {
 }
 
 export function useNsfwFilterProvider() {
+  const { features } = useFeatures();
+  const blurEnabled = features?.nsfwBlurEnabled !== false;
   const [nsfwSet, setNsfwSet] = useState<Set<number>>(new Set());
   const [showAll, setShowAll] = useState(() => localStorage.getItem(STORAGE_KEY) === 'true');
   const [loaded, setLoaded] = useState(false);
@@ -49,8 +53,14 @@ export function useNsfwFilterProvider() {
     });
   }, []);
 
+  // Register global interceptor so any API response with nsfwTmdbIds auto-updates the filter
+  useEffect(() => {
+    registerNsfwHandler(addNsfwIds);
+    return () => registerNsfwHandler(() => {});
+  }, [addNsfwIds]);
+
   return {
-    isNsfw: (tmdbId: number) => !showAll && nsfwSet.has(tmdbId),
+    isNsfw: (tmdbId: number) => blurEnabled && !showAll && nsfwSet.has(tmdbId),
     addNsfwIds,
     showAll,
     disableBlur,

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -497,6 +497,8 @@
   "admin.general.feature.auto_approve_desc": "Requests are automatically approved without admin validation",
   "admin.general.feature.support": "Support",
   "admin.general.feature.support_desc": "Support ticket system",
+  "admin.general.feature.nsfw_blur": "NSFW blur",
+  "admin.general.feature.nsfw_blur_desc": "Blur content rated as explicitly adult (NC-17, X). Does not affect age-restricted content (R, 18+).",
   "admin.general.feature.calendar": "Calendar",
   "admin.general.feature.calendar_desc": "Upcoming releases calendar",
 

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -497,6 +497,8 @@
   "admin.general.feature.auto_approve_desc": "Les demandes sont automatiquement approuvées sans validation admin",
   "admin.general.feature.support": "Support",
   "admin.general.feature.support_desc": "Système de tickets de support",
+  "admin.general.feature.nsfw_blur": "Flou NSFW",
+  "admin.general.feature.nsfw_blur_desc": "Flouter le contenu classé explicitement adulte (NC-17, X). N'affecte pas le contenu avec restriction d'âge (R, 18+).",
   "admin.general.feature.calendar": "Calendrier",
   "admin.general.feature.calendar_desc": "Calendrier des sorties à venir",
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -42,8 +42,18 @@ function showErrorToast(message: string) {
   setTimeout(() => { toast.style.opacity = '0'; setTimeout(() => toast.remove(), 300); }, 4000);
 }
 
+// Global NSFW detection — any API response with nsfwTmdbIds automatically updates the filter
+let _addNsfwIds: ((ids: number[]) => void) | null = null;
+export function registerNsfwHandler(handler: (ids: number[]) => void) { _addNsfwIds = handler; }
+
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    const ids = response.data?.nsfwTmdbIds;
+    if (Array.isArray(ids) && ids.length > 0 && _addNsfwIds) {
+      _addNsfwIds(ids);
+    }
+    return response;
+  },
   (error) => {
     // 401 handling is done by AuthContext + InstallGuard, not here
     if (error.response?.status === 403) {

--- a/packages/frontend/src/pages/admin/GeneralTab.tsx
+++ b/packages/frontend/src/pages/admin/GeneralTab.tsx
@@ -40,6 +40,7 @@ export function GeneralTab() {
   const [requestsEnabled, setRequestsEnabled] = useState(true);
   const [supportEnabled, setSupportEnabled] = useState(true);
   const [calendarEnabled, setCalendarEnabled] = useState(true);
+  const [nsfwBlurEnabled, setNsfwBlurEnabled] = useState(true);
   const [missingSearchCooldownMin, setMissingSearchCooldownMin] = useState(60);
   const [siteName, setSiteName] = useState('Oscarr');
   const [siteUrl, setSiteUrl] = useState('');
@@ -66,6 +67,7 @@ export function GeneralTab() {
           requestsEnabled: data.requestsEnabled ?? true,
           supportEnabled: data.supportEnabled ?? true,
           calendarEnabled: data.calendarEnabled ?? true,
+          nsfwBlurEnabled: data.nsfwBlurEnabled ?? true,
           missingSearchCooldownMin: data.missingSearchCooldownMin ?? 60,
           siteName: data.siteName ?? 'Oscarr',
           siteUrl: data.siteUrl ?? '',
@@ -76,6 +78,7 @@ export function GeneralTab() {
         setRequestsEnabled(vals.requestsEnabled);
         setSupportEnabled(vals.supportEnabled);
         setCalendarEnabled(vals.calendarEnabled);
+        setNsfwBlurEnabled(vals.nsfwBlurEnabled);
         setMissingSearchCooldownMin(vals.missingSearchCooldownMin);
         setSiteName(vals.siteName);
         setSiteUrl(vals.siteUrl);
@@ -92,9 +95,9 @@ export function GeneralTab() {
   }, []);
 
   const currentValues = useMemo(() => ({
-    autoApproveRequests, registrationEnabled, requestsEnabled, supportEnabled,
+    autoApproveRequests, registrationEnabled, requestsEnabled, nsfwBlurEnabled, supportEnabled,
     calendarEnabled, missingSearchCooldownMin, siteName, siteUrl, instanceLanguage, bannerText,
-  }), [autoApproveRequests, registrationEnabled, requestsEnabled, supportEnabled,
+  }), [autoApproveRequests, registrationEnabled, requestsEnabled, nsfwBlurEnabled, supportEnabled,
     calendarEnabled, missingSearchCooldownMin, siteName, siteUrl, instanceLanguage, bannerText]);
 
   const hasChanges = !loading && Object.keys(initialValues.current).length > 0 &&
@@ -107,6 +110,7 @@ export function GeneralTab() {
     setRequestsEnabled(iv.requestsEnabled as boolean);
     setSupportEnabled(iv.supportEnabled as boolean);
     setCalendarEnabled(iv.calendarEnabled as boolean);
+    setNsfwBlurEnabled(iv.nsfwBlurEnabled as boolean);
     setMissingSearchCooldownMin(iv.missingSearchCooldownMin as number);
     setSiteName(iv.siteName as string);
     setSiteUrl(iv.siteUrl as string);
@@ -122,6 +126,7 @@ export function GeneralTab() {
           autoApproveRequests,
           registrationEnabled,
           requestsEnabled,
+          nsfwBlurEnabled,
           supportEnabled,
           calendarEnabled,
           missingSearchCooldownMin,
@@ -145,6 +150,7 @@ export function GeneralTab() {
     { label: t('admin.general.feature.auto_approve'), desc: t('admin.general.feature.auto_approve_desc'), value: autoApproveRequests, set: setAutoApproveRequests },
     { label: t('admin.general.feature.support'), desc: t('admin.general.feature.support_desc'), value: supportEnabled, set: setSupportEnabled },
     { label: t('admin.general.feature.calendar'), desc: t('admin.general.feature.calendar_desc'), value: calendarEnabled, set: setCalendarEnabled },
+    { label: t('admin.general.feature.nsfw_blur'), desc: t('admin.general.feature.nsfw_blur_desc'), value: nsfwBlurEnabled, set: setNsfwBlurEnabled },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Fixes #103 — NSFW blur was too aggressive, blurring mainstream content like Invincible, Daredevil and Crime 101.

### Rating thresholds reduced
- **Before**: NC-17, TV-MA, X, 18, 18+, VM18 → all blurred
- **After**: NC-17, X, XXX, VM18 only → age-restricted content (R, TV-MA, 18) no longer blurred

### Admin toggle
- New `nsfwBlurEnabled` feature flag in Admin > General
- When disabled, no content is ever blurred

### Centralized NSFW detection
- All TMDB routes (trending, popular, search, discover, recommendations) now return `nsfwTmdbIds`
- Global axios interceptor in `api.ts` auto-detects and updates the NSFW filter — zero per-page changes needed
- Auto-tag known NSFW keywords (hentai, pornography, adult animation, softcore, sexploitation) on first encounter

### Code review fixes
- `trackAndFlagNsfw` wrapped with `.catch(() => [])` — DB failure doesn't crash TMDB routes
- Auto-tag applied in both `upsertKeywordsAndRating` and `trackKeywordsFromDetails`

Closes #103

## Test plan
- [x] Invincible, Daredevil, Crime 101 no longer blurred
- [x] Admin toggle disables all blur
- [x] Overflow (hentai keyword) correctly blurred
- [x] Backend + frontend compile
- [x] i18n EN + FR