### PR TITLE
feat: redesign cast section + person page with filmography

### DIFF
--- a/packages/backend/src/middleware/rbac.ts
+++ b/packages/backend/src/middleware/rbac.ts
@@ -50,6 +50,7 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
   'GET:/api/tmdb/tv/:id':                              { permission: AUTH },
   'GET:/api/tmdb/movie/:id/recommendations':           { permission: AUTH },
   'GET:/api/tmdb/tv/:id/recommendations':              { permission: AUTH },
+  'GET:/api/tmdb/person/:id':                           { permission: AUTH },
   'GET:/api/tmdb/collection/:id':                      { permission: AUTH },
   'GET:/api/tmdb/discover/:mediaType/genre/:genreId':  { permission: AUTH },
   'GET:/api/tmdb/genre-backdrops':                     { permission: AUTH },

--- a/packages/backend/src/routes/tmdb.ts
+++ b/packages/backend/src/routes/tmdb.ts
@@ -8,6 +8,7 @@ import {
   searchMulti,
   getMovieDetails,
   getTvDetails,
+  getPersonDetails,
   getMovieRecommendations,
   getTvRecommendations,
   discoverByGenre,
@@ -175,6 +176,16 @@ export async function tmdbRoutes(app: FastifyInstance) {
     const details = await getTvDetails(tvId, getLang(request));
     trackKeywordsFromDetails(tvId, 'tv', details).catch(() => {});
     return details;
+  });
+
+  app.get('/person/:id', {
+    schema: { params: idParamSchema },
+
+  }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const personId = parseId(id);
+    if (!personId) return reply.status(400).send({ error: 'Invalid ID' });
+    return getPersonDetails(personId, getLang(request));
   });
 
   app.get('/movie/:id/recommendations', {

--- a/packages/backend/src/services/tmdb.ts
+++ b/packages/backend/src/services/tmdb.ts
@@ -302,6 +302,30 @@ export async function searchMulti(query: string, page = 1, lang?: string) {
   }, 1);
 }
 
+export interface TmdbPerson {
+  id: number;
+  name: string;
+  biography: string;
+  birthday: string | null;
+  deathday: string | null;
+  place_of_birth: string | null;
+  profile_path: string | null;
+  known_for_department: string;
+  combined_credits: {
+    cast: (TmdbMovie & TmdbTv & { media_type: string; character: string })[];
+  };
+}
+
+export async function getPersonDetails(personId: number, lang?: string): Promise<TmdbPerson> {
+  const l = normalizeLang(lang);
+  return cachedRequest(`person:${personId}:${l}`, async () => {
+    const { data } = await getTmdbApi(l).get(`/person/${personId}`, {
+      params: { append_to_response: 'combined_credits' },
+    });
+    return data;
+  }, 24);
+}
+
 export async function getMovieDetails(movieId: number, lang?: string): Promise<TmdbMovie> {
   const l = normalizeLang(lang);
   return cachedRequest(`movie:${movieId}:${l}`, async () => {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import LoginPage from '@/pages/LoginPage';
 import InstallPage from '@/pages/InstallPage';
 import SearchPage from '@/pages/SearchPage';
 import MediaDetailPage from '@/pages/MediaDetailPage';
+import PersonPage from '@/pages/PersonPage';
 import RequestsPage from '@/pages/RequestsPage';
 import MessagesPage from '@/pages/MessagesPage';
 
@@ -106,6 +107,7 @@ export default function App() {
                   <Route path="/search" element={<RequireAccess><SearchPage /></RequireAccess>} />
                   <Route path="/movie/:id" element={<RequireAccess><MediaDetailPage type="movie" /></RequireAccess>} />
                   <Route path="/tv/:id" element={<RequireAccess><MediaDetailPage type="tv" /></RequireAccess>} />
+                  <Route path="/person/:id" element={<RequireAccess><PersonPage /></RequireAccess>} />
                   <Route path="/requests" element={<RequireFeature feature="requestsEnabled"><RequireAccess><RequestsPage /></RequireAccess></RequireFeature>} />
 
                   <Route path="/discover/:mediaType/genre/:genreId" element={<RequireAccess><DiscoverGenrePage /></RequireAccess>} />

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -17,6 +17,8 @@
   "common.configure": "Configure",
   "common.refresh": "Refresh",
   "common.error": "Error",
+  "common.show_more": "Show more",
+  "common.show_less": "Show less",
   "common.forbidden": "Access denied — insufficient permissions",
   "common.send": "Send",
   "common.sent": "Sent!",
@@ -199,6 +201,9 @@
   "media.all_seasons": "All seasons",
   "media.episodes_short": "ep.",
   "media.casting": "Cast",
+
+  "person.years_old": "years old",
+  "person.filmography": "Filmography",
   "media.recommendations": "Recommendations",
   "media.season_one": "{{count}} season",
   "media.season_other": "{{count}} seasons",

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -17,6 +17,8 @@
   "common.configure": "Configurer",
   "common.refresh": "Rafraîchir",
   "common.error": "Erreur",
+  "common.show_more": "Voir plus",
+  "common.show_less": "Voir moins",
   "common.forbidden": "Accès refusé — permissions insuffisantes",
   "common.send": "Envoyer",
   "common.sent": "Envoyé !",
@@ -199,6 +201,9 @@
   "media.all_seasons": "Toutes les saisons",
   "media.episodes_short": "ép.",
   "media.casting": "Casting",
+
+  "person.years_old": "ans",
+  "person.filmography": "Filmographie",
   "media.recommendations": "Recommandations",
   "media.season_one": "{{count}} saison",
   "media.season_other": "{{count}} saisons",

--- a/packages/frontend/src/pages/MediaDetailPage.tsx
+++ b/packages/frontend/src/pages/MediaDetailPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Star,
@@ -15,6 +15,9 @@ import {
   X,
   EyeOff,
   ShieldAlert,
+  ChevronLeft,
+  ChevronRight,
+  User,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import api from '@/lib/api';
@@ -27,7 +30,7 @@ import { PluginSlot } from '@/plugins/PluginSlot';
 import { useMediaDetailData } from '@/hooks/useMediaDetailData';
 import { useMediaRequestActions } from '@/hooks/useMediaRequestActions';
 import { useEpisodeModal } from '@/hooks/useEpisodeModal';
-import type { TmdbMedia, Media } from '@/types';
+import type { TmdbMedia, Media, TmdbCast, TmdbCrew } from '@/types';
 import { ACTIVE_REQUEST_STATUSES } from '@/utils/requestStatus';
 
 interface Props {
@@ -37,6 +40,7 @@ interface Props {
 export default function MediaDetailPage({ type }: Props) {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const { user } = useAuth();
   const { isNsfw, disableBlur } = useNsfwFilter();
   const [revealed, setRevealed] = useState(false);
@@ -120,7 +124,7 @@ export default function MediaDetailPage({ type }: Props) {
   const year = (media.release_date || media.first_air_date || '').slice(0, 4);
   const genres = media.genres?.map((g) => g.name).join(', ');
   const trailer = media.videos?.results?.find((v) => v.type === 'Trailer' && v.site === 'YouTube');
-  const cast = media.credits?.cast?.slice(0, 12) || [];
+  const cast = media.credits?.cast?.slice(0, 20) || [];
   const director = media.credits?.crew?.find((c) => c.job === 'Director');
 
   return (
@@ -143,9 +147,9 @@ export default function MediaDetailPage({ type }: Props) {
       </div>
 
       {/* Back button - fixed */}
-      <Link to="/" className="fixed top-20 left-4 sm:left-8 z-20 p-2 glass rounded-xl hover:bg-white/10 transition-colors">
+      <button onClick={() => navigate(-1)} className="fixed top-20 left-4 sm:left-8 z-20 p-2 glass rounded-xl hover:bg-white/10 transition-colors">
         <ArrowLeft className="w-5 h-5 text-white" />
-      </Link>
+      </button>
 
       {/* Scrollable content */}
       <div className="relative z-10 pt-[35vh] min-h-screen">
@@ -502,37 +506,13 @@ export default function MediaDetailPage({ type }: Props) {
 
         {/* Cast */}
         {cast.length > 0 && (
-          <div className="mt-12">
-            <h3 className="text-lg font-bold text-ndp-text mb-4">{t('media.casting')}</h3>
-            <div className="flex gap-4 overflow-x-auto pb-4">
-              {cast.map((person) => (
-                <div key={person.id} className="flex-shrink-0 w-28 text-center">
-                  <div className="w-20 h-20 mx-auto rounded-full overflow-hidden bg-ndp-surface-light mb-2">
-                    {person.profile_path ? (
-                      <img
-                        src={`https://image.tmdb.org/t/p/w185${person.profile_path}`}
-                        alt={person.name}
-                        className="w-full h-full object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-ndp-text-dim text-xl">
-                        {person.name[0]}
-                      </div>
-                    )}
-                  </div>
-                  <p className="text-xs font-medium text-ndp-text truncate">{person.name}</p>
-                  <p className="text-[10px] text-ndp-text-dim truncate">{person.character}</p>
-                </div>
-              ))}
-            </div>
-          </div>
+          <CastSection cast={cast} title={t('media.casting')} director={director} />
         )}
 
         {/* Recommendations */}
         {recommendations.length > 0 && (
           <div className="mt-12 pb-16">
-            <MediaRow title={t('media.recommendations')} media={recommendations} />
+            <MediaRow title={t('media.recommendations')} media={recommendations} size="large" />
           </div>
         )}
         </div>
@@ -716,6 +696,81 @@ export default function MediaDetailPage({ type }: Props) {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Cast Section ───────────────────────────────────────────────────
+
+function CastSection({ cast, title, director }: { cast: TmdbCast[]; title: string; director?: TmdbCrew }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scroll = (direction: 'left' | 'right') => {
+    if (!scrollRef.current) return;
+    const amount = scrollRef.current.clientWidth * 0.75;
+    scrollRef.current.scrollBy({ left: direction === 'left' ? -amount : amount, behavior: 'smooth' });
+  };
+
+  return (
+    <div className="mt-12 relative group/cast">
+      <div className="flex items-center gap-3 mb-4 sm:px-8">
+        <h3 className="text-xl font-bold text-ndp-text">{title}</h3>
+        {director && (
+          <span className="text-sm text-ndp-text-muted">
+            <span className="text-ndp-text-dim">·</span>{' '}
+            <span className="text-ndp-accent font-medium">{director.name}</span>
+          </span>
+        )}
+      </div>
+
+      <button
+        onClick={() => scroll('left')}
+        className="absolute left-0 top-12 bottom-0 z-20 w-10 bg-gradient-to-r from-ndp-bg to-transparent flex items-center justify-center opacity-0 group-hover/cast:opacity-100 transition-opacity"
+      >
+        <ChevronLeft className="w-5 h-5 text-white" />
+      </button>
+      <button
+        onClick={() => scroll('right')}
+        className="absolute right-0 top-12 bottom-0 z-20 w-10 bg-gradient-to-l from-ndp-bg to-transparent flex items-center justify-center opacity-0 group-hover/cast:opacity-100 transition-opacity"
+      >
+        <ChevronRight className="w-5 h-5 text-white" />
+      </button>
+
+      <div
+        ref={scrollRef}
+        className="flex gap-3 overflow-x-auto px-4 sm:px-8 pb-2"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        {cast.map((person, i) => (
+          <Link
+            to={`/person/${person.id}`}
+            key={person.id}
+            className="flex-shrink-0 w-[120px] group/card"
+            style={{ animationDelay: `${Math.min(i * 40, 400)}ms` }}
+          >
+            <div className="relative aspect-[2/3] rounded-xl overflow-hidden bg-ndp-surface-light">
+              {person.profile_path ? (
+                <img
+                  src={`https://image.tmdb.org/t/p/w185${person.profile_path}`}
+                  alt={person.name}
+                  className="w-full h-full object-cover transition-transform duration-300 group-hover/card:scale-105"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-ndp-surface-light to-ndp-bg">
+                  <User className="w-10 h-10 text-ndp-text-dim/30" />
+                </div>
+              )}
+              <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent pt-8 pb-2.5 px-2.5">
+                <p className="text-xs font-semibold text-white leading-tight truncate">{person.name}</p>
+                {person.character && (
+                  <p className="text-[10px] text-ndp-text-muted leading-tight truncate mt-0.5">{person.character}</p>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/frontend/src/pages/PersonPage.tsx
+++ b/packages/frontend/src/pages/PersonPage.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, Calendar, MapPin, Loader2, User } from 'lucide-react';
+import api from '@/lib/api';
+import MediaCard from '@/components/MediaCard';
+import { useMediaStatus, getStatusForMedia } from '@/hooks/useMediaStatus';
+import type { TmdbPerson, TmdbMedia } from '@/types';
+
+export default function PersonPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [person, setPerson] = useState<TmdbPerson | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showFullBio, setShowFullBio] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setPerson(null);
+    setShowFullBio(false);
+    api.get(`/tmdb/person/${id}`).then(({ data }) => setPerson(data)).catch(() => {}).finally(() => setLoading(false));
+  }, [id]);
+
+  const filmography = useMemo(() =>
+    person?.combined_credits?.cast
+      ?.filter((c) => c.poster_path && (c.vote_count ?? 0) > 5)
+      .sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0))
+      .slice(0, 40)
+      .map((c) => ({ ...c, media_type: c.media_type || (c.title ? 'movie' : 'tv') })) || [],
+    [person],
+  );
+
+  const statuses = useMediaStatus(filmography as TmdbMedia[]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="w-8 h-8 text-ndp-accent animate-spin" />
+      </div>
+    );
+  }
+
+  if (!person) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-ndp-text-muted">{t('media.not_found')}</p>
+      </div>
+    );
+  }
+
+  const age = person.birthday
+    ? Math.floor((Date.now() - new Date(person.birthday).getTime()) / 31557600000)
+    : null;
+
+  const bioTruncated = person.biography && person.biography.length > 400 && !showFullBio;
+
+  return (
+    <div className="min-h-screen bg-ndp-bg">
+      {/* Back button - same style as media detail */}
+      <button onClick={() => navigate(-1)} className="fixed top-20 left-4 sm:left-8 z-20 p-2 glass rounded-xl hover:bg-white/10 transition-colors">
+        <ArrowLeft className="w-5 h-5 text-white" />
+      </button>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-8 py-8">
+        {/* Profile section */}
+        <div className="flex flex-col sm:flex-row gap-8">
+          {/* Photo */}
+          <div className="flex-shrink-0 w-48 mx-auto sm:mx-0">
+            <div className="aspect-[2/3] rounded-2xl overflow-hidden bg-ndp-surface-light shadow-2xl shadow-black/30">
+              {person.profile_path ? (
+                <img
+                  src={`https://image.tmdb.org/t/p/w342${person.profile_path}`}
+                  alt={person.name}
+                  className="w-full h-full object-cover"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-ndp-surface-light to-ndp-bg">
+                  <User className="w-16 h-16 text-ndp-text-dim/30" />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex-1 min-w-0">
+            <h2 className="text-3xl font-bold text-ndp-text">{person.name}</h2>
+            <p className="text-sm text-ndp-accent font-medium mt-1">{person.known_for_department}</p>
+
+            <div className="flex flex-wrap gap-4 mt-4 text-sm text-ndp-text-muted">
+              {person.birthday && (
+                <span className="flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4 text-ndp-text-dim" />
+                  {new Date(person.birthday).toLocaleDateString()}
+                  {age != null && !person.deathday && (
+                    <span className="text-ndp-text-dim">({age} {t('person.years_old', 'ans')})</span>
+                  )}
+                </span>
+              )}
+              {person.deathday && (
+                <span className="flex items-center gap-1.5 text-ndp-text-dim">
+                  † {new Date(person.deathday).toLocaleDateString()}
+                </span>
+              )}
+              {person.place_of_birth && (
+                <span className="flex items-center gap-1.5">
+                  <MapPin className="w-4 h-4 text-ndp-text-dim" />
+                  {person.place_of_birth}
+                </span>
+              )}
+            </div>
+
+            {/* Biography */}
+            {person.biography && (
+              <div className="mt-6">
+                <p className="text-sm text-ndp-text-muted leading-relaxed whitespace-pre-line">
+                  {bioTruncated ? person.biography.slice(0, 400) + '...' : person.biography}
+                </p>
+                {person.biography.length > 400 && (
+                  <button
+                    onClick={() => setShowFullBio(!showFullBio)}
+                    className="text-sm text-ndp-accent hover:text-ndp-accent/80 mt-2 transition-colors"
+                  >
+                    {showFullBio ? t('common.show_less', 'Voir moins') : t('common.show_more', 'Voir plus')}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Filmography */}
+        {filmography.length > 0 && (
+          <div className="mt-12">
+            <h3 className="text-xl font-bold text-ndp-text mb-6">
+              {t('person.filmography', 'Filmographie')}
+              <span className="text-sm font-normal text-ndp-text-dim ml-2">({filmography.length})</span>
+            </h3>
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
+              {filmography.map((item, i) => {
+                const type = item.media_type || (item.title ? 'movie' : 'tv');
+                return (
+                  <MediaCard
+                    key={`${type}-${item.id}-${i}`}
+                    media={item as TmdbMedia}
+                    availability={getStatusForMedia(statuses, item.id, type)}
+                    index={i}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -97,6 +97,20 @@ export interface TmdbCrew {
   profile_path: string | null;
 }
 
+export interface TmdbPerson {
+  id: number;
+  name: string;
+  biography: string;
+  birthday: string | null;
+  deathday: string | null;
+  place_of_birth: string | null;
+  profile_path: string | null;
+  known_for_department: string;
+  combined_credits: {
+    cast: (TmdbMedia & { character: string; release_date?: string; first_air_date?: string })[];
+  };
+}
+
 export interface TmdbVideo {
   key: string;
   site: string;


### PR DESCRIPTION
## Summary

Closes #59

- **Cast section redesign**: rectangular poster-style cards with photo overlay, scroll arrows, director badge next to section title, clickable links to person page
- **Person page** (`/person/:id`): profile photo, biography (collapsible), metadata (birthday, birthplace), filmography grid with availability badges
- **Back button**: both detail and person pages use `navigate(-1)` for proper history navigation
- **Recommendations**: now use large card size for better visibility
- **RBAC**: `/tmdb/person/:id` route registered
- **i18n**: `person.filmography`, `person.years_old`, `common.show_more/show_less` (EN + FR)

## Test plan

- [x] Click on a cast member on a movie/TV detail page — opens person page with filmography
- [x] Person page shows biography, birthday, birthplace, filmography grid
- [x] Filmography cards show availability badges (available, requested, etc.)
- [x] Back button on person page returns to previous media detail
- [x] Back button on media detail returns to previous page (not always "/")
- [x] Cast section scrolls horizontally with chevron arrows on hover
- [x] Missing profile photos show User icon placeholder