### PR TITLE
chore: replace French logs with English + add debug logging (#98)

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -92,7 +92,7 @@ async function start() {
       },
       uiHooks: {
         preHandler: async (request, reply) => {
-          try { await request.jwtVerify(); } catch { return reply.status(401).send({ error: 'Non autorisé' }); }
+          try { await request.jwtVerify(); } catch { return reply.status(401).send({ error: 'Unauthorized' }); }
           const user = request.user as { id: number; role: string };
           if (user.role !== 'admin') return reply.status(403).send({ error: 'Admin only' });
         },

--- a/packages/backend/src/providers/plex/index.ts
+++ b/packages/backend/src/providers/plex/index.ts
@@ -67,7 +67,7 @@ async function importPlexUsers(plexToken: string, machineId: string) {
     imported++;
   }
 
-  logEvent('info', 'User', `Import Plex : ${imported} importés, ${skipped} existants`);
+  logEvent('info', 'User', `Plex import: ${imported} imported, ${skipped} already existed`);
   return { imported, skipped, total: sharedUsers.length };
 }
 
@@ -95,13 +95,13 @@ const plexAuth: AuthProvider = {
     }, async (request, reply) => {
       const { pinId } = request.body as { pinId: unknown };
       if (typeof pinId !== 'number' || !Number.isFinite(pinId) || pinId < 1) {
-        return reply.status(400).send({ error: 'pinId invalide' });
+        return reply.status(400).send({ error: 'Invalid pinId' });
       }
 
       const authToken = await checkPlexPin(pinId, PLEX_CLIENT_ID);
       if (!authToken) {
-        logEvent('warn', 'Auth', `Échec de validation PIN (pinId: ${pinId})`);
-        return reply.status(400).send({ error: 'PIN non validé. Réessayez.' });
+        logEvent('warn', 'Auth', `PIN validation failed (pinId: ${pinId})`);
+        return reply.status(400).send({ error: 'PIN not validated. Try again.' });
       }
 
       const plexAccount = await getPlexUser(authToken);
@@ -116,7 +116,7 @@ const plexAuth: AuthProvider = {
         avatar: plexAccount.thumb,
       });
 
-      logEvent('info', 'Auth', `${result.displayName} s'est connecté (plex)${result.isNew ? ' — nouveau compte' : ''}`);
+      logEvent('info', 'Auth', `${result.displayName} logged in (plex)${result.isNew ? ' — new account' : ''}`);
       return helpers.signAndSend(reply, result.id);
     });
   },
@@ -138,7 +138,7 @@ const plexAuth: AuthProvider = {
     });
 
     await prisma.user.update({ where: { id: userId }, data: { avatar: plexAccount.thumb } });
-    logEvent('info', 'Auth', `Compte Plex lié : ${plexAccount.username}`);
+    logEvent('info', 'Auth', `Plex account linked: ${plexAccount.username}`);
     return { providerUsername: plexAccount.username };
   },
 

--- a/packages/backend/src/providers/radarr/client.ts
+++ b/packages/backend/src/providers/radarr/client.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosInstance } from 'axios';
 import type { ArrClient, ArrTag, ArrQualityProfile, ArrRootFolder, ArrMediaItem, ArrAvailabilityResult, ArrHistoryEntry, ArrAddMediaOptions, ArrWebhookEvent } from '../types.js';
 import { extractImageFromArr } from '../types.js';
 import type { RadarrMovie, RadarrQueueItem, RadarrHistoryRecord } from './types.js';
+import { logEvent } from '../../utils/logEvent.js';
 
 export class RadarrClient implements ArrClient {
   readonly mediaType = 'movie' as const;
@@ -121,7 +122,7 @@ export class RadarrClient implements ArrClient {
         if (records.length < 1000) break;
         page++;
       } catch {
-        console.warn(`[Radarr] History pagination failed at page ${page}, using ${all.length} records collected so far`);
+        logEvent('debug', 'Radarr', `History pagination failed at page ${page}, using ${all.length} records collected so far`);
         break;
       }
     }

--- a/packages/backend/src/providers/sonarr/client.ts
+++ b/packages/backend/src/providers/sonarr/client.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosInstance } from 'axios';
 import type { ArrClient, ArrTag, ArrQualityProfile, ArrRootFolder, ArrMediaItem, ArrSeasonItem, ArrAvailabilityResult, ArrHistoryEntry, ArrAddMediaOptions, ArrEpisode, ArrWebhookEvent } from '../types.js';
 import { extractImageFromArr } from '../types.js';
 import type { SonarrSeries, SonarrSeason, SonarrQueueItem, SonarrEpisode, SonarrEpisodeFile, SonarrHistoryRecord } from './types.js';
+import { logEvent } from '../../utils/logEvent.js';
 
 export class SonarrClient implements ArrClient {
   readonly mediaType = 'tv' as const;
@@ -157,9 +158,9 @@ export class SonarrClient implements ArrClient {
         // Sonarr can crash on corrupted history entries — log details for debugging
         const statusCode = (err as { response?: { status?: number } })?.response?.status;
         const errorBody = (err as { response?: { data?: unknown } })?.response?.data;
-        console.warn(`[Sonarr] History pagination failed at page ${page} (records ${(page - 1) * 500}-${page * 500}), HTTP ${statusCode || 'unknown'}`);
-        if (errorBody) console.warn(`[Sonarr] Error details:`, typeof errorBody === 'string' ? errorBody.slice(0, 500) : JSON.stringify(errorBody).slice(0, 500));
-        console.warn(`[Sonarr] Using ${all.length} records collected so far`);
+        logEvent('debug', 'Sonarr', `History pagination failed at page ${page} (records ${(page - 1) * 500}-${page * 500}), HTTP ${statusCode || 'unknown'}`);
+        if (errorBody) logEvent('debug', 'Sonarr', `Error details: ${typeof errorBody === 'string' ? errorBody.slice(0, 500) : JSON.stringify(errorBody).slice(0, 500)}`);
+        logEvent('debug', 'Sonarr', `Using ${all.length} records collected so far`);
         break;
       }
     }
@@ -260,7 +261,7 @@ export class SonarrClient implements ArrClient {
         if (filteredSubs.length > 0) subtitleLanguages = filteredSubs;
       } catch (err) {
         const status = (err as { response?: { status?: number } })?.response?.status;
-        console.warn(`[Sonarr] Failed to fetch episode files for series ${series.id} (HTTP ${status || 'unknown'}), skipping language data`);
+        logEvent('debug', 'Sonarr', `Failed to fetch episode files for series ${series.id} (HTTP ${status || 'unknown'}), skipping language data`);
       }
     }
 

--- a/packages/backend/src/routes/admin/danger.ts
+++ b/packages/backend/src/routes/admin/danger.ts
@@ -10,7 +10,7 @@ export async function dangerRoutes(app: FastifyInstance) {
   app.delete('/danger/requests', async (request, reply) => {
 
     const { count } = await prisma.mediaRequest.deleteMany();
-    logEvent('warn', 'Admin', `Purge : ${count} demandes supprim\u00e9es`);
+    logEvent('warn', 'Admin', `Purge: ${count} requests deleted`);
     return { ok: true, deleted: count };
   });
 
@@ -21,7 +21,7 @@ export async function dangerRoutes(app: FastifyInstance) {
     const { count: reqCount } = await prisma.mediaRequest.deleteMany();
     const { count: seasonCount } = await prisma.season.deleteMany();
     const { count: mediaCount } = await prisma.media.deleteMany();
-    logEvent('warn', 'Admin', `Purge : ${mediaCount} m\u00e9dias, ${seasonCount} saisons, ${reqCount} demandes supprim\u00e9s`);
+    logEvent('warn', 'Admin', `Purge: ${mediaCount} media, ${seasonCount} seasons, ${reqCount} requests deleted`);
     return { ok: true, deleted: { media: mediaCount, seasons: seasonCount, requests: reqCount } };
   });
 
@@ -40,16 +40,16 @@ export async function dangerRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const userId = parseId(id);
-    if (!userId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!userId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const currentUser = request.user as { id: number };
-    if (userId === currentUser.id) return reply.status(400).send({ error: 'Impossible de supprimer votre propre compte' });
+    if (userId === currentUser.id) return reply.status(400).send({ error: 'Cannot delete your own account' });
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
-    if (!user) return reply.status(404).send({ error: 'Utilisateur introuvable' });
+    if (!user) return reply.status(404).send({ error: 'User not found' });
 
     await prisma.user.delete({ where: { id: userId } });
-    logEvent('warn', 'Admin', `Utilisateur supprim\u00e9 : ${user.displayName || user.email}`);
+    logEvent('warn', 'Admin', `User deleted: ${user.displayName || user.email}`);
     return { ok: true };
   });
 
@@ -58,7 +58,7 @@ export async function dangerRoutes(app: FastifyInstance) {
 
     const currentUser = request.user as { id: number };
     const { count } = await prisma.user.deleteMany({ where: { id: { not: currentUser.id } } });
-    logEvent('warn', 'Admin', `Purge : ${count} utilisateurs supprim\u00e9s`);
+    logEvent('warn', 'Admin', `Purge: ${count} users deleted`);
     return { ok: true, deleted: count };
   });
 }

--- a/packages/backend/src/routes/admin/folderRules.ts
+++ b/packages/backend/src/routes/admin/folderRules.ts
@@ -32,7 +32,7 @@ export async function folderRulesRoutes(app: FastifyInstance) {
       name: string; mediaType: string; conditions: unknown[]; folderPath: string; seriesType?: string; priority?: number; serviceId?: number;
     };
     if (!name || !mediaType || !conditions || !folderPath) {
-      return reply.status(400).send({ error: 'Tous les champs sont requis' });
+      return reply.status(400).send({ error: 'All fields are required' });
     }
     const rule = await prisma.folderRule.create({
       data: {
@@ -74,7 +74,7 @@ export async function folderRulesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const ruleId = parseId(id);
-    if (!ruleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ruleId) return reply.status(400).send({ error: 'Invalid ID' });
     const { name, mediaType, conditions, folderPath, seriesType, priority, serviceId } = request.body as {
       name?: string; mediaType?: string; conditions?: unknown[]; folderPath?: string; seriesType?: string; priority?: number; serviceId?: number | null;
     };
@@ -107,7 +107,7 @@ export async function folderRulesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const ruleId = parseId(id);
-    if (!ruleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ruleId) return reply.status(400).send({ error: 'Invalid ID' });
     await prisma.folderRule.delete({ where: { id: ruleId } });
     return reply.send({ ok: true });
   });
@@ -141,9 +141,9 @@ export async function folderRulesRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const ruleId = parseId(id);
-    if (!ruleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ruleId) return reply.status(400).send({ error: 'Invalid ID' });
     const rule = await prisma.folderRule.findUnique({ where: { id: ruleId } });
-    if (!rule) return reply.status(404).send({ error: 'R\u00e8gle introuvable' });
+    if (!rule) return reply.status(404).send({ error: 'Rule not found' });
     const updated = await prisma.folderRule.update({ where: { id: ruleId }, data: { enabled: !rule.enabled } });
     return reply.send(updated);
   });
@@ -160,9 +160,9 @@ export async function folderRulesRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const ruleId = parseId(id);
-    if (!ruleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ruleId) return reply.status(400).send({ error: 'Invalid ID' });
     const rule = await prisma.folderRule.findUnique({ where: { id: ruleId } });
-    if (!rule) return reply.status(404).send({ error: 'R\u00e8gle introuvable' });
+    if (!rule) return reply.status(404).send({ error: 'Rule not found' });
     const count = await prisma.folderRule.count();
     const copy = await prisma.folderRule.create({
       data: {

--- a/packages/backend/src/routes/admin/jobs.ts
+++ b/packages/backend/src/routes/admin/jobs.ts
@@ -34,7 +34,7 @@ export async function jobsRoutes(app: FastifyInstance) {
     const { cronExpression, enabled } = request.body as { cronExpression?: string; enabled?: boolean };
 
     if (cronExpression && !nodeSchedule.validate(cronExpression)) {
-      return reply.status(400).send({ error: 'Expression CRON invalide' });
+      return reply.status(400).send({ error: 'Invalid CRON expression' });
     }
 
     const job = await prisma.cronJob.update({
@@ -67,7 +67,7 @@ export async function jobsRoutes(app: FastifyInstance) {
       const job = await prisma.cronJob.findUnique({ where: { key } });
       return { ok: true, result, job };
     } catch (err) {
-      return reply.status(500).send({ error: 'Le job a \u00e9chou\u00e9', details: String(err) });
+      return reply.status(500).send({ error: 'Job failed', details: String(err) });
     }
   });
 }

--- a/packages/backend/src/routes/admin/logs.ts
+++ b/packages/backend/src/routes/admin/logs.ts
@@ -10,7 +10,7 @@ export async function logsRoutes(app: FastifyInstance) {
         type: 'object',
         properties: {
           page: { type: 'string', description: 'Page number (defaults to 1)' },
-          level: { type: 'string', enum: ['info', 'warn', 'error'], description: 'Filter logs by level' },
+          level: { type: 'string', enum: ['info', 'warn', 'error', 'debug'], description: 'Filter logs by level' },
           label: { type: 'string', description: 'Filter logs by label' },
         },
       },
@@ -22,7 +22,7 @@ export async function logsRoutes(app: FastifyInstance) {
     const take = 50;
     const skip = (pageNum - 1) * take;
     const where: Record<string, unknown> = {};
-    if (level && ['info', 'warn', 'error'].includes(level)) where.level = level;
+    if (level && ['info', 'warn', 'error', 'debug'].includes(level)) where.level = level;
     if (label) where.label = label;
 
     const [logs, total] = await Promise.all([

--- a/packages/backend/src/routes/admin/quality.ts
+++ b/packages/backend/src/routes/admin/quality.ts
@@ -31,7 +31,7 @@ export async function qualityRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
 
     const { label, position } = request.body as { label: string; position?: number };
-    if (!label) return reply.status(400).send({ error: 'Label requis' });
+    if (!label) return reply.status(400).send({ error: 'Label required' });
     const maxPos = await prisma.qualityOption.aggregate({ _max: { position: true } });
     const option = await prisma.qualityOption.create({
       data: { label, position: position ?? (maxPos._max.position ?? 0) + 1 },
@@ -62,7 +62,7 @@ export async function qualityRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const optionId = parseId(id);
-    if (!optionId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!optionId) return reply.status(400).send({ error: 'Invalid ID' });
     const { label, position, allowedRoles, approvalMode } = request.body as {
       label?: string; position?: number; allowedRoles?: string[] | null; approvalMode?: string | null;
     };
@@ -92,7 +92,7 @@ export async function qualityRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const optionId = parseId(id);
-    if (!optionId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!optionId) return reply.status(400).send({ error: 'Invalid ID' });
     await prisma.qualityOption.delete({ where: { id: optionId } });
     return { ok: true };
   });
@@ -149,14 +149,14 @@ export async function qualityRoutes(app: FastifyInstance) {
       qualityOptionId: number; serviceId: number; qualityProfileId: number; qualityProfileName: string;
     };
     if (!qualityOptionId || !serviceId || !qualityProfileId || !qualityProfileName) {
-      return reply.status(400).send({ error: 'Tous les champs sont requis' });
+      return reply.status(400).send({ error: 'All fields are required' });
     }
     // Check for duplicate
     const existing = await prisma.qualityMapping.findFirst({
       where: { qualityOptionId, serviceId, qualityProfileId },
     });
     if (existing) {
-      return reply.status(409).send({ error: 'Ce mapping existe d\u00e9j\u00e0' });
+      return reply.status(409).send({ error: 'This mapping already exists' });
     }
     const mapping = await prisma.qualityMapping.create({
       data: { qualityOptionId, serviceId, qualityProfileId, qualityProfileName },
@@ -182,7 +182,7 @@ export async function qualityRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const mappingId = parseId(id);
-    if (!mappingId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!mappingId) return reply.status(400).send({ error: 'Invalid ID' });
     await prisma.qualityMapping.delete({ where: { id: mappingId } });
     return { ok: true };
   });

--- a/packages/backend/src/routes/admin/roles.ts
+++ b/packages/backend/src/routes/admin/roles.ts
@@ -33,10 +33,10 @@ export async function rolesRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { name, permissions, position } = request.body as { name: string; permissions: string[]; position?: number };
 
-    if (!name?.trim()) return reply.status(400).send({ error: 'Nom requis' });
+    if (!name?.trim()) return reply.status(400).send({ error: 'Name required' });
 
     const existing = await prisma.role.findUnique({ where: { name: name.trim().toLowerCase() } });
-    if (existing) return reply.status(409).send({ error: 'Ce r\u00f4le existe d\u00e9j\u00e0' });
+    if (existing) return reply.status(409).send({ error: 'This role already exists' });
 
     const maxPos = await prisma.role.aggregate({ _max: { position: true } });
     const role = await prisma.role.create({
@@ -48,7 +48,7 @@ export async function rolesRoutes(app: FastifyInstance) {
     });
 
     await invalidateRoleCache();
-    logEvent('info', 'Admin', `R\u00f4le cr\u00e9\u00e9 : ${role.name}`);
+    logEvent('info', 'Admin', `Role created: ${role.name}`);
     return reply.status(201).send(role);
   });
 
@@ -72,10 +72,10 @@ export async function rolesRoutes(app: FastifyInstance) {
     },
   }, async (request, reply) => {
     const roleId = parseId((request.params as { id: string }).id);
-    if (!roleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!roleId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const role = await prisma.role.findUnique({ where: { id: roleId } });
-    if (!role) return reply.status(404).send({ error: 'R\u00f4le introuvable' });
+    if (!role) return reply.status(404).send({ error: 'Role not found' });
 
     const { name, permissions, isDefault, position } = request.body as {
       name?: string; permissions?: string[]; isDefault?: boolean; position?: number;
@@ -83,7 +83,7 @@ export async function rolesRoutes(app: FastifyInstance) {
 
     // System roles cannot be renamed
     if (role.isSystem && name && name !== role.name) {
-      return reply.status(400).send({ error: 'Impossible de renommer un r\u00f4le syst\u00e8me' });
+      return reply.status(400).send({ error: 'Cannot rename a system role' });
     }
 
     // If setting as default, unset other defaults
@@ -102,7 +102,7 @@ export async function rolesRoutes(app: FastifyInstance) {
     });
 
     await invalidateRoleCache();
-    logEvent('info', 'Admin', `R\u00f4le modifi\u00e9 : ${updated.name}`);
+    logEvent('info', 'Admin', `Role updated: ${updated.name}`);
     return updated;
   });
 
@@ -117,21 +117,21 @@ export async function rolesRoutes(app: FastifyInstance) {
     },
   }, async (request, reply) => {
     const roleId = parseId((request.params as { id: string }).id);
-    if (!roleId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!roleId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const role = await prisma.role.findUnique({ where: { id: roleId } });
-    if (!role) return reply.status(404).send({ error: 'R\u00f4le introuvable' });
-    if (role.isSystem) return reply.status(400).send({ error: 'Impossible de supprimer un r\u00f4le syst\u00e8me' });
+    if (!role) return reply.status(404).send({ error: 'Role not found' });
+    if (role.isSystem) return reply.status(400).send({ error: 'Cannot delete a system role' });
 
     // Check if any users still have this role
     const usersWithRole = await prisma.user.count({ where: { role: role.name } });
     if (usersWithRole > 0) {
-      return reply.status(400).send({ error: `${usersWithRole} utilisateur(s) ont encore ce r\u00f4le. R\u00e9assignez-les d'abord.` });
+      return reply.status(400).send({ error: `${usersWithRole} user(s) still have this role. Reassign them first.` });
     }
 
     await prisma.role.delete({ where: { id: roleId } });
     await invalidateRoleCache();
-    logEvent('info', 'Admin', `R\u00f4le supprim\u00e9 : ${role.name}`);
+    logEvent('info', 'Admin', `Role deleted: ${role.name}`);
     return { ok: true };
   });
 }

--- a/packages/backend/src/routes/admin/services.ts
+++ b/packages/backend/src/routes/admin/services.ts
@@ -39,7 +39,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       name: string; type: string; config: Record<string, string>; isDefault?: boolean;
     };
     if (!name || !type || !config) {
-      return reply.status(400).send({ error: 'Nom, type et configuration requis' });
+      return reply.status(400).send({ error: 'Name, type and config required' });
     }
     // If this is set as default, unset other defaults of the same type
     if (isDefault) {
@@ -48,7 +48,7 @@ export async function servicesRoutes(app: FastifyInstance) {
     const service = await prisma.service.create({
       data: { name, type, config: JSON.stringify(config), isDefault: isDefault ?? false },
     });
-    logEvent('info', 'Service', `Service "${name}" (${type}) ajout\u00e9`);
+    logEvent('info', 'Service', `Service "${name}" (${type}) added`);
     return reply.status(201).send({ ...service, config: JSON.parse(service.config) });
   });
 
@@ -75,7 +75,7 @@ export async function servicesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const serviceId = parseId(id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
     const { name, config, isDefault, enabled } = request.body as {
       name?: string; config?: Record<string, string>; isDefault?: boolean; enabled?: boolean;
     };
@@ -112,9 +112,9 @@ export async function servicesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const serviceId = parseId(id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
     const deleted = await prisma.service.delete({ where: { id: serviceId } });
-    logEvent('info', 'Service', `Service "${deleted.name}" supprim\u00e9`);
+    logEvent('info', 'Service', `Service "${deleted.name}" deleted`);
     return { ok: true };
   });
 
@@ -132,18 +132,18 @@ export async function servicesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const serviceId = parseId(id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
     const service = await prisma.service.findUnique({ where: { id: serviceId } });
-    if (!service) return reply.status(404).send({ error: 'Service introuvable' });
+    if (!service) return reply.status(404).send({ error: 'Service not found' });
     const config = JSON.parse(service.config) as Record<string, string>;
 
     const def = getServiceDefinition(service.type);
-    if (!def) return reply.status(400).send({ error: 'Test non support\u00e9 pour ce type de service' });
+    if (!def) return reply.status(400).send({ error: 'Test not supported for this service type' });
 
     try {
       return await def.test(config);
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter le service' });
+      return reply.status(502).send({ error: 'Unable to reach the service' });
     }
   });
 
@@ -152,10 +152,10 @@ export async function servicesRoutes(app: FastifyInstance) {
   app.get('/plex-token', async (request, reply) => {
 
     const provider = getAuthProvider('plex');
-    if (!provider?.getToken) return reply.status(404).send({ error: 'Provider Plex non disponible' });
+    if (!provider?.getToken) return reply.status(404).send({ error: 'Plex provider not available' });
     const adminUser = request.user as { id: number };
     const token = await provider.getToken(adminUser.id);
-    if (!token) return reply.status(404).send({ error: 'Aucun token Plex trouv\u00e9' });
+    if (!token) return reply.status(404).send({ error: 'No Plex token found' });
     return { token };
   });
 
@@ -168,7 +168,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       const profiles = await radarr.getQualityProfiles();
       return profiles;
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter Radarr' });
+      return reply.status(502).send({ error: 'Unable to reach Radarr' });
     }
   });
 
@@ -179,7 +179,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       const folders = await radarr.getRootFolders();
       return folders;
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter Radarr' });
+      return reply.status(502).send({ error: 'Unable to reach Radarr' });
     }
   });
 
@@ -190,7 +190,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       const profiles = await sonarr.getQualityProfiles();
       return profiles;
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter Sonarr' });
+      return reply.status(502).send({ error: 'Unable to reach Sonarr' });
     }
   });
 
@@ -201,7 +201,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       const folders = await sonarr.getRootFolders();
       return folders;
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter Sonarr' });
+      return reply.status(502).send({ error: 'Unable to reach Sonarr' });
     }
   });
 
@@ -221,17 +221,17 @@ export async function servicesRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const serviceId = parseId(id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
     const svc = await getServiceById(serviceId);
-    if (!svc) return reply.status(404).send({ error: 'Service introuvable ou d\u00e9sactiv\u00e9' });
+    if (!svc) return reply.status(404).send({ error: 'Service not found or disabled' });
     try {
       const client = createArrClient(svc.type, svc.config);
       return await client.getQualityProfiles();
     } catch (err) {
       if (err instanceof Error && err.message.includes('does not support client creation')) {
-        return reply.status(400).send({ error: 'Ce type de service ne supporte pas les profils qualit\u00e9' });
+        return reply.status(400).send({ error: 'This service type does not support quality profiles' });
       }
-      return reply.status(502).send({ error: 'Impossible de contacter le service' });
+      return reply.status(502).send({ error: 'Unable to reach the service' });
     }
   });
 
@@ -246,17 +246,17 @@ export async function servicesRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const serviceId = parseId(id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
     const svc = await getServiceById(serviceId);
-    if (!svc) return reply.status(404).send({ error: 'Service introuvable ou d\u00e9sactiv\u00e9' });
+    if (!svc) return reply.status(404).send({ error: 'Service not found or disabled' });
     try {
       const client = createArrClient(svc.type, svc.config);
       return await client.getRootFolders();
     } catch (err) {
       if (err instanceof Error && err.message.includes('does not support client creation')) {
-        return reply.status(400).send({ error: 'Ce type de service ne supporte pas les dossiers racine' });
+        return reply.status(400).send({ error: 'This service type does not support root folders' });
       }
-      return reply.status(502).send({ error: 'Impossible de contacter le service' });
+      return reply.status(502).send({ error: 'Unable to reach the service' });
     }
   });
 
@@ -266,10 +266,10 @@ export async function servicesRoutes(app: FastifyInstance) {
     schema: { params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } } },
   }, async (request, reply) => {
     const serviceId = parseId((request.params as { id: string }).id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const svc = await prisma.service.findUnique({ where: { id: serviceId } });
-    if (!svc) return reply.status(404).send({ error: 'Service introuvable' });
+    if (!svc) return reply.status(404).send({ error: 'Service not found' });
 
     const config = JSON.parse(svc.config);
     const def = getServiceDefinition(svc.type);
@@ -309,10 +309,10 @@ export async function servicesRoutes(app: FastifyInstance) {
     schema: { params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } } },
   }, async (request, reply) => {
     const serviceId = parseId((request.params as { id: string }).id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const svc = await prisma.service.findUnique({ where: { id: serviceId } });
-    if (!svc) return reply.status(404).send({ error: 'Service introuvable' });
+    if (!svc) return reply.status(404).send({ error: 'Service not found' });
     if (svc.webhookId) return reply.status(409).send({ error: 'Webhook already enabled', webhookId: svc.webhookId });
 
     const config = JSON.parse(svc.config);
@@ -344,7 +344,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       logEvent('info', 'Webhook', `Webhook enabled for ${svc.name} (ID: ${webhookId})`);
       return { ok: true, webhookId };
     } catch (err) {
-      console.error(`[Webhook] Failed to register webhook for ${svc.name}:`, err);
+      logEvent('debug', 'Webhook', `Failed to register webhook for ${svc.name}: ${err}`);
       return reply.status(502).send({ error: 'Failed to register webhook in service' });
     }
   });
@@ -353,10 +353,10 @@ export async function servicesRoutes(app: FastifyInstance) {
     schema: { params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } } },
   }, async (request, reply) => {
     const serviceId = parseId((request.params as { id: string }).id);
-    if (!serviceId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!serviceId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const svc = await prisma.service.findUnique({ where: { id: serviceId } });
-    if (!svc) return reply.status(404).send({ error: 'Service introuvable' });
+    if (!svc) return reply.status(404).send({ error: 'Service not found' });
     if (!svc.webhookId) return reply.send({ ok: true, message: 'Webhook already disabled' });
 
     const config = JSON.parse(svc.config);
@@ -367,7 +367,7 @@ export async function servicesRoutes(app: FastifyInstance) {
       try {
         await client.removeWebhook(svc.webhookId);
       } catch (err) {
-        console.warn(`[Webhook] Failed to remove webhook ${svc.webhookId} from ${svc.name}:`, err);
+        logEvent('debug', 'Webhook', `Failed to remove webhook ${svc.webhookId} from ${svc.name}: ${err}`);
       }
     }
 

--- a/packages/backend/src/routes/admin/settings.ts
+++ b/packages/backend/src/routes/admin/settings.ts
@@ -144,11 +144,11 @@ export async function settingsRoutes(app: FastifyInstance) {
     if (body.instanceLanguages) {
       invalidateLanguageCache();
       await prisma.tmdbCache.deleteMany();
-      logEvent('info', 'Settings', 'Cache TMDB vid\u00e9 suite au changement de langue');
+      logEvent('info', 'Settings', 'TMDB cache cleared due to language change');
     }
 
     if (body.siteUrl !== undefined) invalidateSiteUrl();
-    logEvent('info', 'Settings', 'Param\u00e8tres mis \u00e0 jour');
+    logEvent('info', 'Settings', 'Settings updated');
     return settings;
   });
 

--- a/packages/backend/src/routes/admin/users.ts
+++ b/packages/backend/src/routes/admin/users.ts
@@ -24,7 +24,7 @@ export async function usersRoutes(app: FastifyInstance) {
     const authProvider = getAuthProvider(providerId);
 
     if (!authProvider?.importUsers) {
-      return reply.status(400).send({ error: `Le provider "${providerId}" ne supporte pas l'import d'utilisateurs.` });
+      return reply.status(400).send({ error: `Provider "${providerId}" does not support user import.` });
     }
 
     const adminUser = request.user as { id: number };
@@ -33,12 +33,12 @@ export async function usersRoutes(app: FastifyInstance) {
       return result;
     } catch (err) {
       const msg = (err as Error).message;
-      if (msg === 'NO_TOKEN') return reply.status(400).send({ error: `Aucun token ${providerId} trouv\u00e9. Configurez le service dans les param\u00e8tres.` });
-      if (msg === 'NO_MACHINE_ID') return reply.status(400).send({ error: `Aucun serveur ${providerId} configur\u00e9.` });
+      if (msg === 'NO_TOKEN') return reply.status(400).send({ error: `No ${providerId} token found. Configure the service in settings.` });
+      if (msg === 'NO_MACHINE_ID') return reply.status(400).send({ error: `No ${providerId} server configured.` });
       const safeProviderId = providerId.replace(/[\r\n\t]/g, '');
       console.error('Failed to import %s users:', safeProviderId, err);
-      logEvent('error', 'User', `Import ${safeProviderId} \u00e9chou\u00e9 : ${String(err)}`);
-      return reply.status(502).send({ error: `Impossible de r\u00e9cup\u00e9rer les utilisateurs ${providerId}` });
+      logEvent('error', 'User', `${safeProviderId} import failed: ${String(err)}`);
+      return reply.status(502).send({ error: `Unable to retrieve ${providerId} users` });
     }
   });
 
@@ -139,13 +139,13 @@ export async function usersRoutes(app: FastifyInstance) {
 
     const { id } = request.params as { id: string };
     const userId = parseId(id);
-    if (!userId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!userId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const { role } = request.body as { role: string };
 
     // Validate role exists in DB
     const roleExists = await prisma.role.findUnique({ where: { name: role } });
-    if (!roleExists) return reply.status(400).send({ error: 'R\u00f4le invalide' });
+    if (!roleExists) return reply.status(400).send({ error: 'Invalid role' });
 
     const user = await prisma.user.update({
       where: { id: userId },
@@ -153,7 +153,7 @@ export async function usersRoutes(app: FastifyInstance) {
       select: { id: true, displayName: true, role: true },
     });
 
-    logEvent('info', 'User', `R\u00f4le de ${user.displayName} chang\u00e9 en ${role}`);
+    logEvent('info', 'User', `${user.displayName} role changed to ${role}`);
     return user;
   });
 }

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -140,7 +140,7 @@ export async function authRoutes(app: FastifyInstance) {
     if (!isFirstUser) {
       const settings = await prisma.appSettings.findUnique({ where: { id: 1 } });
       if (!(settings?.registrationEnabled ?? true)) {
-        return reply.status(403).send({ error: 'L\'inscription est désactivée.' });
+        return reply.status(403).send({ error: 'Registration is disabled.' });
       }
     }
 
@@ -156,13 +156,13 @@ export async function authRoutes(app: FastifyInstance) {
         },
       });
 
-      logEvent('info', 'Auth', `Nouveau compte email créé : ${result.displayName} (${isFirstUser ? 'admin' : 'user'})`);
+      logEvent('info', 'Auth', `New email account created: ${result.displayName} (${isFirstUser ? 'admin' : 'user'})`);
       return helpers.signAndSend(reply, user.id);
     } catch (err) {
       const msg = (err as Error).message;
-      if (msg === 'EMAIL_EXISTS') return reply.status(409).send({ error: 'Cet email est déjà utilisé.' });
-      if (msg === 'PASSWORD_TOO_SHORT') return reply.status(400).send({ error: 'Le mot de passe doit faire au moins 8 caractères.' });
-      if (msg === 'DISPLAY_NAME_REQUIRED') return reply.status(400).send({ error: 'Le nom d\'affichage est requis.' });
+      if (msg === 'EMAIL_EXISTS') return reply.status(409).send({ error: 'This email is already in use.' });
+      if (msg === 'PASSWORD_TOO_SHORT') return reply.status(400).send({ error: 'Password must be at least 8 characters.' });
+      if (msg === 'DISPLAY_NAME_REQUIRED') return reply.status(400).send({ error: 'Display name is required.' });
       throw err;
     }
   });
@@ -192,9 +192,9 @@ export async function authRoutes(app: FastifyInstance) {
     }
 
     const user = await prisma.user.findUnique({ where: { email: email.toLowerCase() } });
-    if (!user) return reply.status(401).send({ error: 'Email ou mot de passe incorrect.' });
+    if (!user) return reply.status(401).send({ error: 'Invalid email or password.' });
 
-    logEvent('info', 'Auth', `${user.displayName} s'est connecté (email)`);
+    logEvent('info', 'Auth', `${user.displayName} logged in (email)`);
     return helpers.signAndSend(reply, user.id);
   });
 
@@ -261,7 +261,7 @@ export async function authRoutes(app: FastifyInstance) {
         providers: { select: { provider: true, providerUsername: true, providerEmail: true } },
       },
     });
-    if (!user) return reply.status(404).send({ error: 'Utilisateur introuvable' });
+    if (!user) return reply.status(404).send({ error: 'User not found' });
     return reply.send(user);
   });
 

--- a/packages/backend/src/routes/media.ts
+++ b/packages/backend/src/routes/media.ts
@@ -94,7 +94,7 @@ export async function mediaRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const mediaId = parseId(id);
-    if (!mediaId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!mediaId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const media = await prisma.media.findUnique({
       where: { id: mediaId },
@@ -110,7 +110,7 @@ export async function mediaRoutes(app: FastifyInstance) {
       },
     });
 
-    if (!media) return reply.status(404).send({ error: 'Média introuvable' });
+    if (!media) return reply.status(404).send({ error: 'Media not found' });
     return media;
   });
 
@@ -129,8 +129,8 @@ export async function mediaRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { tmdbId, mediaType } = request.params as { tmdbId: string; mediaType: string };
     const tmdbIdNum = parseId(tmdbId);
-    if (!tmdbIdNum) return reply.status(400).send({ error: 'tmdbId invalide' });
-    if (!VALID_MEDIA_TYPES.includes(mediaType)) return reply.status(400).send({ error: 'mediaType invalide' });
+    if (!tmdbIdNum) return reply.status(400).send({ error: 'Invalid tmdbId' });
+    if (!VALID_MEDIA_TYPES.includes(mediaType)) return reply.status(400).send({ error: 'Invalid mediaType' });
 
     const media = await prisma.media.findUnique({
       where: {
@@ -293,7 +293,7 @@ export async function mediaRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { ids } = request.body as { ids?: unknown };
     if (!Array.isArray(ids) || ids.length === 0) {
-      return reply.status(400).send({ error: 'ids requis (array of {tmdbId, mediaType})' });
+      return reply.status(400).send({ error: 'ids required (array of {tmdbId, mediaType})' });
     }
 
     // Limit to 50 per request
@@ -345,7 +345,7 @@ export async function mediaRoutes(app: FastifyInstance) {
     const { tmdbId, seasonNumber } = request.query as { tmdbId: string; seasonNumber: string };
     const tmdbIdNum = parseId(tmdbId);
     const seasonNum = parseInt(seasonNumber, 10);
-    if (!tmdbIdNum || isNaN(seasonNum)) return reply.status(400).send({ error: 'Paramètres invalides' });
+    if (!tmdbIdNum || isNaN(seasonNum)) return reply.status(400).send({ error: 'Invalid parameters' });
 
     // Find the media in our DB to get sonarrId
     const media = await prisma.media.findUnique({
@@ -353,15 +353,15 @@ export async function mediaRoutes(app: FastifyInstance) {
     });
 
     if (!media?.sonarrId) {
-      return reply.status(404).send({ error: 'Série non trouvée dans Sonarr' });
+      return reply.status(404).send({ error: 'Series not found in Sonarr' });
     }
 
     try {
       const client = await getArrClient('sonarr');
-      if (!client.getEpisodesNormalized) return reply.status(400).send({ error: 'Ce service ne supporte pas les épisodes' });
+      if (!client.getEpisodesNormalized) return reply.status(400).send({ error: 'This service does not support episodes' });
       return await client.getEpisodesNormalized(media.sonarrId, seasonNum);
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter Sonarr' });
+      return reply.status(502).send({ error: 'Unable to reach Sonarr' });
     }
   });
 

--- a/packages/backend/src/routes/notifications.ts
+++ b/packages/backend/src/routes/notifications.ts
@@ -73,12 +73,12 @@ export async function notificationRoutes(app: FastifyInstance) {
     const user = request.user as { id: number };
     const { id } = request.params as { id: string };
     const notifId = parseId(id);
-    if (!notifId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!notifId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const notif = await prisma.userNotification.findFirst({
       where: { id: notifId, userId: user.id },
     });
-    if (!notif) return reply.status(404).send({ error: 'Notification introuvable' });
+    if (!notif) return reply.status(404).send({ error: 'Notification not found' });
 
     await prisma.userNotification.update({
       where: { id: notifId },
@@ -114,12 +114,12 @@ export async function notificationRoutes(app: FastifyInstance) {
     const user = request.user as { id: number };
     const { id } = request.params as { id: string };
     const notifId = parseId(id);
-    if (!notifId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!notifId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const notif = await prisma.userNotification.findFirst({
       where: { id: notifId, userId: user.id },
     });
-    if (!notif) return reply.status(404).send({ error: 'Notification introuvable' });
+    if (!notif) return reply.status(404).send({ error: 'Notification not found' });
 
     await prisma.userNotification.delete({ where: { id: notifId } });
 

--- a/packages/backend/src/routes/radarr-sonarr.ts
+++ b/packages/backend/src/routes/radarr-sonarr.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { getArrClient } from '../providers/index.js';
 import { prisma } from '../utils/prisma.js';
+import { logEvent } from '../utils/logEvent.js';
 
 export async function radarrSonarrRoutes(app: FastifyInstance) {
   // Radarr status
@@ -121,7 +122,7 @@ export async function radarrSonarrRoutes(app: FastifyInstance) {
 
       return downloads;
     } catch (err) {
-      console.warn('[Downloads] Failed to fetch queue:', err);
+      logEvent('debug', 'Downloads', `Failed to fetch queue: ${err}`);
       return [];
     }
   });
@@ -154,8 +155,8 @@ export async function radarrSonarrRoutes(app: FastifyInstance) {
         },
       };
     } catch (err) {
-      console.warn('[Stats] Failed to fetch library stats:', err);
-      return { error: 'Impossible de recuperer les statistiques' };
+      logEvent('debug', 'Stats', `Failed to fetch library stats: ${err}`);
+      return { error: 'Unable to retrieve statistics' };
     }
   });
 
@@ -214,7 +215,7 @@ export async function radarrSonarrRoutes(app: FastifyInstance) {
         })),
         ...episodeItems.map((e) => ({
           type: 'episode' as const,
-          title: e.series?.title || 'Serie inconnue',
+          title: e.series?.title || 'Unknown series',
           episodeTitle: e.title,
           season: e.seasonNumber,
           episode: e.episodeNumber,
@@ -228,7 +229,7 @@ export async function radarrSonarrRoutes(app: FastifyInstance) {
 
       return items;
     } catch (err) {
-      console.warn('[Calendar] Failed to fetch calendar:', err);
+      logEvent('debug', 'Calendar', `Failed to fetch calendar: ${err}`);
       return [];
     }
   });

--- a/packages/backend/src/routes/requests.ts
+++ b/packages/backend/src/routes/requests.ts
@@ -135,7 +135,7 @@ export async function requestRoutes(app: FastifyInstance) {
     const existing = await prisma.mediaRequest.findFirst({
       where: { mediaId: media.id, userId: user.id, status: { in: [...ACTIVE_REQUEST_STATUSES] } },
     });
-    if (existing) return reply.status(409).send({ error: 'Vous avez déjà une demande en cours pour ce média' });
+    if (existing) return reply.status(409).send({ error: 'You already have an active request for this media' });
 
     // Validate quality option role restriction
     const settings = await prisma.appSettings.findUnique({ where: { id: 1 } });
@@ -180,13 +180,13 @@ export async function requestRoutes(app: FastifyInstance) {
 
     // Notifications
     const dbUser = await prisma.user.findUnique({ where: { id: user.id }, select: { displayName: true } });
-    const username = dbUser?.displayName || 'Utilisateur';
+    const username = dbUser?.displayName || 'User';
     const mediaUrl = await buildSiteLink(`/${mediaType}/${media.tmdbId}`);
     safeNotify('request_new', { title: media.title, mediaType, username, posterPath: media.posterPath, tmdbId: media.tmdbId, url: mediaUrl });
     if (shouldAutoApprove && !sendFailed) {
-      safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: `Votre demande pour "${media.title}" a été approuvée automatiquement.`, metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType } });
+      safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: 'notifications.msg.request_auto_approved', metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType, msgParams: { title: media.title } } });
     }
-    logEvent('info', 'Request', `${username} a demandé "${media.title}"`);
+    logEvent('info', 'Request', `${username} requested "${media.title}"`);
 
     if (sendFailed) return reply.status(202).send({ ...mediaRequest, status: 'failed', sendError: true });
     return reply.status(201).send(mediaRequest);
@@ -200,14 +200,14 @@ export async function requestRoutes(app: FastifyInstance) {
     },
   }, async (request, reply) => {
     const requestId = parseId((request.params as { id: string }).id);
-    if (!requestId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!requestId) return reply.status(400).send({ error: 'Invalid ID' });
     const overrideQuality = parseId((request.query as { qualityOptionId?: string }).qualityOptionId || '');
 
     const mediaRequest = await prisma.mediaRequest.findUnique({
       where: { id: requestId },
       include: { media: true, qualityOption: { select: { id: true, label: true } } },
     });
-    if (!mediaRequest) return reply.status(404).send({ error: 'Demande introuvable' });
+    if (!mediaRequest) return reply.status(404).send({ error: 'Request not found' });
 
     const effectiveQuality = overrideQuality ?? mediaRequest.qualityOptionId ?? undefined;
     let ctx;
@@ -264,15 +264,15 @@ export async function requestRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const user = request.user as { id: number };
     const requestId = parseId((request.params as { id: string }).id);
-    if (!requestId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!requestId) return reply.status(400).send({ error: 'Invalid ID' });
     const { qualityOptionId: overrideQuality } = (request.body as { qualityOptionId?: number }) || {};
 
     const mediaRequest = await prisma.mediaRequest.findUnique({
       where: { id: requestId },
       include: { media: true, user: { select: { displayName: true, email: true, id: true } } },
     });
-    if (!mediaRequest) return reply.status(404).send({ error: 'Demande introuvable' });
-    if (mediaRequest.status !== 'pending') return reply.status(400).send({ error: 'Cette demande ne peut pas être approuvée' });
+    if (!mediaRequest) return reply.status(404).send({ error: 'Request not found' });
+    if (mediaRequest.status !== 'pending') return reply.status(400).send({ error: 'This request cannot be approved' });
 
     // Use override quality if provided, otherwise keep the original
     const effectiveQuality = overrideQuality ?? mediaRequest.qualityOptionId ?? undefined;
@@ -292,11 +292,11 @@ export async function requestRoutes(app: FastifyInstance) {
 
     if (sent) {
       const approvedUrl = await buildSiteLink(`/${updated.mediaType}/${updated.media.tmdbId}`);
-      safeNotify('request_approved', { title: updated.media.title, mediaType: updated.mediaType as 'movie' | 'tv', username: updated.user?.displayName || 'Utilisateur', posterPath: updated.media.posterPath, url: approvedUrl });
-      safeUserNotify(updated.user.id, { type: 'request_approved', title: updated.media.title, message: `Votre demande pour "${updated.media.title}" a été approuvée.`, metadata: { mediaId: updated.mediaId, tmdbId: updated.media.tmdbId, mediaType: updated.mediaType } });
-      logEvent('info', 'Request', `Demande "${updated.media.title}" approuvée`);
+      safeNotify('request_approved', { title: updated.media.title, mediaType: updated.mediaType as 'movie' | 'tv', username: updated.user?.displayName || 'User', posterPath: updated.media.posterPath, url: approvedUrl });
+      safeUserNotify(updated.user.id, { type: 'request_approved', title: updated.media.title, message: 'notifications.msg.request_approved', metadata: { mediaId: updated.mediaId, tmdbId: updated.media.tmdbId, mediaType: updated.mediaType, msgParams: { title: updated.media.title } } });
+      logEvent('info', 'Request', `Request "${updated.media.title}" approved`);
     } else {
-      logEvent('error', 'Request', `Demande "${updated.media.title}" approuvée mais l'envoi au service a échoué`);
+      logEvent('error', 'Request', `Request "${updated.media.title}" approved but failed to send to service`);
     }
 
     return reply.send(updated);
@@ -308,7 +308,7 @@ export async function requestRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const user = request.user as { id: number };
     const requestId = parseId((request.params as { id: string }).id);
-    if (!requestId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!requestId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const updated = await prisma.mediaRequest.update({
       where: { id: requestId },
@@ -317,9 +317,9 @@ export async function requestRoutes(app: FastifyInstance) {
     });
 
     const declinedUrl = await buildSiteLink(`/${updated.mediaType}/${updated.media.tmdbId}`);
-    safeNotify('request_declined', { title: updated.media.title, mediaType: updated.mediaType as 'movie' | 'tv', username: updated.user?.displayName || 'Utilisateur', posterPath: updated.media.posterPath, url: declinedUrl });
-    safeUserNotify(updated.user.id, { type: 'request_declined', title: updated.media.title, message: `Votre demande pour "${updated.media.title}" a été refusée.`, metadata: { mediaId: updated.mediaId, tmdbId: updated.media.tmdbId, mediaType: updated.mediaType } });
-    logEvent('info', 'Request', `Demande "${updated.media.title}" refusée`);
+    safeNotify('request_declined', { title: updated.media.title, mediaType: updated.mediaType as 'movie' | 'tv', username: updated.user?.displayName || 'User', posterPath: updated.media.posterPath, url: declinedUrl });
+    safeUserNotify(updated.user.id, { type: 'request_declined', title: updated.media.title, message: 'notifications.msg.request_declined', metadata: { mediaId: updated.mediaId, tmdbId: updated.media.tmdbId, mediaType: updated.mediaType, msgParams: { title: updated.media.title } } });
+    logEvent('info', 'Request', `Request "${updated.media.title}" declined`);
 
     return reply.send(updated);
   });
@@ -346,7 +346,7 @@ export async function requestRoutes(app: FastifyInstance) {
     }
 
     const media = await prisma.media.findUnique({ where: { tmdbId_mediaType: { tmdbId, mediaType } } });
-    if (!media) return reply.status(404).send({ error: 'Média introuvable' });
+    if (!media) return reply.status(404).send({ error: 'Media not found' });
 
     // Cooldown check
     const settings = await prisma.appSettings.findUnique({ where: { id: 1 } });
@@ -355,25 +355,25 @@ export async function requestRoutes(app: FastifyInstance) {
       const elapsed = Date.now() - new Date(media.lastMissingSearchAt).getTime();
       const remaining = Math.ceil((cooldownMin * 60 * 1000 - elapsed) / 60000);
       if (elapsed < cooldownMin * 60 * 1000) {
-        return reply.status(429).send({ error: `Recherche déjà lancée récemment. Réessayez dans ${remaining} min.`, cooldownRemaining: remaining });
+        return reply.status(429).send({ error: `Search already started recently. Try again in ${remaining} min.`, cooldownRemaining: remaining });
       }
     }
 
     try {
       const serviceId = mediaType === 'movie' ? media.radarrId : media.sonarrId;
       if (!serviceId) {
-        return reply.status(400).send({ error: 'Ce média n\'est pas encore dans le service' });
+        return reply.status(400).send({ error: 'This media is not yet in the service' });
       }
       const serviceType = getServiceTypeForMedia(mediaType);
       const client = await getArrClient(serviceType);
       await client.searchMedia(serviceId);
 
       await prisma.media.update({ where: { id: media.id }, data: { lastMissingSearchAt: new Date() } });
-      logEvent('info', 'Request', `Recherche des manquants lancée pour "${media.title}"`);
+      logEvent('info', 'Request', `Missing episodes search started for "${media.title}"`);
       return reply.send({ ok: true });
     } catch (err) {
-      console.error('Search missing failed:', err);
-      return reply.status(502).send({ error: 'Erreur lors du lancement de la recherche' });
+      logEvent('debug', 'Request', `Search missing failed: ${err}`);
+      return reply.status(502).send({ error: 'Failed to start search' });
     }
   });
 
@@ -385,7 +385,7 @@ export async function requestRoutes(app: FastifyInstance) {
     },
   }, async (request, reply) => {
     const requestId = parseId((request.params as { id: string }).id);
-    if (!requestId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!requestId) return reply.status(400).send({ error: 'Invalid ID' });
     const { rootFolder, qualityOptionId } = (request.body as { rootFolder?: string; qualityOptionId?: number }) || {};
 
     const data: Record<string, unknown> = {};
@@ -395,7 +395,7 @@ export async function requestRoutes(app: FastifyInstance) {
     if (Object.keys(data).length === 0) return reply.status(400).send({ error: 'Nothing to update' });
 
     const existing = await prisma.mediaRequest.findUnique({ where: { id: requestId } });
-    if (!existing) return reply.status(404).send({ error: 'Demande introuvable' });
+    if (!existing) return reply.status(404).send({ error: 'Request not found' });
 
     const updated = await prisma.mediaRequest.update({
       where: { id: requestId },
@@ -447,7 +447,7 @@ export async function requestRoutes(app: FastifyInstance) {
               deletedFromService++;
             }
           } catch (err) {
-            console.warn(`[Cleanup] Failed to delete from service for request ${req.id}:`, err);
+            logEvent('debug', 'Cleanup', `Failed to delete from service for request ${req.id}: ${err}`);
           }
         }
       }
@@ -466,11 +466,11 @@ export async function requestRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const user = request.user as { id: number };
     const requestId = parseId((request.params as { id: string }).id);
-    if (!requestId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!requestId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const mediaRequest = await prisma.mediaRequest.findUnique({ where: { id: requestId } });
-    if (!mediaRequest) return reply.status(404).send({ error: 'Demande introuvable' });
-    if (request.ownerScoped && mediaRequest.userId !== user.id) return reply.status(403).send({ error: 'Non autorisé' });
+    if (!mediaRequest) return reply.status(404).send({ error: 'Request not found' });
+    if (request.ownerScoped && mediaRequest.userId !== user.id) return reply.status(403).send({ error: 'Unauthorized' });
 
     await prisma.mediaRequest.delete({ where: { id: requestId } });
     return reply.send({ ok: true });
@@ -490,7 +490,7 @@ export async function requestRoutes(app: FastifyInstance) {
     const { collectionId } = request.body as { collectionId: unknown };
 
     if (typeof collectionId !== 'number' || !Number.isFinite(collectionId) || collectionId < 1) {
-      return reply.status(400).send({ error: 'collectionId invalide' });
+      return reply.status(400).send({ error: 'Invalid collectionId' });
     }
 
     if (user.role !== 'admin') {
@@ -499,7 +499,7 @@ export async function requestRoutes(app: FastifyInstance) {
     }
 
     const collection = await getCollection(collectionId);
-    if (!collection?.parts?.length) return reply.status(404).send({ error: 'Collection introuvable' });
+    if (!collection?.parts?.length) return reply.status(404).send({ error: 'Collection not found' });
 
     let requested = 0;
     let skipped = 0;

--- a/packages/backend/src/routes/setup.ts
+++ b/packages/backend/src/routes/setup.ts
@@ -14,17 +14,17 @@ if (!SETUP_SECRET) {
 
 async function requireNotInstalled(_request: FastifyRequest, reply: FastifyReply) {
   if (isInstalled()) {
-    return reply.status(403).send({ error: 'Installation déjà effectuée' });
+    return reply.status(403).send({ error: 'Installation already completed' });
   }
 }
 
 async function requireSetupSecret(request: FastifyRequest, reply: FastifyReply) {
   if (!SETUP_SECRET) {
-    return reply.status(500).send({ error: 'SETUP_SECRET non configuré dans le .env' });
+    return reply.status(500).send({ error: 'SETUP_SECRET not configured in .env' });
   }
   const token = request.headers['x-setup-secret'];
   if (token !== SETUP_SECRET) {
-    return reply.status(401).send({ error: 'Secret d\'installation invalide' });
+    return reply.status(401).send({ error: 'Invalid setup secret' });
   }
 }
 
@@ -72,10 +72,10 @@ export async function setupRoutes(app: FastifyInstance) {
     },
   }, async (request, reply) => {
     const { pinId } = request.body as { pinId: number };
-    if (!pinId) return reply.status(400).send({ error: 'pinId requis' });
+    if (!pinId) return reply.status(400).send({ error: 'pinId required' });
     const { plexCheckPin } = await import('../providers/plex/index.js');
     const authToken = await plexCheckPin(pinId);
-    if (!authToken) return reply.status(400).send({ error: 'PIN non validé' });
+    if (!authToken) return reply.status(400).send({ error: 'PIN not validated' });
     return reply.send({ token: authToken });
   });
 
@@ -95,12 +95,12 @@ export async function setupRoutes(app: FastifyInstance) {
     const { type, config } = request.body as { type: string; config: Record<string, string> };
     const { getServiceDefinition } = await import('../providers/index.js');
     const def = getServiceDefinition(type);
-    if (!def) return reply.status(400).send({ error: 'Type de service non supporté' });
+    if (!def) return reply.status(400).send({ error: 'Unsupported service type' });
 
     try {
       return await def.test(config);
     } catch {
-      return reply.status(502).send({ error: 'Impossible de contacter le service' });
+      return reply.status(502).send({ error: 'Unable to reach the service' });
     }
   });
 
@@ -120,7 +120,7 @@ export async function setupRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { name, type, config } = request.body as { name: string; type: string; config: Record<string, string> };
     if (!name || !type || !config) {
-      return reply.status(400).send({ error: 'Tous les champs sont requis' });
+      return reply.status(400).send({ error: 'All fields are required' });
     }
 
     const service = await prisma.service.create({
@@ -142,7 +142,7 @@ export async function setupRoutes(app: FastifyInstance) {
       });
     }
 
-    logEvent('info', 'Setup', `Service "${name}" (${type}) ajouté via l'installation`);
+    logEvent('info', 'Setup', `Service "${name}" (${type}) added during installation`);
     return reply.status(201).send({ ok: true, service: { ...service, config: JSON.parse(service.config) } });
   });
 
@@ -152,7 +152,7 @@ export async function setupRoutes(app: FastifyInstance) {
       where: { type: { in: ['radarr', 'sonarr'] }, enabled: true },
     });
     if (!arrService) {
-      return reply.status(400).send({ error: 'Configurez au moins un service Radarr ou Sonarr' });
+      return reply.status(400).send({ error: 'Configure at least one Radarr or Sonarr service' });
     }
 
     try {
@@ -162,10 +162,10 @@ export async function setupRoutes(app: FastifyInstance) {
       // Mark installation as complete — locks all setup routes
       markInstalled();
 
-      logEvent('info', 'Setup', 'Première synchronisation complète effectuée');
+      logEvent('info', 'Setup', 'First full sync completed');
       return { ok: true, result };
     } catch (err) {
-      return reply.status(500).send({ error: 'Sync échouée', details: String(err) });
+      return reply.status(500).send({ error: 'Sync failed', details: String(err) });
     }
   });
 }

--- a/packages/backend/src/routes/support.ts
+++ b/packages/backend/src/routes/support.ts
@@ -52,8 +52,8 @@ export async function supportRoutes(app: FastifyInstance) {
     const user = request.user as { id: number };
     const { subject, message } = request.body as { subject: string; message: string };
 
-    if (!subject?.trim()) return reply.status(400).send({ error: 'Sujet requis' });
-    if (!message?.trim()) return reply.status(400).send({ error: 'Message requis' });
+    if (!subject?.trim()) return reply.status(400).send({ error: 'Subject required' });
+    if (!message?.trim()) return reply.status(400).send({ error: 'Message required' });
 
     const ticket = await prisma.supportTicket.create({
       data: {
@@ -68,7 +68,7 @@ export async function supportRoutes(app: FastifyInstance) {
       },
     });
 
-    logEvent('info', 'Support', `Ticket créé par ${ticket.user.displayName} : "${subject.trim()}"`);
+    logEvent('info', 'Support', `Ticket created by ${ticket.user.displayName}: "${subject.trim()}"`);
     return reply.status(201).send(ticket);
   });
 
@@ -88,12 +88,12 @@ export async function supportRoutes(app: FastifyInstance) {
     const user = request.user as { id: number; role: string };
     const { id } = request.params as { id: string };
     const ticketId = parseId(id);
-    if (!ticketId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ticketId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const ticket = await prisma.supportTicket.findUnique({ where: { id: ticketId } });
-    if (!ticket) return reply.status(404).send({ error: 'Ticket introuvable' });
+    if (!ticket) return reply.status(404).send({ error: 'Ticket not found' });
     if (request.ownerScoped && ticket.userId !== user.id) {
-      return reply.status(403).send({ error: 'Accès refusé' });
+      return reply.status(403).send({ error: 'Access denied' });
     }
 
     const messages = await prisma.ticketMessage.findMany({
@@ -128,15 +128,15 @@ export async function supportRoutes(app: FastifyInstance) {
     const user = request.user as { id: number; role: string };
     const { id } = request.params as { id: string };
     const ticketId = parseId(id);
-    if (!ticketId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ticketId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const { content } = request.body as { content: string };
-    if (!content?.trim()) return reply.status(400).send({ error: 'Contenu requis' });
+    if (!content?.trim()) return reply.status(400).send({ error: 'Content required' });
 
     const ticket = await prisma.supportTicket.findUnique({ where: { id: ticketId } });
-    if (!ticket) return reply.status(404).send({ error: 'Ticket introuvable' });
+    if (!ticket) return reply.status(404).send({ error: 'Ticket not found' });
     if (request.ownerScoped && ticket.userId !== user.id) {
-      return reply.status(403).send({ error: 'Accès refusé' });
+      return reply.status(403).send({ error: 'Access denied' });
     }
 
     // Reopen ticket if closed and user replies
@@ -153,9 +153,9 @@ export async function supportRoutes(app: FastifyInstance) {
     if (user.role === 'admin' && ticket.userId !== user.id) {
       safeUserNotify(ticket.userId, {
         type: 'support_reply',
-        title: `Réponse sur votre ticket #${ticketId}`,
+        title: 'notifications.msg.support_reply',
         message: content.trim().slice(0, 200),
-        metadata: { ticketId },
+        metadata: { ticketId, msgParams: { ticketId } },
       });
     }
 
@@ -184,10 +184,10 @@ export async function supportRoutes(app: FastifyInstance) {
   }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const ticketId = parseId(id);
-    if (!ticketId) return reply.status(400).send({ error: 'ID invalide' });
+    if (!ticketId) return reply.status(400).send({ error: 'Invalid ID' });
 
     const { status } = request.body as { status: string };
-    if (!['open', 'closed'].includes(status)) return reply.status(400).send({ error: 'Statut invalide' });
+    if (!['open', 'closed'].includes(status)) return reply.status(400).send({ error: 'Invalid status' });
 
     const ticket = await prisma.supportTicket.update({
       where: { id: ticketId },
@@ -197,7 +197,7 @@ export async function supportRoutes(app: FastifyInstance) {
       },
     });
 
-    logEvent('info', 'Support', `Ticket #${ticketId} ${status === 'closed' ? 'fermé' : 'réouvert'}`);
+    logEvent('info', 'Support', `Ticket #${ticketId} ${status === 'closed' ? 'closed' : 'reopened'}`);
     return ticket;
   });
 }

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -67,7 +67,7 @@ export async function webhookRoutes(app: FastifyInstance) {
 
     // 3. Handle event
     if (event.type === 'test') {
-      console.log(`[Webhook] ${sanitize(serviceType)} test received`);
+      logEvent('debug', 'Webhook', `${sanitize(serviceType)} test received`);
       logEvent('info', 'Webhook', `${sanitize(serviceType)} webhook test successful`);
       return reply.send({ ok: true, message: 'Webhook configured successfully' });
     }
@@ -100,7 +100,7 @@ export async function webhookRoutes(app: FastifyInstance) {
           },
         });
         logEvent('info', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" added — created in Oscarr`);
-        console.log(`[Webhook] ${sanitize(serviceType)}: "${sanitize(event.title)}" added → created in DB`);
+        logEvent('debug', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" added, created in DB`);
       }
       return reply.send({ ok: true });
     }
@@ -117,7 +117,7 @@ export async function webhookRoutes(app: FastifyInstance) {
           data: { status: 'deleted' },
         });
         logEvent('info', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" deleted from service`);
-        console.log(`[Webhook] ${sanitize(serviceType)}: "${sanitize(event.title)}" → deleted`);
+        logEvent('debug', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" deleted`);
       }
       return reply.send({ ok: true });
     }
@@ -138,7 +138,7 @@ export async function webhookRoutes(app: FastifyInstance) {
       }
 
       if (!media) {
-        console.log(`[Webhook] ${sanitize(serviceType)} download event for unknown media: ${sanitize(event.title)} (${event.externalId})`);
+        logEvent('debug', 'Webhook', `${sanitize(serviceType)} download event for unknown media: ${sanitize(event.title)} (${event.externalId})`);
         return reply.send({ ok: true, message: 'Media not tracked' });
       }
 
@@ -153,7 +153,7 @@ export async function webhookRoutes(app: FastifyInstance) {
           media.tmdbId,
         );
         logEvent('info', 'Webhook', `"${sanitize(event.title)}" is now available (via ${sanitize(serviceType)} webhook)`);
-        console.log(`[Webhook] ${sanitize(serviceType)}: "${sanitize(event.title)}" → available`);
+        logEvent('debug', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" now available`);
       }
 
       return reply.send({ ok: true, message: 'Media updated' });

--- a/packages/backend/src/services/folderRules.ts
+++ b/packages/backend/src/services/folderRules.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../utils/prisma.js';
 import type { TmdbMovie, TmdbTv } from './tmdb.js';
+import { logEvent } from '../utils/logEvent.js';
 
 export interface RuleCondition {
   field: 'genre' | 'language' | 'country' | 'user' | 'role' | 'tag' | 'quality';
@@ -36,7 +37,7 @@ function parseKeywordIds(raw: string, tmdbId: number): number[] {
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? parsed : [];
   } catch {
-    console.warn(`[FolderRules] Malformed keywordIds for tmdbId=${tmdbId}: ${raw}`);
+    logEvent('debug', 'FolderRules', `Malformed keywordIds for tmdbId=${tmdbId}: ${raw}`);
     return [];
   }
 }
@@ -147,7 +148,7 @@ function parseRuleConditions(rule: { id: number; name: string; conditions: strin
   try {
     return JSON.parse(rule.conditions);
   } catch {
-    console.warn(`[FolderRules] Malformed conditions in rule id=${rule.id} "${rule.name}", skipping`);
+    logEvent('debug', 'FolderRules', `Malformed conditions in rule id=${rule.id} "${rule.name}", skipping`);
     return null;
   }
 }

--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -17,10 +17,10 @@ export function validateRequestBody(body: { tmdbId: unknown; mediaType: unknown;
 } | { valid: false; error: string } {
   const { tmdbId, mediaType, seasons } = body;
   if (typeof tmdbId !== 'number' || !Number.isFinite(tmdbId) || tmdbId < 1) {
-    return { valid: false, error: 'tmdbId invalide' };
+    return { valid: false, error: 'Invalid tmdbId' };
   }
   if (!VALID_MEDIA_TYPES.includes(mediaType as string)) {
-    return { valid: false, error: 'mediaType doit être "movie" ou "tv"' };
+    return { valid: false, error: 'mediaType must be "movie" or "tv"' };
   }
   const validSeasons = Array.isArray(seasons) && seasons.every((s) => typeof s === 'number' && Number.isFinite(s))
     ? (seasons as number[])
@@ -215,11 +215,11 @@ export async function sendToService(
             data: { tvdbId: resolvedTvdbId },
           });
         } else {
-          console.error('Cannot send TV request — tvdbId not found in TMDB for "%s"', media.title);
+          logEvent('debug', 'Request', `Cannot send TV request — tvdbId not found in TMDB for "${media.title}"`);
           return false;
         }
       } catch {
-        console.error('Cannot send TV request — failed to resolve tvdbId for "%s"', media.title);
+        logEvent('debug', 'Request', `Cannot send TV request — failed to resolve tvdbId for "${media.title}"`);
         return false;
       }
     }
@@ -227,8 +227,8 @@ export async function sendToService(
     await sendToArrService(resolvedMedia, mediaType, username, ctx, seasons, rootFolderOverride);
     return true;
   } catch (err) {
-    console.error('Failed to send %s "%s" to service:', mediaType, media.title, err);
-    logEvent('error', 'Request', `Échec d'envoi de "${media.title}" vers ${getServiceTypeForMedia(mediaType)} : ${String(err)}`);
+    logEvent('debug', 'Request', `Failed to send ${mediaType} "${media.title}" to service: ${err}`);
+    logEvent('error', 'Request', `Failed to send "${media.title}" to ${getServiceTypeForMedia(mediaType)}: ${String(err)}`);
     return false;
   }
 }
@@ -318,7 +318,7 @@ export async function retryFailedRequests(): Promise<{ retried: number; succeede
   }
 
   if (succeeded > 0) {
-    logEvent('info', 'Request', `${succeeded}/${failed.length} demandes échouées réessayées avec succès`);
+    logEvent('info', 'Request', `${succeeded}/${failed.length} failed requests retried successfully`);
   }
 
   return { retried: failed.length, succeeded };

--- a/packages/backend/src/services/requestSync.ts
+++ b/packages/backend/src/services/requestSync.ts
@@ -3,6 +3,7 @@ import { getArrClient } from '../providers/index.js';
 import type { ArrMediaItem } from '../providers/types.js';
 import { getServiceConfig } from '../utils/services.js';
 import { chunk } from '../utils/batch.js';
+import { logEvent } from '../utils/logEvent.js';
 
 export async function cleanupOrphanedRequests(): Promise<{ deleted: number }> {
   const result = await prisma.$executeRaw`DELETE FROM MediaRequest WHERE userId NOT IN (SELECT id FROM User) OR mediaId NOT IN (SELECT id FROM Media)`;
@@ -47,7 +48,7 @@ async function syncServiceRequests(serviceType: string, usernameMap: Map<string,
 
   const config = await getServiceConfig(serviceType);
   if (!config) {
-    console.log(`[RequestSync] ${serviceType}: no service configured, skipping`);
+    logEvent('debug', 'RequestSync', `${serviceType}: no service configured, skipping`);
     return { imported: 0, skipped: 0, errors: 0 };
   }
 
@@ -131,7 +132,7 @@ async function syncServiceRequests(serviceType: string, usernameMap: Map<string,
       imported = toCreate.length;
     }
   } catch (err) {
-    console.error(`[RequestSync] ${serviceType} sync failed:`, err);
+    logEvent('debug', 'RequestSync', `${serviceType} sync failed: ${err}`);
     errors++;
   }
 

--- a/packages/backend/src/services/scheduler.ts
+++ b/packages/backend/src/services/scheduler.ts
@@ -66,12 +66,11 @@ async function runJob(key: string) {
         lastResult: JSON.stringify(result ?? null),
       },
     });
-    console.log(`[Scheduler] Job "${sanitize(key)}" completed in ${duration}ms`);
-    logEvent('info', 'Job', `Job "${sanitize(key)}" terminé en ${duration}ms`);
+    logEvent('info', 'Job', `Job "${sanitize(key)}" completed in ${duration}ms`);
 
     // After the first successful full sync, start all cron schedules
     if (wasFirstSync && key === 'full_sync' && activeTasks.size === 0) {
-      console.log('[Scheduler] First full sync done — starting cron schedules');
+      logEvent('debug', 'Job', 'First full sync done — starting cron schedules');
       await startAllJobs();
     }
 
@@ -87,8 +86,7 @@ async function runJob(key: string) {
         lastResult: JSON.stringify({ error: String(err) }),
       },
     });
-    console.error('[Scheduler] Job "%s" failed:', sanitize(key), err);
-    logEvent('error', 'Job', `Job "${sanitize(key)}" échoué : ${String(err)}`);
+    logEvent('error', 'Job', `Job "${sanitize(key)}" failed: ${String(err)}`);
     throw err;
   }
 }
@@ -102,7 +100,7 @@ function scheduleJob(key: string, cronExpression: string) {
   }
 
   if (!cron.validate(cronExpression)) {
-    console.error('[Scheduler] Invalid cron expression for "%s": %s', sanitize(key), sanitize(cronExpression));
+    logEvent('debug', 'Job', `Invalid cron expression for "${sanitize(key)}": ${sanitize(cronExpression)}`);
     return;
   }
 
@@ -110,7 +108,7 @@ function scheduleJob(key: string, cronExpression: string) {
     runJob(key).catch(() => {});
   });
   activeTasks.set(key, task);
-  console.log('[Scheduler] Job "%s" scheduled: %s', sanitize(key), sanitize(cronExpression));
+  logEvent('debug', 'Job', `Job "${sanitize(key)}" scheduled: ${sanitize(cronExpression)}`);
 }
 
 /** Check if a first full sync has been completed */
@@ -127,7 +125,7 @@ async function startAllJobs() {
       scheduleJob(job.key, job.cronExpression);
     }
   }
-  console.log(`[Scheduler] ${jobs.filter((j) => j.enabled).length}/${jobs.length} jobs active`);
+  logEvent('debug', 'Job', `${jobs.filter((j) => j.enabled).length}/${jobs.length} jobs active`);
 }
 
 export async function initScheduler(pluginEngine?: PluginEngine) {
@@ -152,7 +150,7 @@ export async function initScheduler(pluginEngine?: PluginEngine) {
   if (await hasCompletedFirstSync()) {
     await startAllJobs();
   } else {
-    console.log('[Scheduler] Jobs seeded but not started — waiting for first full sync');
+    logEvent('debug', 'Job', 'Jobs seeded but not started — waiting for first full sync');
   }
 }
 

--- a/packages/backend/src/services/sync/availabilitySync.ts
+++ b/packages/backend/src/services/sync/availabilitySync.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../utils/prisma.js';
 import { getArrClient } from '../../providers/index.js';
 import { getServiceConfig } from '../../utils/services.js';
+import { logEvent } from '../../utils/logEvent.js';
 
 export async function syncAvailabilityDates(since?: Date | null): Promise<{ radarrUpdated: number; sonarrUpdated: number }> {
   let radarrUpdated = 0;
@@ -9,13 +10,13 @@ export async function syncAvailabilityDates(since?: Date | null): Promise<{ rada
   try {
     radarrUpdated = await syncServiceAvailability('radarr', since ?? null);
   } catch (err) {
-    console.error('[Sync] Radarr availability sync failed:', err);
+    logEvent('debug', 'Sync', `Radarr availability sync failed: ${err}`);
   }
 
   try {
     sonarrUpdated = await syncServiceAvailability('sonarr', since ?? null);
   } catch (err) {
-    console.error('[Sync] Sonarr availability sync failed:', err);
+    logEvent('debug', 'Sync', `Sonarr availability sync failed: ${err}`);
   }
 
   return { radarrUpdated, sonarrUpdated };
@@ -57,10 +58,10 @@ async function syncServiceAvailability(serviceType: string, since: Date | null):
       updated += result.count;
     }
 
-    console.log(`[Sync] ${serviceType} availability: ${entries.length} history events -> ${updated} media updated`);
+    logEvent('debug', 'Sync', `${serviceType} availability: ${entries.length} history events -> ${updated} media updated`);
     return updated;
   } catch (err) {
-    console.error(`[Sync] ${serviceType} availability sync failed:`, err);
+    logEvent('debug', 'Sync', `${serviceType} availability sync failed: ${err}`);
     return 0;
   }
 }

--- a/packages/backend/src/services/sync/helpers.ts
+++ b/packages/backend/src/services/sync/helpers.ts
@@ -27,8 +27,8 @@ export function sendAvailabilityNotifications(
       safeUserNotify(req.userId, {
         type: 'media_available',
         title,
-        message: `"${title}" est maintenant disponible.`,
-        metadata: { mediaId, tmdbId, mediaType },
+        message: 'notifications.msg.media_available',
+        metadata: { mediaId, tmdbId, mediaType, msgParams: { title } },
       });
     }
   }).catch(() => {});

--- a/packages/backend/src/services/sync/keywordSync.ts
+++ b/packages/backend/src/services/sync/keywordSync.ts
@@ -48,7 +48,7 @@ export async function syncMissingKeywords(): Promise<{ synced: number; errors: n
 
   if (mediasWithoutKeywords.length === 0) return { synced: 0, errors: 0 };
 
-  console.log(`[KeywordSync] ${mediasWithoutKeywords.length} media without keywords`);
+  logEvent('debug', 'KeywordSync', `${mediasWithoutKeywords.length} media without keywords`);
 
   for (let i = 0; i < mediasWithoutKeywords.length; i += BATCH_SIZE) {
     const batch = mediasWithoutKeywords.slice(i, i + BATCH_SIZE);
@@ -69,7 +69,7 @@ export async function syncMissingKeywords(): Promise<{ synced: number; errors: n
           data: { keywordIds: '[]' },
         }).catch(() => {});
         errors++;
-        console.error(`[KeywordSync] Failed for "${media.title}" (tmdb:${media.tmdbId}):`, err);
+        logEvent('debug', 'KeywordSync', `Failed for "${media.title}" (tmdb:${media.tmdbId}): ${err}`);
       }
     }
 

--- a/packages/backend/src/services/sync/mediaSync.ts
+++ b/packages/backend/src/services/sync/mediaSync.ts
@@ -13,7 +13,7 @@ export async function syncArrService(serviceType: string, since?: Date | null): 
 
   const config = await getServiceConfig(serviceType);
   if (!config) {
-    console.log(`[Sync] ${serviceType}: no service configured, skipping`);
+    logEvent('debug', 'Sync', `${serviceType}: no service configured, skipping`);
     return { added: 0, updated: 0, errors: 0, duration: 0 };
   }
 
@@ -45,11 +45,11 @@ export async function syncArrService(serviceType: string, since?: Date | null): 
       filtered = [...combined.values()];
 
       if (needsUpdateIds.size > 0) {
-        console.log(`[Sync] ${serviceType} incremental: ${newlyAdded.length} newly added, ${toUpdate.length} need status update`);
+        logEvent('debug', 'Sync', `${serviceType} incremental: ${newlyAdded.length} newly added, ${toUpdate.length} need status update`);
       }
     }
 
-    console.log(`[Sync] ${serviceType}: ${filtered.length} items to process (${since ? 'incremental' : 'full scan'})`);
+    logEvent('debug', 'Sync', `${serviceType}: ${filtered.length} items to process (${since ? 'incremental' : 'full scan'})`);
 
     for (const item of filtered) {
       try {
@@ -58,7 +58,7 @@ export async function syncArrService(serviceType: string, since?: Date | null): 
         else if (result === 'updated') updated++;
       } catch (err) {
         errors++;
-        console.error(`[Sync] Error processing ${item.title}:`, err);
+        logEvent('debug', 'Sync', `Error processing ${item.title}: ${err}`);
       }
     }
 
@@ -70,7 +70,6 @@ export async function syncArrService(serviceType: string, since?: Date | null): 
       create: { id: 1, [syncField]: new Date(), updatedAt: new Date() },
     });
   } catch (err) {
-    console.error(`[Sync] ${serviceType} sync failed:`, err);
     logEvent('error', 'Sync', `${serviceType} sync failed: ${err}`);
     errors++;
   }
@@ -153,7 +152,7 @@ async function processSingleMedia(item: ArrMediaItem, client: ArrClient): Promis
 
   const becameAvailable = item.status === 'available' && existing.status !== 'available';
   if (becameAvailable) {
-    console.log(`[Sync] "${item.title}" (${client.serviceType}:${item.externalId}) status: ${existing.status} -> ${item.status}`);
+    logEvent('debug', 'Sync', `"${item.title}" (${client.serviceType}:${item.externalId}) status: ${existing.status} -> ${item.status}`);
     sendAvailabilityNotifications(
       existing.title || item.title,
       client.mediaType,

--- a/packages/backend/src/utils/logEvent.ts
+++ b/packages/backend/src/utils/logEvent.ts
@@ -1,8 +1,21 @@
 import { prisma } from './prisma.js';
 
-export async function logEvent(level: 'info' | 'warn' | 'error', label: string, message: string) {
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+/** Strip newlines/tabs to prevent log injection */
+function sanitize(input: string): string {
+  return input.replace(/[\r\n\t]/g, '');
+}
+
+export async function logEvent(level: LogLevel, label: string, message: string) {
+  const safeMessage = sanitize(message);
+  if (level === 'debug') {
+    console.log(`[${label}] ${safeMessage}`);
+    // Only persist debug logs when explicitly enabled (for support bundles)
+    if (process.env.DEBUG_LOGS !== 'true') return;
+  }
   try {
-    await prisma.appLog.create({ data: { level, label, message } });
+    await prisma.appLog.create({ data: { level, label: sanitize(label), message: safeMessage } });
   } catch {
     // Silently fail if table doesn't exist yet
   }

--- a/packages/frontend/src/components/NotificationBell.tsx
+++ b/packages/frontend/src/components/NotificationBell.tsx
@@ -110,9 +110,15 @@ export default function NotificationBell() {
                   {/* Content */}
                   <div className="flex-1 min-w-0">
                     <p className={clsx('text-sm truncate', notif.read ? 'text-ndp-text-muted' : 'text-ndp-text font-medium')}>
-                      {notif.title}
+                      {notif.title?.startsWith('notifications.msg.')
+                        ? t(notif.title, (notif.metadata?.msgParams as Record<string, unknown>) || {})
+                        : notif.title}
                     </p>
-                    <p className="text-xs text-ndp-text-dim mt-0.5 line-clamp-2">{notif.message}</p>
+                    <p className="text-xs text-ndp-text-dim mt-0.5 line-clamp-2">
+                      {notif.message?.startsWith('notifications.msg.')
+                        ? t(notif.message, (notif.metadata?.msgParams as Record<string, unknown>) || {})
+                        : notif.message}
+                    </p>
                     <p className="text-[10px] text-ndp-text-dim mt-1">{timeAgo(notif.createdAt, t)}</p>
                   </div>
 

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -593,5 +593,10 @@
   "notifications.request_approved": "Request approved",
   "notifications.request_declined": "Request declined",
   "notifications.media_available": "Media available",
-  "notifications.support_reply": "Support reply"
+  "notifications.support_reply": "Support reply",
+  "notifications.msg.request_auto_approved": "Your request for \"{{title}}\" has been auto-approved.",
+  "notifications.msg.request_approved": "Your request for \"{{title}}\" has been approved.",
+  "notifications.msg.request_declined": "Your request for \"{{title}}\" has been declined.",
+  "notifications.msg.media_available": "\"{{title}}\" is now available.",
+  "notifications.msg.support_reply": "Reply on your ticket #{{ticketId}}"
 }

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -593,5 +593,10 @@
   "notifications.request_approved": "Demande approuvée",
   "notifications.request_declined": "Demande refusée",
   "notifications.media_available": "Média disponible",
-  "notifications.support_reply": "Réponse support"
+  "notifications.support_reply": "Réponse support",
+  "notifications.msg.request_auto_approved": "Votre demande pour \"{{title}}\" a été approuvée automatiquement.",
+  "notifications.msg.request_approved": "Votre demande pour \"{{title}}\" a été approuvée.",
+  "notifications.msg.request_declined": "Votre demande pour \"{{title}}\" a été refusée.",
+  "notifications.msg.media_available": "\"{{title}}\" est maintenant disponible.",
+  "notifications.msg.support_reply": "Réponse sur votre ticket #{{ticketId}}"
 }


### PR DESCRIPTION
## Summary

Closes #98

### French → English (165 replacements across 30 files)
- All `logEvent()` messages
- All `reply.send({ error: })` responses
- All `safeUserNotify` user-facing messages
- All `console.log/warn/error` technical messages

### Debug logging system
- New `debug` level in `logEvent` — prints to stdout by default
- Set `DEBUG_LOGS=true` env var to persist debug entries in DB (for support bundles)
- 37 `console.*` calls converted to `logEvent('debug', ...)`  
- API `/admin/logs` supports `?level=debug` filter
- Kept `console` for startup/plugin lifecycle (DB not ready at boot)

### Cleanup
- Removed duplicate debug+info/error pairs in scheduler and mediaSync
- Unified labels (`Job` instead of mixed `Scheduler`/`Job`)

## Test plan

- [ ] Admin > Logs shows all entries in English
- [ ] No French text in log entries or API error responses
- [ ] Debug logs appear in server stdout
- [ ] With `DEBUG_LOGS=true`, debug entries persist in DB and appear in Admin > Logs with debug filter
- [ ] Without `DEBUG_LOGS`, debug entries only in stdout, not DB