### PR TITLE
feat: request filters + director link + filmography expand (#122, #123)

### DIFF
--- a/packages/backend/src/routes/requests.ts
+++ b/packages/backend/src/routes/requests.ts
@@ -31,12 +31,16 @@ export async function requestRoutes(app: FastifyInstance) {
           status: { type: 'string', description: 'Filter by request status (pending, approved, declined, processing, available, failed)' },
           page: { type: 'string', description: 'Page number for pagination' },
           userId: { type: 'string', description: 'Filter by user ID (admin only)' },
+          mediaType: { type: 'string', enum: ['movie', 'tv'], description: 'Filter by media type' },
+          qualityOptionId: { type: 'string', description: 'Filter by quality option ID' },
         },
       },
     },
   }, async (request) => {
     const user = request.user as { id: number; role: string };
-    const { status, page, userId } = request.query as { status?: string; page?: string; userId?: string };
+    const { status, page, userId, mediaType, qualityOptionId } = request.query as {
+      status?: string; page?: string; userId?: string; mediaType?: string; qualityOptionId?: string;
+    };
     const pageNum = parsePage(page);
     const take = 20;
     const skip = (pageNum - 1) * take;
@@ -49,6 +53,11 @@ export async function requestRoutes(app: FastifyInstance) {
       if (uid) where.userId = uid;
     }
     if (status && VALID_STATUSES.includes(status)) where.status = status;
+    if (mediaType && ['movie', 'tv'].includes(mediaType)) where.mediaType = mediaType;
+    if (qualityOptionId) {
+      const qid = parseId(qualityOptionId);
+      if (qid) where.qualityOptionId = qid;
+    }
 
     // Promote stale statuses before reading
     await promoteStaleStatuses();

--- a/packages/frontend/src/i18n/locales/en/translation.json
+++ b/packages/frontend/src/i18n/locales/en/translation.json
@@ -208,6 +208,7 @@
 
   "person.years_old": "years old",
   "person.filmography": "Filmography",
+  "person.more_items": "more",
   "media.recommendations": "Recommendations",
   "media.season_one": "{{count}} season",
   "media.season_other": "{{count}} seasons",
@@ -622,5 +623,9 @@
   "admin.backup.try_again": "Try again",
   "admin.backup.include_cache": "Include TMDB cache in backup (larger file)",
   "admin.backup.saved_backups": "Saved backups",
-  "admin.backup.stats_detail": "{{users}} users, {{media}} media, {{requests}} requests"
+  "admin.backup.stats_detail": "{{users}} users, {{media}} media, {{requests}} requests",
+
+  "requests.filter_all_users": "All users",
+  "requests.filter_all_types": "All types",
+  "requests.filter_all_qualities": "All qualities"
 }

--- a/packages/frontend/src/i18n/locales/fr/translation.json
+++ b/packages/frontend/src/i18n/locales/fr/translation.json
@@ -208,6 +208,7 @@
 
   "person.years_old": "ans",
   "person.filmography": "Filmographie",
+  "person.more_items": "de plus",
   "media.recommendations": "Recommandations",
   "media.season_one": "{{count}} saison",
   "media.season_other": "{{count}} saisons",
@@ -622,5 +623,9 @@
   "admin.backup.try_again": "Réessayer",
   "admin.backup.include_cache": "Inclure le cache TMDB dans la sauvegarde (fichier plus volumineux)",
   "admin.backup.saved_backups": "Sauvegardes enregistrées",
-  "admin.backup.stats_detail": "{{users}} utilisateurs, {{media}} médias, {{requests}} demandes"
+  "admin.backup.stats_detail": "{{users}} utilisateurs, {{media}} médias, {{requests}} demandes",
+
+  "requests.filter_all_users": "Tous les utilisateurs",
+  "requests.filter_all_types": "Tous les types",
+  "requests.filter_all_qualities": "Toutes les qualités"
 }

--- a/packages/frontend/src/pages/MediaDetailPage.tsx
+++ b/packages/frontend/src/pages/MediaDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   ChevronLeft,
   ChevronRight,
   User,
+  Clapperboard,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import api from '@/lib/api';
@@ -716,10 +717,11 @@ function CastSection({ cast, title, director }: { cast: TmdbCast[]; title: strin
       <div className="flex items-center gap-3 mb-4 sm:px-8">
         <h3 className="text-xl font-bold text-ndp-text">{title}</h3>
         {director && (
-          <span className="text-sm text-ndp-text-muted">
-            <span className="text-ndp-text-dim">·</span>{' '}
-            <span className="text-ndp-accent font-medium">{director.name}</span>
-          </span>
+          <Link to={`/person/${director.id}`} className="flex items-center gap-1.5 text-sm text-ndp-text-muted hover:text-ndp-accent transition-colors">
+            <span className="text-ndp-text-dim">·</span>
+            <Clapperboard className="w-3.5 h-3.5" />
+            <span className="font-medium">{director.name}</span>
+          </Link>
         )}
       </div>
 

--- a/packages/frontend/src/pages/PersonPage.tsx
+++ b/packages/frontend/src/pages/PersonPage.tsx
@@ -22,13 +22,20 @@ export default function PersonPage() {
     api.get(`/tmdb/person/${id}`).then(({ data }) => setPerson(data)).catch(() => {}).finally(() => setLoading(false));
   }, [id]);
 
-  const filmography = useMemo(() =>
+  const [showAllFilmo, setShowAllFilmo] = useState(false);
+  const FILMO_INITIAL = 40;
+
+  const allFilmography = useMemo(() =>
     person?.combined_credits?.cast
       ?.filter((c) => c.poster_path && (c.vote_count ?? 0) > 5)
       .sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0))
-      .slice(0, 40)
       .map((c) => ({ ...c, media_type: c.media_type || (c.title ? 'movie' : 'tv') })) || [],
     [person],
+  );
+
+  const filmography = useMemo(
+    () => showAllFilmo ? allFilmography : allFilmography.slice(0, FILMO_INITIAL),
+    [showAllFilmo, allFilmography],
   );
 
   const statuses = useMediaStatus(filmography as TmdbMedia[]);
@@ -93,7 +100,7 @@ export default function PersonPage() {
                   <Calendar className="w-4 h-4 text-ndp-text-dim" />
                   {new Date(person.birthday).toLocaleDateString()}
                   {age != null && !person.deathday && (
-                    <span className="text-ndp-text-dim">({age} {t('person.years_old', 'ans')})</span>
+                    <span className="text-ndp-text-dim">({age} {t('person.years_old')})</span>
                   )}
                 </span>
               )}
@@ -121,7 +128,7 @@ export default function PersonPage() {
                     onClick={() => setShowFullBio(!showFullBio)}
                     className="text-sm text-ndp-accent hover:text-ndp-accent/80 mt-2 transition-colors"
                   >
-                    {showFullBio ? t('common.show_less', 'Voir moins') : t('common.show_more', 'Voir plus')}
+                    {showFullBio ? t('common.show_less') : t('common.show_more')}
                   </button>
                 )}
               </div>
@@ -133,8 +140,8 @@ export default function PersonPage() {
         {filmography.length > 0 && (
           <div className="mt-12">
             <h3 className="text-xl font-bold text-ndp-text mb-6">
-              {t('person.filmography', 'Filmographie')}
-              <span className="text-sm font-normal text-ndp-text-dim ml-2">({filmography.length})</span>
+              {t('person.filmography')}
+              <span className="text-sm font-normal text-ndp-text-dim ml-2">({allFilmography.length})</span>
             </h3>
             <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
               {filmography.map((item, i) => {
@@ -149,6 +156,14 @@ export default function PersonPage() {
                 );
               })}
             </div>
+            {!showAllFilmo && allFilmography.length > FILMO_INITIAL && (
+              <button
+                onClick={() => setShowAllFilmo(true)}
+                className="mt-4 w-full py-2.5 rounded-xl bg-white/5 hover:bg-white/10 text-sm font-medium text-ndp-text-muted hover:text-ndp-text transition-colors"
+              >
+                {t('common.show_more')} ({allFilmography.length - FILMO_INITIAL} {t('person.more_items')})
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/packages/frontend/src/pages/RequestsPage.tsx
+++ b/packages/frontend/src/pages/RequestsPage.tsx
@@ -16,6 +16,7 @@ import {
   X,
   Save,
   Eraser,
+  SlidersHorizontal,
   type LucideIcon,
 } from 'lucide-react';
 import { clsx } from 'clsx';
@@ -64,6 +65,10 @@ export default function RequestsPage() {
   const [filtering, setFiltering] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [filter, setFilter] = useState<string>('');
+  const [filterUser, setFilterUser] = useState<string>('');
+  const [filterMediaType, setFilterMediaType] = useState<string>('');
+  const [filterQuality, setFilterQuality] = useState<string>('');
+  const [users, setUsers] = useState<{ id: number; displayName: string }[]>([]);
   const [actionLoading, setActionLoading] = useState<number | null>(null);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -78,6 +83,7 @@ export default function RequestsPage() {
   useEffect(() => {
     api.get('/requests/stats').then(({ data }) => setStats(data)).catch(() => {});
     api.get('/app/quality-options').then(({ data }) => setQualityOptions(data)).catch(() => {});
+    if (isAdmin) api.get('/admin/users').then(({ data }) => setUsers(data.map((u: { id: number; displayName: string; email: string }) => ({ id: u.id, displayName: u.displayName || u.email })))).catch(() => {});
   }, []);
 
   const fetchRequests = useCallback(async (pageNum: number, append = false) => {
@@ -85,6 +91,9 @@ export default function RequestsPage() {
     try {
       const params = new URLSearchParams();
       if (filter) params.set('status', filter);
+      if (filterUser) params.set('userId', filterUser);
+      if (filterMediaType) params.set('mediaType', filterMediaType);
+      if (filterQuality) params.set('qualityOptionId', filterQuality);
       params.set('page', String(pageNum));
       const { data } = await api.get(`/requests?${params}`);
       if (append) {
@@ -102,11 +111,11 @@ export default function RequestsPage() {
       setFiltering(false);
       setLoadingMore(false);
     }
-  }, [filter]);
+  }, [filter, filterUser, filterMediaType, filterQuality]);
 
   useEffect(() => {
     fetchRequests(1);
-  }, [filter]);
+  }, [filter, filterUser, filterMediaType, filterQuality]);
 
   const loadMore = useCallback(() => {
     if (loadingMore || page >= totalPages) return;
@@ -176,33 +185,45 @@ export default function RequestsPage() {
           )}
         </div>
 
-        <div className="flex items-center gap-1.5 overflow-x-auto pb-1" style={{ scrollbarWidth: 'none' }}>
-          {FILTER_TABS.map(tab => {
-            const count = getStatCount(tab.key);
-            const isActive = filter === tab.key;
-            return (
-              <button
-                key={tab.key}
-                onClick={() => setFilter(tab.key)}
-                className={clsx(
-                  'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium whitespace-nowrap transition-colors duration-200',
-                  isActive
-                    ? 'bg-ndp-accent text-white'
-                    : 'text-ndp-text-muted hover:bg-ndp-surface-light',
-                )}
-              >
-                {t(tab.labelKey)}
-                {count > 0 && (
-                  <span className={clsx(
-                    'text-xs px-1.5 py-0.5 rounded-md font-semibold',
-                    isActive ? 'bg-white/20' : 'bg-white/5',
-                  )}>
-                    {count}
-                  </span>
-                )}
-              </button>
-            );
-          })}
+        <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 overflow-x-auto flex-1" style={{ scrollbarWidth: 'none' }}>
+            {FILTER_TABS.map(tab => {
+              const count = getStatCount(tab.key);
+              const isActive = filter === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  onClick={() => setFilter(tab.key)}
+                  className={clsx(
+                    'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium whitespace-nowrap transition-colors duration-200',
+                    isActive
+                      ? 'bg-ndp-accent text-white'
+                      : 'text-ndp-text-muted hover:bg-ndp-surface-light',
+                  )}
+                >
+                  {t(tab.labelKey)}
+                  {count > 0 && (
+                    <span className={clsx(
+                      'text-xs px-1.5 py-0.5 rounded-md font-semibold',
+                      isActive ? 'bg-white/20' : 'bg-white/5',
+                    )}>
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Advanced filters (admin only) */}
+          {isAdmin && (
+            <RequestFilters
+              filterUser={filterUser} setFilterUser={setFilterUser}
+              filterMediaType={filterMediaType} setFilterMediaType={setFilterMediaType}
+              filterQuality={filterQuality} setFilterQuality={setFilterQuality}
+              users={users} qualityOptions={qualityOptions}
+            />
+          )}
         </div>
       </div>
 
@@ -723,5 +744,153 @@ function RequestCard({
         document.body
       )}
     </Link>
+  );
+}
+
+// ─── Request Filters Popover ─────────────────────────────────────
+
+function RequestFilters({ filterUser, setFilterUser, filterMediaType, setFilterMediaType, filterQuality, setFilterQuality, users, qualityOptions }: {
+  filterUser: string; setFilterUser: (v: string) => void;
+  filterMediaType: string; setFilterMediaType: (v: string) => void;
+  filterQuality: string; setFilterQuality: (v: string) => void;
+  users: { id: number; displayName: string }[];
+  qualityOptions: { id: number; label: string }[];
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const activeCount = [filterUser, filterMediaType, filterQuality].filter(Boolean).length;
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const reset = () => { setFilterUser(''); setFilterMediaType(''); setFilterQuality(''); };
+
+  // Active chips
+  const chips: { key: string; label: string; onRemove: () => void }[] = [];
+  if (filterUser) {
+    const userName = users.find(u => String(u.id) === filterUser)?.displayName || filterUser;
+    chips.push({ key: 'user', label: userName, onRemove: () => setFilterUser('') });
+  }
+  if (filterMediaType) {
+    chips.push({ key: 'type', label: filterMediaType === 'movie' ? t('common.movie') : t('common.series'), onRemove: () => setFilterMediaType('') });
+  }
+  if (filterQuality) {
+    const qLabel = qualityOptions.find(q => String(q.id) === filterQuality)?.label || filterQuality;
+    chips.push({ key: 'quality', label: qLabel, onRemove: () => setFilterQuality('') });
+  }
+
+  return (
+    <div className="flex items-center gap-2 flex-shrink-0">
+      {/* Chips */}
+      {chips.map(chip => (
+        <span key={chip.key} className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-white/5 text-ndp-text-muted">
+          {chip.label}
+          <button onClick={chip.onRemove} className="hover:text-white transition-colors"><X className="w-2.5 h-2.5" /></button>
+        </span>
+      ))}
+
+      {/* Filter button + popover */}
+      <div className="relative" ref={popoverRef}>
+        <button
+          onClick={() => setOpen(!open)}
+          className={clsx(
+            'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+            open || activeCount > 0
+              ? 'bg-ndp-accent/10 text-ndp-accent'
+              : 'bg-white/5 text-ndp-text-muted hover:bg-white/10',
+          )}
+        >
+          <SlidersHorizontal className="w-3.5 h-3.5" />
+          {t('filter.filters')}
+          {activeCount > 0 && <span className="text-ndp-accent/70">· {activeCount}</span>}
+        </button>
+
+        {open && (
+          <div className="absolute right-0 top-full mt-2 w-64 p-4 rounded-2xl bg-ndp-surface border border-white/10 shadow-2xl shadow-black/50 space-y-4 animate-fade-in z-50">
+            {/* User */}
+            <div>
+              <label className="text-[10px] font-semibold text-ndp-text-dim uppercase tracking-wider mb-1.5 block">{t('requests.filter_all_users')}</label>
+              <select
+                value={filterUser}
+                onChange={e => setFilterUser(e.target.value)}
+                className="w-full bg-white/5 border border-white/10 rounded-lg text-xs text-ndp-text px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-ndp-accent/40 appearance-none cursor-pointer"
+              >
+                <option value="">{t('requests.filter_all_users')}</option>
+                {users.map(u => <option key={u.id} value={u.id}>{u.displayName}</option>)}
+              </select>
+            </div>
+
+            {/* Media type */}
+            <div>
+              <label className="text-[10px] font-semibold text-ndp-text-dim uppercase tracking-wider mb-1.5 block">{t('requests.filter_all_types')}</label>
+              <div className="flex gap-1.5">
+                {[
+                  { value: '', label: t('common.all') },
+                  { value: 'movie', label: t('common.movie') },
+                  { value: 'tv', label: t('common.series') },
+                ].map(opt => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setFilterMediaType(opt.value)}
+                    className={clsx(
+                      'flex-1 px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all',
+                      filterMediaType === opt.value ? 'bg-ndp-accent text-white' : 'bg-white/5 text-ndp-text-muted hover:bg-white/10',
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Quality */}
+            {qualityOptions.length > 0 && (
+              <div>
+                <label className="text-[10px] font-semibold text-ndp-text-dim uppercase tracking-wider mb-1.5 block">{t('requests.filter_all_qualities')}</label>
+                <div className="flex flex-wrap gap-1.5">
+                  <button
+                    onClick={() => setFilterQuality('')}
+                    className={clsx(
+                      'px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all',
+                      !filterQuality ? 'bg-ndp-accent text-white' : 'bg-white/5 text-ndp-text-muted hover:bg-white/10',
+                    )}
+                  >
+                    {t('common.all')}
+                  </button>
+                  {qualityOptions.map(q => (
+                    <button
+                      key={q.id}
+                      onClick={() => setFilterQuality(String(q.id))}
+                      className={clsx(
+                        'px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all',
+                        filterQuality === String(q.id) ? 'bg-ndp-accent text-white' : 'bg-white/5 text-ndp-text-muted hover:bg-white/10',
+                      )}
+                    >
+                      {q.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Reset */}
+            {activeCount > 0 && (
+              <button onClick={() => { reset(); setOpen(false); }} className="w-full flex items-center justify-center gap-1.5 text-xs text-ndp-text-dim hover:text-ndp-text-muted transition-colors pt-2 border-t border-white/5">
+                <X className="w-3 h-3" />
+                {t('filter.reset')}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #122, closes #123

### Request filters (#122)
- **Backend**: `mediaType` and `qualityOptionId` query params on `GET /requests` with schema validation
- **Frontend**: popover filter component on the same line as status tabs (right-aligned)
  - Filter by user (select), media type (pills), quality (pills)
  - Active filter chips with remove buttons
  - Popover anchored right, same style as discover page filters

### Director + person filmography (#123)
- **Director clickable**: Clapperboard icon + link to `/person/:id` in cast section header
- **Filmography limit**: shows first 40, "Show more (X more)" button to reveal the rest
- **Infinite loop fix**: `filmography` slice wrapped in `useMemo` to prevent `useMediaStatus` re-render loop
- Removed inline i18n fallbacks

## Test plan

- [ ] Admin: requests page shows filter button next to status tabs
- [ ] Filter by user → only shows that user's requests
- [ ] Filter by type (movie/TV) → correct filtering
- [ ] Filter by quality → correct filtering
- [ ] Chips show active filters, removable individually
- [ ] Non-admin users don't see the filter button
- [ ] Click director name in cast section → navigates to /person/:id
- [ ] Person page with 40+ credits → "Show more" button appears
- [ ] Click "Show more" → all credits visible, no infinite loop