### PR TITLE
fix(auth): JWT authentication on HTTP and plugin order

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # TMDB — optional, a built-in read access token is provided by default
 # TMDB_API_TOKEN=your_own_tmdb_read_access_token
+# Cookie security - set to 'true' in production behind reverse proxy
 
 # App
 PORT=3456
@@ -7,7 +8,7 @@ NODE_ENV=production
 JWT_SECRET=change_me_to_a_random_secret
 DATABASE_URL=file:../data/oscarr.db
 FRONTEND_URL=http://localhost:5173
-
+# COOKIE_SECURE=true
 # Setup security — minimum 8 characters recommended
 SETUP_SECRET=change_me_to_a_random_secret
 INSTALL_FILE_PATH=./data/install.json

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -42,12 +42,12 @@ async function start() {
     throw new Error('JWT_SECRET environment variable is required');
   }
 
+  await app.register(cookie);
+
   await app.register(jwt, {
     secret: jwtSecret,
     cookie: { cookieName: 'token', signed: false },
   });
-
-  await app.register(cookie);
   await app.register(rateLimit, { global: false });
 
   // Hydrate instance language cache before any route handles requests

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -23,7 +23,8 @@ function buildHelpers(app: FastifyInstance): AuthHelpers {
         .setCookie('token', token, {
           path: '/',
           httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
+          secure: process.env.COOKIE_SECURE === 'true'
+            || (process.env.COOKIE_SECURE !== 'false' && reply.request.protocol === 'https'),
           sameSite: 'lax',
           maxAge: 24 * 60 * 60,
         })


### PR DESCRIPTION
## Problem

JWT authentication was failing on HTTP connections with 401 Unauthorized errors on all protected routes (`/api/admin/*`, `/api/auth/me`, etc.) even after successful login.

**Root causes:**
1. `@fastify/jwt` was registered before `@fastify/cookie`, preventing JWT from reading the token cookie
2. Cookie `secure` attribute was hardcoded based on `NODE_ENV=production`, forcing HTTPS-only cookies even in local HTTP development

## Solution

**1. Plugin registration order** (`packages/backend/src/index.ts`)
- Register `@fastify/cookie` before `@fastify/jwt` to ensure cookie parser is available when JWT initializes

**2. Smart cookie security** (`packages/backend/src/routes/auth.ts`)
- Support `COOKIE_SECURE` environment variable with 3-state logic:
  - `COOKIE_SECURE=true`: force secure (production behind reverse proxy)
  - `COOKIE_SECURE=false`: force insecure (local dev override)
  - unset: auto-detect via `request.protocol` (default)

## Testing

Tested on Docker local deployment (HTTP) - JWT authentication now works correctly.