### PR TITLE
feat: plugin system v2 — full rewrite + security hardening

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 # Plugin Development Guide
 
-Oscarr supports plugins for extending functionality without modifying the core. Plugins can add backend routes, scheduled jobs, admin UI tabs, navigation items, full pages, and feature flags.
+Oscarr supports plugins for extending functionality without modifying the core. Plugins can add backend routes, scheduled jobs, admin UI tabs, navigation items, full pages, feature flags, guards, custom permissions, and event-driven workflows.
 
 ## Getting started
 
@@ -17,6 +17,15 @@ packages/plugins/
     frontend/              # Optional
       index.tsx             # Frontend page component
 ```
+
+### Plugin discovery
+
+On startup, Oscarr scans `packages/plugins/` for directories with a `manifest.json`. You can override the scan directory with the `OSCARR_PLUGINS_DIR` environment variable.
+
+- Follows symlinks (useful for dev workflows: `ln -s /path/to/plugin packages/plugins/name`)
+- Skips hidden directories (starting with `.`)
+- Validates manifests thoroughly: required fields, hooks shape, settings shape
+- Validates `apiVersion` against supported versions (currently only `"v1"`)
 
 ### manifest.json
 
@@ -50,7 +59,7 @@ packages/plugins/
     }
   ],
   "hooks": {
-    "routes": true,
+    "routes": { "prefix": "/api/plugins/my-plugin" },
     "jobs": [
       {
         "key": "my_job",
@@ -83,6 +92,8 @@ packages/plugins/
   }
 }
 ```
+
+> **Note:** `hooks.routes` is now an object `{ "prefix": "/api/plugins/my-plugin" }`, not just `true`. This gives plugins explicit control over their route prefix.
 
 ### Entry point
 
@@ -125,6 +136,16 @@ export function register(ctx: PluginContext): PluginRegistration {
       ctx.log.info('Plugin installed for the first time');
       await ctx.setSetting('installDate', new Date().toISOString());
     },
+
+    // Optional: run when plugin is enabled
+    async onEnable(ctx) {
+      ctx.log.info('Plugin enabled');
+    },
+
+    // Optional: run when plugin is disabled
+    async onDisable(ctx) {
+      ctx.log.info('Plugin disabled — cleaning up');
+    },
   };
 }
 ```
@@ -138,10 +159,16 @@ The context object provides access to Oscarr's core functionality:
 | `ctx.log` | Fastify logger instance (child logger with plugin context) |
 | `ctx.getUser(userId)` | Get a user by ID. Returns `{ id, email, displayName, role }` or `null` |
 | `ctx.getAppSettings()` | Get all app settings as `Record<string, unknown>` |
-| `ctx.getSetting(key)` | Get a plugin-specific setting value |
-| `ctx.setSetting(key, value)` | Set a plugin-specific setting value |
+| `ctx.getSetting(key)` | Get a plugin-specific setting value (cached in memory) |
+| `ctx.setSetting(key, value)` | Set a plugin-specific setting value (persists to DB + updates cache) |
 | `ctx.sendNotification(type, data)` | Send a system notification (Discord, Telegram, Email) |
 | `ctx.sendUserNotification(userId, payload)` | Send an in-app notification to a specific user |
+| `ctx.notificationRegistry` | Access to the notification registry |
+| `ctx.getArrClient(serviceType)` | Get an existing Arr client (Sonarr, Radarr, etc.) |
+| `ctx.getServiceConfig(serviceType)` | Get service config `{ url, apiKey }` or `null` for direct API access |
+| `ctx.registerRoutePermission(routeKey, rule)` | Register an RBAC rule for a route |
+| `ctx.registerPluginPermission(permission, description?)` | Declare a custom permission |
+| `ctx.events` | Event bus — see [Events](#events) |
 
 ### sendNotification
 
@@ -168,9 +195,57 @@ await ctx.sendUserNotification(userId, {
 });
 ```
 
+### getServiceConfig
+
+Get the URL and API key for a connected service, useful for direct API calls:
+
+```typescript
+const radarr = await ctx.getServiceConfig('radarr');
+if (radarr) {
+  const res = await fetch(`${radarr.url}/api/v3/movie?apikey=${radarr.apiKey}`);
+  const movies = await res.json();
+}
+```
+
+### registerRoutePermission / registerPluginPermission
+
+Register RBAC rules directly from the plugin context (see [Permissions & RBAC](#permissions--rbac) for full details):
+
+```typescript
+export function register(ctx: PluginContext): PluginRegistration {
+  ctx.registerPluginPermission('myplugin.access', 'Access My Plugin features');
+  ctx.registerRoutePermission('GET:/api/plugins/my-plugin/data', { permission: 'myplugin.access' });
+
+  return {
+    manifest: require('./manifest.json'),
+    // ...
+  };
+}
+```
+
+## Events
+
+The context object provides an in-process event bus for decoupled communication between plugins and the core:
+
+```typescript
+// Subscribe to events
+ctx.events.on('media.requested', async (data) => {
+  ctx.log.info(`New request: ${data.title}`);
+  await ctx.sendNotification('custom_request', data);
+});
+
+// Unsubscribe
+ctx.events.off('media.requested', handler);
+
+// Emit custom events
+ctx.events.emit('myplugin.sync_complete', { count: 42 });
+```
+
+> **Note:** The event bus is in-process only. Events are not persisted and will not survive a server restart.
+
 ## Backend routes
 
-Routes registered by plugins are automatically prefixed with the plugin's route prefix (default: `/api/plugins/<pluginId>`).
+Routes registered by plugins are automatically prefixed with the route prefix defined in `hooks.routes.prefix` (e.g. `/api/plugins/my-plugin`).
 
 All plugin routes require authentication by default (handled by the RBAC middleware). You can register custom permissions for your routes — see [Permissions & RBAC](#permissions--rbac).
 
@@ -184,6 +259,10 @@ async registerRoutes(app, ctx) {
   });
 }
 ```
+
+### Error handling for routes
+
+If route registration fails (e.g. a syntax error or invalid schema), the plugin is automatically disabled and the error is persisted to the database. This prevents a broken plugin from taking down the server.
 
 ## Scheduled jobs
 
@@ -207,6 +286,12 @@ Jobs appear in the admin Jobs & Sync tab where admins can:
 - View last run status and duration
 - Manually trigger the job
 - Change the cron schedule
+
+### Job lifecycle
+
+- Jobs **stop automatically** when a plugin is disabled
+- Jobs **resume** when the plugin is re-enabled
+- A runtime guard prevents disabled-plugin jobs from executing even on race conditions
 
 ## UI contributions
 
@@ -267,6 +352,10 @@ export default function MediaActions({ context }: HookComponentProps) {
 }
 ```
 
+### Error boundary
+
+Plugin frontend components are wrapped in an error boundary. If a plugin component crashes, the rest of the app continues to work. The error boundary shows the plugin name, the error message, and a "Try again" button.
+
 ### Navigation item
 
 ```json
@@ -285,7 +374,7 @@ Icons use [Lucide React](https://lucide.dev/icons/) icon names.
 
 ### Admin tab
 
-Plugins with settings automatically get an admin tab. You can also add custom tabs:
+Plugins with settings automatically get an admin tab. Plugins with a `frontend` entry render their custom component in the admin tab instead of the default settings form. You can also add custom tabs:
 
 ```json
 {
@@ -297,6 +386,42 @@ Plugins with settings automatically get an admin tab. You can also add custom ta
 }
 ```
 
+## Frontend SDK (`@oscarr/sdk`)
+
+Plugins can import helpers from the SDK instead of reaching into the main app bundle:
+
+```javascript
+import { api, apiPost, apiPut, apiDelete, formatSize, formatDate, formatRelative, storageGet, storageSet } from '@oscarr/sdk';
+```
+
+### API helpers
+
+| Function | Description |
+|----------|-------------|
+| `api(path)` | GET request with auth, returns JSON |
+| `apiPost(path, body)` | POST with auth + JSON body |
+| `apiPut(path, body)` | PUT with auth + JSON body |
+| `apiDelete(path)` | DELETE with auth |
+
+### Formatting helpers
+
+| Function | Description |
+|----------|-------------|
+| `formatSize(bytes)` | Format bytes to human-readable string (e.g. `"1.5 GB"`) |
+| `formatDate(dateStr)` | Format date string to localized date |
+| `formatRelative(dateStr)` | Format date string to relative time (e.g. `"2h ago"`) |
+
+### Namespaced storage
+
+| Function | Description |
+|----------|-------------|
+| `storageGet(pluginId, key, fallback)` | Read from namespaced localStorage |
+| `storageSet(pluginId, key, value)` | Write to namespaced localStorage |
+
+### Shared React
+
+React is shared via import map. Plugins import `react`, `react-dom`, and `react/jsx-runtime` normally — the host provides them at runtime. No need to bundle React in your plugin.
+
 ## Frontend pages
 
 Plugins can provide a full-page React component at `/p/:pluginId`:
@@ -304,14 +429,13 @@ Plugins can provide a full-page React component at `/p/:pluginId`:
 ```tsx
 // packages/plugins/my-plugin/frontend/index.tsx
 import { useState, useEffect } from 'react';
+import { api } from '@oscarr/sdk';
 
 export default function MyPluginPage() {
   const [data, setData] = useState(null);
 
   useEffect(() => {
-    fetch('/api/plugins/my-plugin/stats')
-      .then(res => res.json())
-      .then(setData);
+    api('/api/plugins/my-plugin/stats').then(setData);
   }, []);
 
   return (
@@ -323,7 +447,7 @@ export default function MyPluginPage() {
 }
 ```
 
-The frontend component is lazy-loaded by Oscarr's router. It has access to all Tailwind CSS classes and Oscarr's design system (e.g. `text-ndp-text`, `card`, `btn-primary`).
+The frontend component is lazy-loaded via ESM by Oscarr's router. It has access to all Tailwind CSS classes and Oscarr's design system (e.g. `text-ndp-text`, `card`, `btn-primary`).
 
 ## Settings
 
@@ -379,9 +503,11 @@ const apiUrl = await ctx.getSetting('apiUrl') as string;
 await ctx.setSetting('lastRun', new Date().toISOString());
 ```
 
+Settings are validated on save: required fields are checked and types are enforced (string, number, boolean, password). Settings are cached in memory and the cache is invalidated on update or plugin toggle.
+
 Settings are stored as a JSON blob in the `PluginState` table and managed via:
 - `GET /api/plugins/:id/settings` — get schema + current values
-- `PUT /api/plugins/:id/settings` — update values
+- `PUT /api/plugins/:id/settings` — update values (validated)
 
 ## Feature flags
 
@@ -409,19 +535,21 @@ if (features.myPluginEnabled) {
 
 ## Plugin lifecycle
 
-1. **Discovery**: On startup, Oscarr scans `packages/plugins/` for directories with a `manifest.json`
+1. **Discovery**: On startup, Oscarr scans the plugins directory for directories with a `manifest.json`
 2. **Validation**: Manifest must have `id`, `name`, `version`, `entry`, and `apiVersion: "v1"`
 3. **Loading**: Entry module is dynamically imported, `register(ctx)` is called
-4. **Install**: On first load, `onInstall(ctx)` is called (if defined)
-5. **Route registration**: Plugin routes are registered with Fastify
-6. **Job registration**: Plugin jobs are registered with the scheduler
-7. **Runtime**: Plugin is active — routes serve requests, jobs run on schedule
+4. **Install**: On first load, `onInstall(ctx)` is called if defined (tracked by DB flag `onInstallRan`, never re-fires)
+5. **Enable**: `onEnable(ctx)` is called if defined (best-effort, does not block the toggle)
+6. **Route registration**: Plugin routes are registered with Fastify
+7. **Job registration**: Plugin jobs are registered with the scheduler
+8. **Runtime**: Plugin is active — routes serve requests, jobs run on schedule
 
 ### Enable/disable
 
 Plugins can be enabled or disabled from the admin panel without restarting:
 - `PUT /api/plugins/:id/toggle` with `{ enabled: boolean }`
 - Disabled plugins' routes still exist but their jobs don't run
+- `onEnable(ctx)` is called when a plugin is enabled, `onDisable(ctx)` when disabled (both best-effort)
 
 ### Plugin state persistence
 
@@ -435,6 +563,16 @@ model PluginState {
   settings  String  @default("{}")  // JSON blob
 }
 ```
+
+## Plugin logs
+
+All plugin log output (`info`, `warn`, `error`) is captured to the `PluginLog` database table. Logs can be retrieved via the API:
+
+```
+GET /api/plugins/:id/logs?limit=100
+```
+
+The `limit` parameter accepts values up to 500 (default: 100).
 
 ## API reference
 
@@ -450,7 +588,7 @@ model PluginState {
 | `entry` | string | Yes | Path to compiled entry point |
 | `frontend` | string | No | Path to frontend component |
 | `settings` | PluginSettingDef[] | No | Settings schema |
-| `hooks.routes` | boolean | No | Whether plugin registers routes |
+| `hooks.routes` | `{ prefix: string }` | No | Route prefix object |
 | `hooks.jobs` | PluginJobDef[] | No | Scheduled job definitions |
 | `hooks.ui` | UIContribution[] | No | UI hook contributions |
 | `hooks.features` | Record<string, boolean> | No | Feature flags |
@@ -463,7 +601,10 @@ model PluginState {
 | `registerRoutes(app, ctx)` | No | Register Fastify routes |
 | `registerJobs(ctx)` | No | Return job handlers |
 | `registerGuards(ctx)` | No | Return guard handlers (see [Guards](#guards)) |
-| `onInstall(ctx)` | No | Run once on first install |
+| `registerNotificationProviders(registry)` | No | Register notification providers |
+| `onInstall(ctx)` | No | Run once on first install (tracked by DB flag, never re-fires) |
+| `onEnable(ctx)` | No | Run when plugin is enabled (best-effort) |
+| `onDisable(ctx)` | No | Run when plugin is disabled (best-effort) |
 
 ## Guards
 
@@ -508,19 +649,17 @@ Oscarr uses a centralized RBAC (Role-Based Access Control) middleware. Roles and
 
 ### Registering custom permissions
 
-Declare new permissions so admins can assign them to roles:
+Declare new permissions so admins can assign them to roles. Use the context methods provided to your `register` function:
 
 ```typescript
-import { registerPluginPermission, registerRoutePermission } from '../../../backend/src/middleware/rbac.js';
-
 export function register(ctx: PluginContext): PluginRegistration {
   // 1. Declare the permission (appears in admin role editor)
-  registerPluginPermission('myplugin.access', 'Access My Plugin features');
-  registerPluginPermission('myplugin.admin', 'Manage My Plugin settings');
+  ctx.registerPluginPermission('myplugin.access', 'Access My Plugin features');
+  ctx.registerPluginPermission('myplugin.admin', 'Manage My Plugin settings');
 
   // 2. Protect your routes with these permissions
-  registerRoutePermission('GET:/api/plugins/my-plugin/data', { permission: 'myplugin.access' });
-  registerRoutePermission('PUT:/api/plugins/my-plugin/config', { permission: 'myplugin.admin' });
+  ctx.registerRoutePermission('GET:/api/plugins/my-plugin/data', { permission: 'myplugin.access' });
+  ctx.registerRoutePermission('PUT:/api/plugins/my-plugin/config', { permission: 'myplugin.admin' });
 
   return {
     manifest: require('./manifest.json'),
@@ -529,10 +668,12 @@ export function register(ctx: PluginContext): PluginRegistration {
 }
 ```
 
+> **Deprecated:** The old pattern of importing `registerPluginPermission` and `registerRoutePermission` directly from `rbac.js` still works but is deprecated. Use `ctx.registerRoutePermission()` and `ctx.registerPluginPermission()` instead.
+
 ### How it works
 
-1. **Plugin registers permissions** via `registerPluginPermission(key, description)` — these appear in the admin Roles tab with a "plugin" badge
-2. **Plugin protects routes** via `registerRoutePermission(routeKey, rule)` — the RBAC middleware enforces the permission
+1. **Plugin registers permissions** via `ctx.registerPluginPermission(key, description)` — these appear in the admin Roles tab with a "plugin" badge
+2. **Plugin protects routes** via `ctx.registerRoutePermission(routeKey, rule)` — the RBAC middleware enforces the permission
 3. **Admin assigns permissions** to roles from the admin panel — users with matching roles get access
 
 ### Route rule format
@@ -541,12 +682,12 @@ The `registerRoutePermission` key is `METHOD:/full/path` matching Fastify's para
 
 ```typescript
 // Exact route
-registerRoutePermission('GET:/api/plugins/my-plugin/stats', {
+ctx.registerRoutePermission('GET:/api/plugins/my-plugin/stats', {
   permission: 'myplugin.access',
 });
 
 // Owner-scoped route (non-admin users only see their own data)
-registerRoutePermission('GET:/api/plugins/my-plugin/history', {
+ctx.registerRoutePermission('GET:/api/plugins/my-plugin/history', {
   permission: 'myplugin.access',
   ownerScoped: true,
 });
@@ -589,9 +730,19 @@ app.get('/history', async (request) => {
 
 Admins can create custom roles (e.g. "moderator") with any combination of permissions from the Roles tab.
 
+## Admin UI
+
+The admin panel provides several tools for managing plugins:
+
+- **Installed tab**: Toggle plugins on/off, view version info, detect available updates
+- **Discover tab**: Browse community plugins from the GitHub registry
+- **Reload plugins button**: Triggers a graceful server restart to discover newly added or removed plugins
+- **Plugin with frontend**: Renders the plugin's custom component in the admin tab instead of the default settings form
+
 ## Current limitations
 
 - Plugins cannot modify the database schema (no Prisma migrations)
-- Plugin frontend components are lazy-loaded and cannot import from the main app bundle
-- No plugin dependency system
-- No hot-reload — server restart required after adding/removing plugins
+- Plugin frontend components are lazy-loaded via ESM and cannot import from the main app bundle (use `@oscarr/sdk` instead)
+- No plugin dependency system (no way to declare that plugin A requires plugin B)
+- Adding/removing plugins requires a server restart (use "Reload plugins" button in admin)
+- The event bus is in-process only (no persistence, no cross-restart delivery)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -557,10 +557,13 @@ Plugin state (enabled flag + settings) is stored in the `PluginState` table:
 
 ```prisma
 model PluginState {
-  id        Int     @id @default(autoincrement())
-  pluginId  String  @unique
-  enabled   Boolean @default(true)
-  settings  String  @default("{}")  // JSON blob
+  id            Int       @id @default(autoincrement())
+  pluginId      String    @unique
+  enabled       Boolean   @default(true)
+  settings      String    @default("{}")  // JSON blob for plugin-specific settings
+  onInstallRan  Boolean   @default(false) // Tracks whether onInstall() has been executed
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
 }
 ```
 

--- a/packages/backend/prisma/migrations/20260413000000_add_on_install_ran/migration.sql
+++ b/packages/backend/prisma/migrations/20260413000000_add_on_install_ran/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PluginState" ADD COLUMN "onInstallRan" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/backend/prisma/migrations/20260413010000_add_plugin_log/migration.sql
+++ b/packages/backend/prisma/migrations/20260413010000_add_plugin_log/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "PluginLog" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "pluginId" TEXT NOT NULL,
+    "level" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE INDEX "PluginLog_pluginId_createdAt_idx" ON "PluginLog"("pluginId", "createdAt");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -327,3 +327,13 @@ model Patchnote {
   titleFr String
   entries String   // JSON: [{ type: "feat"|"fix"|"perf", titleEn, titleFr, descEn?, descFr? }]
 }
+
+model PluginLog {
+  id        Int      @id @default(autoincrement())
+  pluginId  String
+  level     String   // "info" | "warn" | "error" | "debug"
+  message   String
+  createdAt DateTime @default(now())
+
+  @@index([pluginId, createdAt])
+}

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -288,6 +288,7 @@ model PluginState {
   pluginId      String    @unique
   enabled       Boolean   @default(true)
   settings      String    @default("{}") // JSON blob for plugin-specific settings
+  onInstallRan  Boolean   @default(false)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }

--- a/packages/backend/src/middleware/rbac.ts
+++ b/packages/backend/src/middleware/rbac.ts
@@ -117,6 +117,7 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
   'GET:/api/plugins/ui/:hookPoint':      { permission: AUTH },
   'GET:/api/plugins/:id/frontend/*':     { permission: AUTH },
   'GET:/api/plugins/features':           { permission: PUBLIC },
+  'GET:/api/plugins/registry':           { permission: AUTH },  // Plugin discovery — any authenticated user
 
   // ── Admin RBAC routes ──
   'GET:/api/admin/roles':                { permission: 'admin.roles' },
@@ -129,7 +130,10 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
 // ── Prefix-based fallback (first match wins — order matters) ────────────────
 const PREFIX_DEFAULTS: [string, RouteRule][] = [
   ['/api/admin',    { permission: 'admin.*' }],
-  ['/api/plugins',  { permission: AUTH }],    // Plugin custom routes — any authenticated user
+  // Plugin custom routes fall through here (registered dynamically by plugins at /api/plugins/:pluginId/*).
+  // Any authenticated user can access. Plugins that need admin-only routes should use
+  // ctx.registerRoutePermission() to override specific routes.
+  ['/api/plugins',  { permission: AUTH }],
   ['/api/setup',    { permission: PUBLIC }],  // setup has its own secret-based guards
   ['/api/auth',     { permission: PUBLIC }],  // OAuth callback routes registered dynamically
   ['/api/webhooks', { permission: PUBLIC }],  // Auth via API key in handler

--- a/packages/backend/src/middleware/rbac.ts
+++ b/packages/backend/src/middleware/rbac.ts
@@ -115,6 +115,7 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
   'GET:/api/plugins/:id/settings':       { permission: 'admin.plugins' },
   'PUT:/api/plugins/:id/settings':       { permission: 'admin.plugins' },
   'GET:/api/plugins/ui/:hookPoint':      { permission: AUTH },
+  'GET:/api/plugins/:id/logs':           { permission: 'admin.plugins' },
   'GET:/api/plugins/:id/frontend/*':     { permission: AUTH },
   'GET:/api/plugins/features':           { permission: PUBLIC },
   'GET:/api/plugins/registry':           { permission: AUTH },  // Plugin discovery — any authenticated user
@@ -125,6 +126,7 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
   'PUT:/api/admin/roles/:id':            { permission: 'admin.roles' },
   'DELETE:/api/admin/roles/:id':         { permission: 'admin.roles' },
   'GET:/api/admin/permissions':          { permission: 'admin.roles' },
+  'POST:/api/admin/restart':             { permission: 'admin.*' },
 };
 
 // ── Prefix-based fallback (first match wins — order matters) ────────────────

--- a/packages/backend/src/middleware/rbac.ts
+++ b/packages/backend/src/middleware/rbac.ts
@@ -128,9 +128,10 @@ const ROUTE_PERMISSIONS: Record<string, RouteRule> = {
 
 // ── Prefix-based fallback (first match wins — order matters) ────────────────
 const PREFIX_DEFAULTS: [string, RouteRule][] = [
-  ['/api/admin',  { permission: 'admin.*' }],
-  ['/api/setup',  { permission: PUBLIC }],    // setup has its own secret-based guards
-  ['/api/auth',   { permission: PUBLIC }],    // OAuth callback routes registered dynamically
+  ['/api/admin',    { permission: 'admin.*' }],
+  ['/api/plugins',  { permission: AUTH }],    // Plugin custom routes — any authenticated user
+  ['/api/setup',    { permission: PUBLIC }],  // setup has its own secret-based guards
+  ['/api/auth',     { permission: PUBLIC }],  // OAuth callback routes registered dynamically
   ['/api/webhooks', { permission: PUBLIC }],  // Auth via API key in handler
 ];
 

--- a/packages/backend/src/plugins/context/index.ts
+++ b/packages/backend/src/plugins/context/index.ts
@@ -1,0 +1,43 @@
+import type { PluginContext, PluginManifest } from '../types.js';
+import { createContextV1, type V1FactoryDeps } from './v1.js';
+
+// ─── Public types ──────────────────────────────────────────────────
+
+/** Union of all dep interfaces accepted by context factories. */
+export type ContextFactoryDeps = V1FactoryDeps;
+
+/** Signature shared by every versioned factory function. */
+type ContextFactory = (manifest: PluginManifest, deps: ContextFactoryDeps) => PluginContext;
+
+// ─── Registry ──────────────────────────────────────────────────────
+
+const contextFactories = new Map<string, ContextFactory>([
+  ['v1', createContextV1],
+]);
+
+// ─── Public API ────────────────────────────────────────────────────
+
+/**
+ * Create a PluginContext for the given manifest, dispatching to the
+ * correct versioned factory based on `manifest.apiVersion`.
+ */
+export function createContext(manifest: PluginManifest, deps: ContextFactoryDeps): PluginContext {
+  const factory = contextFactories.get(manifest.apiVersion);
+  if (!factory) {
+    throw new Error(
+      `Unsupported plugin API version "${manifest.apiVersion}" ` +
+        `(plugin: "${manifest.id}"). Supported: ${getSupportedVersions().join(', ')}`,
+    );
+  }
+  return factory(manifest, deps);
+}
+
+/** List all API versions the engine can serve. */
+export function getSupportedVersions(): string[] {
+  return Array.from(contextFactories.keys());
+}
+
+/** Check whether a specific API version is supported. */
+export function isVersionSupported(version: string): boolean {
+  return contextFactories.has(version);
+}

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -1,4 +1,5 @@
 import type { FastifyBaseLogger } from 'fastify';
+import { pluginEventBus } from '../eventBus.js';
 import { prisma } from '../../utils/prisma.js';
 import { notificationRegistry } from '../../notifications/index.js';
 import type { NotificationPayload } from '../../notifications/types.js';
@@ -79,6 +80,11 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
     },
     registerPluginPermission(permission: string, description?: string) {
       rbacRegisterPermission(permission, description);
+    },
+    events: {
+      on: (event, handler) => pluginEventBus.on(event, handler),
+      off: (event, handler) => pluginEventBus.off(event, handler),
+      emit: (event, data) => pluginEventBus.emit(event, data),
     },
   };
 }

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -1,0 +1,84 @@
+import type { FastifyBaseLogger } from 'fastify';
+import { prisma } from '../../utils/prisma.js';
+import { notificationRegistry } from '../../notifications/index.js';
+import type { NotificationPayload } from '../../notifications/types.js';
+import { sendUserNotification } from '../../services/userNotifications.js';
+import { getArrClient } from '../../providers/index.js';
+import {
+  registerRoutePermission as rbacRegisterRoute,
+  registerPluginPermission as rbacRegisterPermission,
+} from '../../middleware/rbac.js';
+import type { PluginContext, PluginManifest } from '../types.js';
+
+/**
+ * Dependencies injected by the engine so the factory stays decoupled
+ * from PluginEngine internals.
+ */
+export interface V1FactoryDeps {
+  logger: FastifyBaseLogger | null;
+  getCachedSettings(pluginId: string): Promise<Record<string, unknown>>;
+  setSettingsCache(pluginId: string, values: Record<string, unknown>): void;
+  makeFallbackLogger(pluginId: string): FastifyBaseLogger;
+}
+
+/**
+ * Frozen V1 context factory.
+ * This is a faithful extraction of the former `PluginEngine.createContext`
+ * private method -- no behaviour changes.
+ */
+export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): PluginContext {
+  const pluginId = manifest.id;
+  const log =
+    deps.logger?.child({ plugin: pluginId }) || deps.makeFallbackLogger(pluginId);
+
+  return {
+    log,
+    async getUser(userId: number) {
+      return prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true, email: true, displayName: true, role: true },
+      });
+    },
+    async getAppSettings() {
+      const s = await prisma.appSettings.findUnique({ where: { id: 1 } });
+      return (s ?? {}) as Record<string, unknown>;
+    },
+    async getSetting(key: string) {
+      const settings = await deps.getCachedSettings(pluginId);
+      return settings[key];
+    },
+    async setSetting(key: string, value: unknown) {
+      const settings = await deps.getCachedSettings(pluginId);
+      settings[key] = value;
+      await prisma.pluginState.update({
+        where: { pluginId },
+        data: { settings: JSON.stringify(settings) },
+      });
+      deps.setSettingsCache(pluginId, settings);
+    },
+    async sendNotification(type: string, data: NotificationPayload) {
+      await notificationRegistry.send(type, data);
+    },
+    async sendUserNotification(userId: number, payload) {
+      await sendUserNotification(userId, payload);
+    },
+    notificationRegistry,
+    getArrClient: (serviceType: string) => getArrClient(serviceType),
+    async getServiceConfig(serviceType: string) {
+      const svc = await prisma.service.findFirst({ where: { type: serviceType } });
+      if (!svc) return null;
+      try {
+        const config = JSON.parse(svc.config);
+        return { url: config.url || config.baseUrl, apiKey: config.apiKey };
+      } catch {
+        return null;
+      }
+    },
+    registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }) {
+      rbacRegisterRoute(routeKey, rule);
+    },
+    registerPluginPermission(permission: string, description?: string) {
+      rbacRegisterPermission(permission, description);
+    },
+  };
+}

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -22,6 +22,32 @@ export interface V1FactoryDeps {
   makeFallbackLogger(pluginId: string): FastifyBaseLogger;
 }
 
+function createCapturingLogger(
+  baseLogger: FastifyBaseLogger,
+  pluginId: string
+): FastifyBaseLogger {
+  const child = baseLogger.child({ plugin: pluginId });
+
+  const capture = (level: string, args: unknown[]) => {
+    const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+    // Fire-and-forget — don't block plugin execution
+    prisma.pluginLog.create({
+      data: { pluginId, level, message: msg.slice(0, 2000) },
+    }).catch(() => {});
+  };
+
+  // Wrap the log methods
+  const origInfo = child.info.bind(child);
+  const origWarn = child.warn.bind(child);
+  const origError = child.error.bind(child);
+
+  child.info = ((...args: any[]) => { capture('info', args); return origInfo(...args); }) as any;
+  child.warn = ((...args: any[]) => { capture('warn', args); return origWarn(...args); }) as any;
+  child.error = ((...args: any[]) => { capture('error', args); return origError(...args); }) as any;
+
+  return child;
+}
+
 /**
  * Frozen V1 context factory.
  * This is a faithful extraction of the former `PluginEngine.createContext`
@@ -29,8 +55,9 @@ export interface V1FactoryDeps {
  */
 export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): PluginContext {
   const pluginId = manifest.id;
-  const log =
-    deps.logger?.child({ plugin: pluginId }) || deps.makeFallbackLogger(pluginId);
+  const log = deps.logger
+    ? createCapturingLogger(deps.logger, pluginId)
+    : deps.makeFallbackLogger(pluginId);
 
   return {
     log,

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -28,22 +28,29 @@ function createCapturingLogger(
 ): FastifyBaseLogger {
   const child = baseLogger.child({ plugin: pluginId });
 
-  const capture = (level: string, args: unknown[]) => {
-    const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
-    // Fire-and-forget — don't block plugin execution
+  const capture = (level: string, msg: string) => {
     prisma.pluginLog.create({
-      data: { pluginId, level, message: msg.slice(0, 2000) },
-    }).catch(() => {});
+      data: { pluginId, level, message: String(msg).slice(0, 2000) },
+    }).catch(() => {}); // Fire-and-forget
   };
 
-  // Wrap the log methods
-  const origInfo = child.info.bind(child);
-  const origWarn = child.warn.bind(child);
-  const origError = child.error.bind(child);
+  // Wrap log methods — use function() + apply() to preserve Pino's overloaded signatures
+  const origInfo = child.info;
+  const origWarn = child.warn;
+  const origError = child.error;
 
-  child.info = ((...args: any[]) => { capture('info', args); return origInfo(...args); }) as any;
-  child.warn = ((...args: any[]) => { capture('warn', args); return origWarn(...args); }) as any;
-  child.error = ((...args: any[]) => { capture('error', args); return origError(...args); }) as any;
+  child.info = function (this: any, ...args: any[]) {
+    capture('info', typeof args[0] === 'string' ? args[0] : args[1] || '');
+    return origInfo.apply(this, args as any);
+  } as typeof child.info;
+  child.warn = function (this: any, ...args: any[]) {
+    capture('warn', typeof args[0] === 'string' ? args[0] : args[1] || '');
+    return origWarn.apply(this, args as any);
+  } as typeof child.warn;
+  child.error = function (this: any, ...args: any[]) {
+    capture('error', typeof args[0] === 'string' ? args[0] : args[1] || '');
+    return origError.apply(this, args as any);
+  } as typeof child.error;
 
   return child;
 }

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -2,15 +2,11 @@ import { join } from 'path';
 import type { FastifyInstance, FastifyBaseLogger } from 'fastify';
 import { prisma } from '../utils/prisma.js';
 import { notificationRegistry } from '../notifications/index.js';
-import type { NotificationPayload } from '../notifications/types.js';
-import { sendUserNotification } from '../services/userNotifications.js';
-import { getArrClient } from '../providers/index.js';
-import { registerRoutePermission as rbacRegisterRoute, registerPluginPermission as rbacRegisterPermission } from '../middleware/rbac.js';
 import { discoverPlugins } from './loader.js';
+import { createContext, type ContextFactoryDeps } from './context/index.js';
 import type {
   LoadedPlugin,
   LoadedUIContribution,
-  PluginContext,
   PluginGuardResult,
   PluginInfo,
   PluginManifest,
@@ -55,7 +51,7 @@ export class PluginEngine {
           throw new Error(`Plugin "${manifest.id}" does not export a register() function`);
         }
 
-        const ctx = this.createContext(manifest);
+        const ctx = createContext(manifest, this.getContextDeps());
         const registration: PluginRegistration = await mod.register(ctx);
 
         // Run onInstall ONLY on first load (tracked by DB flag)
@@ -97,7 +93,7 @@ export class PluginEngine {
 
       const prefix = plugin.manifest.hooks?.routes?.prefix || `/api/plugins/${id}`;
       try {
-        const ctx = this.createContext(plugin.manifest);
+        const ctx = createContext(plugin.manifest, this.getContextDeps());
         await app.register(
           async (instance) => {
             await plugin.registration.registerRoutes!(instance, ctx);
@@ -123,7 +119,7 @@ export class PluginEngine {
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error || !plugin.registration.registerJobs) continue;
       try {
-        const ctx = this.createContext(plugin.manifest);
+        const ctx = createContext(plugin.manifest, this.getContextDeps());
         const jobs = plugin.registration.registerJobs(ctx);
         for (const [key, handler] of Object.entries(jobs)) {
           handlers[key] = handler;
@@ -221,7 +217,7 @@ export class PluginEngine {
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error || !plugin.registration.registerGuards) continue;
       try {
-        const ctx = this.createContext(plugin.manifest);
+        const ctx = createContext(plugin.manifest, this.getContextDeps());
         const guards = plugin.registration.registerGuards(ctx);
         const guard = guards[guardName];
         if (!guard) continue;
@@ -246,60 +242,14 @@ export class PluginEngine {
     return values;
   }
 
-  private createContext(manifest: PluginManifest): PluginContext {
-    const pluginId = manifest.id;
-    const engine = this;
-    const log = this.logger?.child({ plugin: pluginId }) || this.makeFallbackLogger(pluginId);
-
+  private getContextDeps(): ContextFactoryDeps {
     return {
-      log,
-      async getUser(userId: number) {
-        return prisma.user.findUnique({
-          where: { id: userId },
-          select: { id: true, email: true, displayName: true, role: true },
-        });
+      logger: this.logger,
+      getCachedSettings: (pluginId: string) => this.getCachedSettings(pluginId),
+      setSettingsCache: (pluginId: string, values: Record<string, unknown>) => {
+        this.settingsCache.set(pluginId, values);
       },
-      async getAppSettings() {
-        const s = await prisma.appSettings.findUnique({ where: { id: 1 } });
-        return (s ?? {}) as Record<string, unknown>;
-      },
-      async getSetting(key: string) {
-        const settings = await engine.getCachedSettings(pluginId);
-        return settings[key];
-      },
-      async setSetting(key: string, value: unknown) {
-        const settings = await engine.getCachedSettings(pluginId);
-        settings[key] = value;
-        await prisma.pluginState.update({
-          where: { pluginId },
-          data: { settings: JSON.stringify(settings) },
-        });
-        engine.settingsCache.set(pluginId, settings);
-      },
-      async sendNotification(type: string, data: NotificationPayload) {
-        await notificationRegistry.send(type, data);
-      },
-      async sendUserNotification(userId: number, payload) {
-        await sendUserNotification(userId, payload);
-      },
-      notificationRegistry,
-      getArrClient: (serviceType: string) => getArrClient(serviceType),
-      async getServiceConfig(serviceType: string) {
-        const svc = await prisma.service.findFirst({ where: { type: serviceType } });
-        if (!svc) return null;
-        try {
-          const config = JSON.parse(svc.config);
-          return { url: config.url || config.baseUrl, apiKey: config.apiKey };
-        } catch {
-          return null;
-        }
-      },
-      registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }) {
-        rbacRegisterRoute(routeKey, rule);
-      },
-      registerPluginPermission(permission: string, description?: string) {
-        rbacRegisterPermission(permission, description);
-      },
+      makeFallbackLogger: (pluginId: string) => this.makeFallbackLogger(pluginId),
     };
   }
 

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -29,7 +29,7 @@ export class PluginEngine {
       this.logger[level](msg);
     } else {
       const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
-      fn(`[PluginEngine] ${msg}`);
+      fn('[PluginEngine]', String(msg));
     }
   }
 

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyBaseLogger } from 'fastify';
 import { prisma } from '../utils/prisma.js';
 import { notificationRegistry } from '../notifications/index.js';
 import { discoverPlugins } from './loader.js';
+import { updateJobSchedule } from '../services/scheduler.js';
 import { createContext, type ContextFactoryDeps } from './context/index.js';
 import type {
   LoadedPlugin,
@@ -205,6 +206,20 @@ export class PluginEngine {
     });
     plugin.enabled = enabled;
     this.settingsCache.delete(id);
+
+    // Stop or restart plugin cron jobs
+    const jobDefs = plugin.manifest.hooks?.jobs || [];
+    for (const job of jobDefs) {
+      try {
+        const dbJob = await prisma.cronJob.findUnique({ where: { key: job.key } });
+        if (dbJob) {
+          await updateJobSchedule(job.key, dbJob.cronExpression, enabled && dbJob.enabled);
+          this.log('info', `${enabled ? 'Resumed' : 'Stopped'} job "${job.key}" for plugin "${id}"`);
+        }
+      } catch (err) {
+        this.log('error', `Failed to ${enabled ? 'resume' : 'stop'} job "${job.key}" for plugin "${id}": ${err}`);
+      }
+    }
   }
 
   async getSettings(id: string): Promise<{ schema: PluginManifest['settings']; values: Record<string, unknown> }> {

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -206,6 +206,9 @@ export class PluginEngine {
     const plugin = this.plugins.get(id);
     if (!plugin) throw new Error(`Plugin "${id}" not found`);
 
+    const validationError = this.validateSettings(plugin.manifest, values);
+    if (validationError) throw new Error(validationError);
+
     await prisma.pluginState.update({
       where: { pluginId: id },
       data: { settings: JSON.stringify(values) },
@@ -231,6 +234,33 @@ export class PluginEngine {
   }
 
   // ── Private helpers ───────────────────────────────────────────────
+
+  private validateSettings(manifest: PluginManifest, values: Record<string, unknown>): string | null {
+    const schema = manifest.settings || [];
+    for (const field of schema) {
+      const val = values[field.key];
+
+      if (field.required && (val === undefined || val === null || val === '')) {
+        return `Setting "${field.label}" is required`;
+      }
+
+      if (val === undefined || val === null || val === '') continue;
+
+      switch (field.type) {
+        case 'number':
+          if (typeof val !== 'number' || isNaN(val)) return `Setting "${field.label}" must be a number`;
+          break;
+        case 'boolean':
+          if (typeof val !== 'boolean') return `Setting "${field.label}" must be a boolean`;
+          break;
+        case 'string':
+        case 'password':
+          if (typeof val !== 'string') return `Setting "${field.label}" must be a string`;
+          break;
+      }
+    }
+    return null;
+  }
 
   private async getCachedSettings(pluginId: string): Promise<Record<string, unknown>> {
     const cached = this.settingsCache.get(pluginId);

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -186,6 +186,19 @@ export class PluginEngine {
     const plugin = this.plugins.get(id);
     if (!plugin) throw new Error(`Plugin "${id}" not found`);
 
+    // Call lifecycle hook before persisting (best-effort, don't block toggle)
+    try {
+      if (enabled && plugin.registration.onEnable) {
+        const ctx = createContext(plugin.manifest, this.getContextDeps());
+        await plugin.registration.onEnable(ctx);
+      } else if (!enabled && plugin.registration.onDisable) {
+        const ctx = createContext(plugin.manifest, this.getContextDeps());
+        await plugin.registration.onDisable(ctx);
+      }
+    } catch (err) {
+      this.log('error', `Lifecycle hook ${enabled ? 'onEnable' : 'onDisable'} failed for "${id}": ${err}`);
+    }
+
     await prisma.pluginState.update({
       where: { pluginId: id },
       data: { enabled },

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -5,34 +5,49 @@ import { notificationRegistry } from '../notifications/index.js';
 import type { NotificationPayload } from '../notifications/types.js';
 import { sendUserNotification } from '../services/userNotifications.js';
 import { getArrClient } from '../providers/index.js';
+import { registerRoutePermission as rbacRegisterRoute, registerPluginPermission as rbacRegisterPermission } from '../middleware/rbac.js';
 import { discoverPlugins } from './loader.js';
 import type {
   LoadedPlugin,
+  LoadedUIContribution,
   PluginContext,
   PluginGuardResult,
   PluginInfo,
   PluginManifest,
   PluginRegistration,
-  UIContribution,
 } from './types.js';
 
 export class PluginEngine {
   private plugins = new Map<string, LoadedPlugin>();
+  private settingsCache = new Map<string, Record<string, unknown>>();
+  private logger: FastifyBaseLogger | null = null;
+
+  /** Call once after Fastify is ready to provide a structured logger. */
+  setLogger(logger: FastifyBaseLogger): void {
+    this.logger = logger;
+  }
+
+  private log(level: 'info' | 'warn' | 'error' | 'debug', msg: string): void {
+    if (this.logger) {
+      this.logger[level](msg);
+    } else {
+      const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+      fn(`[PluginEngine] ${msg}`);
+    }
+  }
 
   async loadAll(): Promise<void> {
     const discovered = await discoverPlugins();
-    console.log(`[PluginEngine] Discovered ${discovered.length} plugin(s)`);
+    this.log('info', `Discovered ${discovered.length} plugin(s)`);
 
     for (const { dir, manifest } of discovered) {
       try {
-        // Ensure PluginState row exists
         const state = await prisma.pluginState.upsert({
           where: { pluginId: manifest.id },
           update: {},
           create: { pluginId: manifest.id, enabled: true, settings: '{}' },
         });
 
-        // Import the plugin entry module
         const entryPath = join(dir, manifest.entry);
         const mod = await import(entryPath);
 
@@ -40,31 +55,28 @@ export class PluginEngine {
           throw new Error(`Plugin "${manifest.id}" does not export a register() function`);
         }
 
-        const ctx = this.createContext(manifest, this.createFallbackLogger());
+        const ctx = this.createContext(manifest);
         const registration: PluginRegistration = await mod.register(ctx);
 
-        // Run onInstall on first load
-        if (state.settings === '{}' && registration.onInstall) {
+        // Run onInstall ONLY on first load (tracked by DB flag)
+        if (!state.onInstallRan && registration.onInstall) {
           await registration.onInstall(ctx);
-          console.log(`[PluginEngine] Ran onInstall for "${manifest.id}"`);
+          await prisma.pluginState.update({
+            where: { pluginId: manifest.id },
+            data: { onInstallRan: true },
+          });
+          this.log('info', `Ran onInstall for "${manifest.id}"`);
         }
 
-        // Register notification providers from plugin
         if (registration.registerNotificationProviders) {
           registration.registerNotificationProviders(notificationRegistry);
-          console.log(`[PluginEngine] Registered notification providers for "${manifest.id}"`);
+          this.log('info', `Registered notification providers for "${manifest.id}"`);
         }
 
-        this.plugins.set(manifest.id, {
-          manifest,
-          registration,
-          dir,
-          enabled: state.enabled,
-        });
-
-        console.log(`[PluginEngine] Loaded "${manifest.id}" v${manifest.version} (${state.enabled ? 'enabled' : 'disabled'})`);
+        this.plugins.set(manifest.id, { manifest, registration, dir, enabled: state.enabled });
+        this.log('info', `Loaded "${manifest.id}" v${manifest.version} (${state.enabled ? 'enabled' : 'disabled'})`);
       } catch (err) {
-        console.error(`[PluginEngine] Failed to load plugin "${manifest.id}":`, err);
+        this.log('error', `Failed to load plugin "${manifest.id}": ${err}`);
         this.plugins.set(manifest.id, {
           manifest,
           registration: { manifest } as PluginRegistration,
@@ -77,23 +89,31 @@ export class PluginEngine {
   }
 
   async registerWithFastify(app: FastifyInstance): Promise<void> {
+    this.setLogger(app.log);
+
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error) continue;
       if (!plugin.registration.registerRoutes) continue;
 
       const prefix = plugin.manifest.hooks?.routes?.prefix || `/api/plugins/${id}`;
       try {
-        const ctx = this.createContext(plugin.manifest, app.log);
+        const ctx = this.createContext(plugin.manifest);
         await app.register(
           async (instance) => {
             await plugin.registration.registerRoutes!(instance, ctx);
           },
           { prefix }
         );
-        console.log(`[PluginEngine] Registered routes for "${id}" at ${prefix}`);
+        this.log('info', `Registered routes for "${id}" at ${prefix}`);
       } catch (err) {
-        console.error(`[PluginEngine] Failed to register routes for "${id}":`, err);
+        this.log('error', `Failed to register routes for "${id}": ${err}`);
         plugin.error = `Route registration failed: ${err}`;
+        plugin.enabled = false;
+        // Persist disabled state so the UI reflects the failure
+        await prisma.pluginState.update({
+          where: { pluginId: id },
+          data: { enabled: false },
+        }).catch(() => {}); // best-effort
       }
     }
   }
@@ -103,13 +123,13 @@ export class PluginEngine {
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error || !plugin.registration.registerJobs) continue;
       try {
-        const ctx = this.createContext(plugin.manifest, this.createFallbackLogger());
+        const ctx = this.createContext(plugin.manifest);
         const jobs = plugin.registration.registerJobs(ctx);
         for (const [key, handler] of Object.entries(jobs)) {
           handlers[key] = handler;
         }
       } catch (err) {
-        console.error(`[PluginEngine] Failed to get job handlers for "${id}":`, err);
+        this.log('error', `Failed to get job handlers for "${id}": ${err}`);
       }
     }
     return handlers;
@@ -126,8 +146,8 @@ export class PluginEngine {
     return defs;
   }
 
-  getUIContributions(hookPoint: string): (UIContribution & { pluginId: string })[] {
-    const contributions: (UIContribution & { pluginId: string })[] = [];
+  getUIContributions(hookPoint: string): LoadedUIContribution[] {
+    const contributions: LoadedUIContribution[] = [];
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error) continue;
       for (const ui of plugin.manifest.hooks?.ui || []) {
@@ -175,15 +195,14 @@ export class PluginEngine {
       data: { enabled },
     });
     plugin.enabled = enabled;
+    this.settingsCache.delete(id);
   }
 
   async getSettings(id: string): Promise<{ schema: PluginManifest['settings']; values: Record<string, unknown> }> {
     const plugin = this.plugins.get(id);
     if (!plugin) throw new Error(`Plugin "${id}" not found`);
 
-    const state = await prisma.pluginState.findUnique({ where: { pluginId: id } });
-    const values = state ? JSON.parse(state.settings) : {};
-
+    const values = await this.getCachedSettings(id);
     return { schema: plugin.manifest.settings || [], values };
   }
 
@@ -195,45 +214,45 @@ export class PluginEngine {
       where: { pluginId: id },
       data: { settings: JSON.stringify(values) },
     });
+    this.settingsCache.set(id, values);
   }
 
-  /** Run all plugin guards for a given hook. Returns the first block result, or null if all pass. */
   async runGuards(guardName: string, userId: number): Promise<PluginGuardResult | null> {
     for (const [id, plugin] of this.plugins) {
       if (!plugin.enabled || plugin.error || !plugin.registration.registerGuards) continue;
       try {
-        const ctx = this.createContext(plugin.manifest, this.createFallbackLogger());
+        const ctx = this.createContext(plugin.manifest);
         const guards = plugin.registration.registerGuards(ctx);
         const guard = guards[guardName];
         if (!guard) continue;
         const result = await guard(userId);
         if (result?.blocked) return result;
       } catch (err) {
-        console.error(`[PluginEngine] Guard "${guardName}" failed for plugin "${id}":`, err);
+        this.log('error', `Guard "${guardName}" failed for plugin "${id}": ${err}`);
       }
     }
     return null;
   }
 
-  private createFallbackLogger(): FastifyBaseLogger {
-    const log = Object.assign((...args: unknown[]) => console.log(...args), {
-      info: (...args: unknown[]) => console.info('[Plugin]', ...args),
-      warn: (...args: unknown[]) => console.warn('[Plugin]', ...args),
-      error: (...args: unknown[]) => console.error('[Plugin]', ...args),
-      debug: (...args: unknown[]) => console.debug('[Plugin]', ...args),
-      fatal: (...args: unknown[]) => console.error('[Plugin:FATAL]', ...args),
-      trace: (...args: unknown[]) => console.debug('[Plugin:TRACE]', ...args),
-      silent: () => {},
-      child: () => log,
-      level: 'info',
-    });
-    return log as unknown as FastifyBaseLogger;
+  // ── Private helpers ───────────────────────────────────────────────
+
+  private async getCachedSettings(pluginId: string): Promise<Record<string, unknown>> {
+    const cached = this.settingsCache.get(pluginId);
+    if (cached) return cached;
+
+    const state = await prisma.pluginState.findUnique({ where: { pluginId } });
+    const values = state ? JSON.parse(state.settings) : {};
+    this.settingsCache.set(pluginId, values);
+    return values;
   }
 
-  private createContext(manifest: PluginManifest, logger: FastifyBaseLogger): PluginContext {
+  private createContext(manifest: PluginManifest): PluginContext {
     const pluginId = manifest.id;
+    const engine = this;
+    const log = this.logger?.child({ plugin: pluginId }) || this.makeFallbackLogger(pluginId);
+
     return {
-      log: logger.child({ plugin: pluginId }),
+      log,
       async getUser(userId: number) {
         return prisma.user.findUnique({
           where: { id: userId },
@@ -245,27 +264,25 @@ export class PluginEngine {
         return (s ?? {}) as Record<string, unknown>;
       },
       async getSetting(key: string) {
-        const state = await prisma.pluginState.findUnique({ where: { pluginId } });
-        if (!state) return undefined;
-        const settings = JSON.parse(state.settings);
+        const settings = await engine.getCachedSettings(pluginId);
         return settings[key];
       },
       async setSetting(key: string, value: unknown) {
-        const state = await prisma.pluginState.findUnique({ where: { pluginId } });
-        const settings = state ? JSON.parse(state.settings) : {};
+        const settings = await engine.getCachedSettings(pluginId);
         settings[key] = value;
         await prisma.pluginState.update({
           where: { pluginId },
           data: { settings: JSON.stringify(settings) },
         });
+        engine.settingsCache.set(pluginId, settings);
       },
       async sendNotification(type: string, data: NotificationPayload) {
         await notificationRegistry.send(type, data);
       },
-      async sendUserNotification(userId: number, payload: { type: string; title: string; message: string; metadata?: Record<string, unknown> }) {
+      async sendUserNotification(userId: number, payload) {
         await sendUserNotification(userId, payload);
       },
-      notificationRegistry: notificationRegistry,
+      notificationRegistry,
       getArrClient: (serviceType: string) => getArrClient(serviceType),
       async getServiceConfig(serviceType: string) {
         const svc = await prisma.service.findFirst({ where: { type: serviceType } });
@@ -277,9 +294,30 @@ export class PluginEngine {
           return null;
         }
       },
+      registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }) {
+        rbacRegisterRoute(routeKey, rule);
+      },
+      registerPluginPermission(permission: string, description?: string) {
+        rbacRegisterPermission(permission, description);
+      },
     };
+  }
+
+  private makeFallbackLogger(pluginId: string): FastifyBaseLogger {
+    const prefix = `[Plugin:${pluginId}]`;
+    const log = Object.assign((...args: unknown[]) => console.log(prefix, ...args), {
+      info: (...args: unknown[]) => console.info(prefix, ...args),
+      warn: (...args: unknown[]) => console.warn(prefix, ...args),
+      error: (...args: unknown[]) => console.error(prefix, ...args),
+      debug: (...args: unknown[]) => console.debug(prefix, ...args),
+      fatal: (...args: unknown[]) => console.error(`${prefix}[FATAL]`, ...args),
+      trace: (...args: unknown[]) => console.debug(`${prefix}[TRACE]`, ...args),
+      silent: () => {},
+      child: () => log,
+      level: 'info',
+    });
+    return log as unknown as FastifyBaseLogger;
   }
 }
 
-// Singleton
 export const pluginEngine = new PluginEngine();

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -267,6 +267,16 @@ export class PluginEngine {
       },
       notificationRegistry: notificationRegistry,
       getArrClient: (serviceType: string) => getArrClient(serviceType),
+      async getServiceConfig(serviceType: string) {
+        const svc = await prisma.service.findFirst({ where: { type: serviceType } });
+        if (!svc) return null;
+        try {
+          const config = JSON.parse(svc.config);
+          return { url: config.url || config.baseUrl, apiKey: config.apiKey };
+        } catch {
+          return null;
+        }
+      },
     };
   }
 }

--- a/packages/backend/src/plugins/eventBus.ts
+++ b/packages/backend/src/plugins/eventBus.ts
@@ -1,0 +1,35 @@
+type EventHandler = (data: unknown) => void | Promise<void>;
+
+export class PluginEventBus {
+  private listeners = new Map<string, Set<EventHandler>>();
+
+  on(event: string, handler: EventHandler): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler);
+  }
+
+  off(event: string, handler: EventHandler): void {
+    this.listeners.get(event)?.delete(handler);
+  }
+
+  async emit(event: string, data: unknown): Promise<void> {
+    const handlers = this.listeners.get(event);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        await handler(data);
+      } catch (err) {
+        console.error(`[EventBus] Handler error for "${event}":`, err);
+      }
+    }
+  }
+
+  listEvents(): string[] {
+    return Array.from(this.listeners.keys());
+  }
+}
+
+// Singleton — shared across all plugins and the core app
+export const pluginEventBus = new PluginEventBus();

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, stat, access } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import type { PluginManifest } from './types.js';
+import { isVersionSupported, getSupportedVersions } from './context/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,7 +22,11 @@ function validateManifest(data: unknown, dir: string): PluginManifest {
   if (!m.id || typeof m.id !== 'string') throw new Error(`Missing or invalid "id" in ${dir}`);
   if (!m.name || typeof m.name !== 'string') throw new Error(`Missing or invalid "name" in ${dir}`);
   if (!m.version || typeof m.version !== 'string') throw new Error(`Missing or invalid "version" in ${dir}`);
-  if (m.apiVersion !== 'v1') throw new Error(`Unsupported apiVersion "${m.apiVersion}" in ${dir} (expected "v1")`);
+  if (typeof m.apiVersion !== 'string' || !isVersionSupported(m.apiVersion)) {
+    throw new Error(
+      `Unsupported apiVersion "${m.apiVersion}" in ${dir}. Supported: ${getSupportedVersions().join(', ')}`
+    );
+  }
   if (!m.entry || typeof m.entry !== 'string') throw new Error(`Missing or invalid "entry" in ${dir}`);
 
   // Validate hooks shape if present

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -91,13 +91,9 @@ export async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
     if (!entryStat.isDirectory()) continue;
 
     const manifestPath = join(entryPath, 'manifest.json');
-    try {
-      await access(manifestPath);
-    } catch {
-      continue; // No manifest.json — skip
-    }
 
     try {
+      // Read directly — if the file doesn't exist, readFile throws and we skip
       const raw = await readFile(manifestPath, 'utf-8');
       const data = JSON.parse(raw);
       const manifest = validateManifest(data, entryPath);

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -29,6 +29,19 @@ function validateManifest(data: unknown, dir: string): PluginManifest {
   }
   if (!m.entry || typeof m.entry !== 'string') throw new Error(`Missing or invalid "entry" in ${dir}`);
 
+  // Prevent path traversal in entry field
+  const normalizedEntry = (m.entry as string).replace(/\\/g, '/');
+  if (normalizedEntry.startsWith('..') || normalizedEntry.includes('/../') || normalizedEntry.startsWith('/')) {
+    throw new Error(`Invalid "entry" in ${dir}: path traversal or absolute path not allowed`);
+  }
+  // Same check for frontend field if present
+  if (typeof m.frontend === 'string') {
+    const normalizedFrontend = m.frontend.replace(/\\/g, '/');
+    if (normalizedFrontend.startsWith('..') || normalizedFrontend.includes('/../') || normalizedFrontend.startsWith('/')) {
+      throw new Error(`Invalid "frontend" in ${dir}: path traversal or absolute path not allowed`);
+    }
+  }
+
   // Validate hooks shape if present
   if (m.hooks !== undefined && (typeof m.hooks !== 'object' || m.hooks === null)) {
     throw new Error(`Invalid "hooks" in ${dir}: must be an object`);

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from 'fs/promises';
+import { readdir, readFile, stat } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
@@ -29,7 +29,10 @@ export async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
   const plugins: DiscoveredPlugin[] = [];
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
+    // Follow symlinks: isDirectory() returns false for symlinks, so stat the resolved path
+    const entryPath = join(PLUGINS_DIR, entry.name);
+    const entryStat = await stat(entryPath); // stat follows symlinks, lstat doesn't
+    if (!entryStat.isDirectory()) continue;
 
     const dir = join(PLUGINS_DIR, entry.name);
     const manifestPath = join(dir, 'manifest.json');

--- a/packages/backend/src/plugins/loader.ts
+++ b/packages/backend/src/plugins/loader.ts
@@ -1,11 +1,15 @@
-import { readdir, readFile, stat } from 'fs/promises';
+import { readdir, readFile, stat, access } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
-import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import type { PluginManifest } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PLUGINS_DIR = resolve(__dirname, '../../../plugins');
+
+/** Resolve the plugins directory. Supports OSCARR_PLUGINS_DIR env var. */
+function getPluginsDir(): string {
+  if (process.env.OSCARR_PLUGINS_DIR) return resolve(process.env.OSCARR_PLUGINS_DIR);
+  return resolve(__dirname, '../../../plugins');
+}
 
 export interface DiscoveredPlugin {
   dir: string;
@@ -19,33 +23,69 @@ function validateManifest(data: unknown, dir: string): PluginManifest {
   if (!m.version || typeof m.version !== 'string') throw new Error(`Missing or invalid "version" in ${dir}`);
   if (m.apiVersion !== 'v1') throw new Error(`Unsupported apiVersion "${m.apiVersion}" in ${dir} (expected "v1")`);
   if (!m.entry || typeof m.entry !== 'string') throw new Error(`Missing or invalid "entry" in ${dir}`);
+
+  // Validate hooks shape if present
+  if (m.hooks !== undefined && (typeof m.hooks !== 'object' || m.hooks === null)) {
+    throw new Error(`Invalid "hooks" in ${dir}: must be an object`);
+  }
+  const hooks = m.hooks as Record<string, unknown> | undefined;
+  if (hooks?.routes !== undefined) {
+    if (typeof hooks.routes !== 'object' || hooks.routes === null || typeof (hooks.routes as any).prefix !== 'string') {
+      throw new Error(`Invalid "hooks.routes" in ${dir}: must be { prefix: string }`);
+    }
+  }
+  if (hooks?.jobs !== undefined && !Array.isArray(hooks.jobs)) {
+    throw new Error(`Invalid "hooks.jobs" in ${dir}: must be an array`);
+  }
+  if (hooks?.ui !== undefined && !Array.isArray(hooks.ui)) {
+    throw new Error(`Invalid "hooks.ui" in ${dir}: must be an array`);
+  }
+  if (hooks?.features !== undefined && (typeof hooks.features !== 'object' || hooks.features === null)) {
+    throw new Error(`Invalid "hooks.features" in ${dir}: must be an object`);
+  }
+
+  // Validate settings shape if present
+  if (m.settings !== undefined && !Array.isArray(m.settings)) {
+    throw new Error(`Invalid "settings" in ${dir}: must be an array`);
+  }
+
   return data as PluginManifest;
 }
 
 export async function discoverPlugins(): Promise<DiscoveredPlugin[]> {
-  if (!existsSync(PLUGINS_DIR)) return [];
+  const pluginsDir = getPluginsDir();
 
-  const entries = await readdir(PLUGINS_DIR, { withFileTypes: true });
+  try {
+    await access(pluginsDir);
+  } catch {
+    return []; // Directory doesn't exist — no plugins
+  }
+
+  const entries = await readdir(pluginsDir, { withFileTypes: true });
   const plugins: DiscoveredPlugin[] = [];
 
   for (const entry of entries) {
-    // Follow symlinks: isDirectory() returns false for symlinks, so stat the resolved path
-    const entryPath = join(PLUGINS_DIR, entry.name);
-    const entryStat = await stat(entryPath); // stat follows symlinks, lstat doesn't
+    if (entry.name.startsWith('.')) continue; // Skip hidden files/dirs
+
+    // Follow symlinks: stat() follows symlinks, isDirectory() doesn't for symlink entries
+    const entryPath = join(pluginsDir, entry.name);
+    const entryStat = await stat(entryPath);
     if (!entryStat.isDirectory()) continue;
 
-    const dir = join(PLUGINS_DIR, entry.name);
-    const manifestPath = join(dir, 'manifest.json');
-
-    if (!existsSync(manifestPath)) continue;
+    const manifestPath = join(entryPath, 'manifest.json');
+    try {
+      await access(manifestPath);
+    } catch {
+      continue; // No manifest.json — skip
+    }
 
     try {
       const raw = await readFile(manifestPath, 'utf-8');
       const data = JSON.parse(raw);
-      const manifest = validateManifest(data, dir);
-      plugins.push({ dir, manifest });
+      const manifest = validateManifest(data, entryPath);
+      plugins.push({ dir: entryPath, manifest });
     } catch (err) {
-      console.error(`[PluginLoader] Failed to load manifest from ${dir}:`, err);
+      console.error(`[PluginLoader] Failed to load manifest from ${entryPath}:`, err);
     }
   }
 

--- a/packages/backend/src/plugins/routes.ts
+++ b/packages/backend/src/plugins/routes.ts
@@ -1,34 +1,30 @@
 import type { FastifyInstance } from 'fastify';
-import { join, extname, resolve, sep } from 'path';
+import { join, extname, resolve, sep, relative } from 'path';
 import { existsSync, createReadStream } from 'fs';
 import { pluginEngine } from './engine.js';
 
+// ── Registry cache (module scope) ───────────────────────────────────
+const REGISTRY_URL = 'https://raw.githubusercontent.com/arediss/Oscarr-Plugin-Registry/main/plugins.json';
+const REGISTRY_TTL = 30 * 60 * 1000; // 30 minutes
+let registryCache: { data: unknown; timestamp: number } | null = null;
+
+// Allowed file extensions for plugin frontend serving
+const ALLOWED_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.json', '.map', '.svg']);
+
 export async function pluginRoutes(app: FastifyInstance) {
-  // List all plugins (admin only)
+
+  // ── List installed plugins ──────────────────────────────────────
   app.get('/', async () => {
     return pluginEngine.getPluginList();
   });
 
-  // Toggle plugin enable/disable (admin only)
+  // ── Toggle plugin ───────────────────────────────────────────────
   app.put<{ Params: { id: string }; Body: { enabled: boolean } }>(
     '/:id/toggle',
     {
-
       schema: {
-        params: {
-          type: 'object',
-          required: ['id'],
-          properties: {
-            id: { type: 'string', description: 'Plugin identifier' },
-          },
-        },
-        body: {
-          type: 'object',
-          required: ['enabled'],
-          properties: {
-            enabled: { type: 'boolean', description: 'Whether the plugin should be enabled' },
-          },
-        },
+        params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } },
+        body: { type: 'object', required: ['enabled'], properties: { enabled: { type: 'boolean' } } },
       },
     },
     async (request, reply) => {
@@ -43,20 +39,11 @@ export async function pluginRoutes(app: FastifyInstance) {
     }
   );
 
-  // Get plugin settings schema + values (admin only)
+  // ── Get settings ────────────────────────────────────────────────
   app.get<{ Params: { id: string } }>(
     '/:id/settings',
     {
-
-      schema: {
-        params: {
-          type: 'object',
-          required: ['id'],
-          properties: {
-            id: { type: 'string', description: 'Plugin identifier' },
-          },
-        },
-      },
+      schema: { params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } } },
     },
     async (request, reply) => {
       try {
@@ -67,24 +54,13 @@ export async function pluginRoutes(app: FastifyInstance) {
     }
   );
 
-  // Update plugin settings (admin only)
+  // ── Update settings ─────────────────────────────────────────────
   app.put<{ Params: { id: string }; Body: Record<string, unknown> }>(
     '/:id/settings',
     {
-
       schema: {
-        params: {
-          type: 'object',
-          required: ['id'],
-          properties: {
-            id: { type: 'string', description: 'Plugin identifier' },
-          },
-        },
-        body: {
-          type: 'object',
-          description: 'Plugin-specific settings (schema varies by plugin)',
-          additionalProperties: true,
-        },
+        params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } },
+        body: { type: 'object', additionalProperties: true },
       },
     },
     async (request, reply) => {
@@ -97,27 +73,23 @@ export async function pluginRoutes(app: FastifyInstance) {
     }
   );
 
-  // Get UI contributions for a hook point (authenticated)
+  // ── UI contributions ────────────────────────────────────────────
   app.get<{ Params: { hookPoint: string } }>(
     '/ui/:hookPoint',
     {
-
-      schema: {
-        params: {
-          type: 'object',
-          required: ['hookPoint'],
-          properties: {
-            hookPoint: { type: 'string', description: 'UI hook point identifier' },
-          },
-        },
-      },
+      schema: { params: { type: 'object', required: ['hookPoint'], properties: { hookPoint: { type: 'string' } } } },
     },
     async (request) => {
       return pluginEngine.getUIContributions(request.params.hookPoint);
     }
   );
 
-  // Serve plugin frontend files as ESM modules
+  // ── Feature flags ───────────────────────────────────────────────
+  app.get('/features', async () => {
+    return pluginEngine.getAllFeatureFlags();
+  });
+
+  // ── Plugin frontend files ───────────────────────────────────────
   app.get('/:id/frontend/*', { config: { rateLimit: { max: 120, timeWindow: '1 minute' } } }, async (request, reply) => {
     const { id } = request.params as { id: string };
     const filePath = (request.params as Record<string, string>)['*'];
@@ -126,15 +98,20 @@ export async function pluginRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: 'Plugin not found' });
     }
 
-    // Security: sanitize path
     const safePath = (filePath || '').replace(/^\//, '');
     if (!safePath) return reply.status(400).send({ error: 'File path required' });
 
-    const fullPath = resolve(join(plugin.dir, 'dist', 'frontend', safePath));
-    const pluginBoundary = resolve(plugin.dir) + sep;
+    // Extension whitelist
+    const ext = extname(safePath);
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      return reply.status(403).send({ error: 'File type not allowed' });
+    }
 
-    // Verify the resolved path stays inside the plugin directory
-    if (!fullPath.startsWith(pluginBoundary)) {
+    const fullPath = resolve(join(plugin.dir, 'dist', 'frontend', safePath));
+
+    // Path traversal check using relative path
+    const rel = relative(resolve(plugin.dir), fullPath);
+    if (rel.startsWith('..') || rel.includes(`..${sep}`)) {
       return reply.status(403).send({ error: 'Access denied' });
     }
 
@@ -142,29 +119,20 @@ export async function pluginRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: 'File not found' });
     }
 
-    const ext = extname(fullPath);
     const contentTypes: Record<string, string> = {
       '.js': 'application/javascript',
       '.mjs': 'application/javascript',
       '.css': 'text/css',
       '.json': 'application/json',
+      '.svg': 'image/svg+xml',
+      '.map': 'application/json',
     };
     reply.header('content-type', contentTypes[ext] || 'text/plain');
     reply.header('cache-control', process.env.NODE_ENV === 'production' ? 'public, max-age=3600' : 'no-cache');
     return reply.send(createReadStream(fullPath));
   });
 
-  // Get plugin feature flags (no auth - needed before login)
-  app.get('/features', async () => {
-    return pluginEngine.getAllFeatureFlags();
-  });
-
-  // ── Plugin Registry (Discover) ───────────────────────────────────
-
-  const REGISTRY_URL = 'https://raw.githubusercontent.com/arediss/Oscarr-Plugin-Registry/main/plugins.json';
-  let registryCache: { data: unknown; timestamp: number } | null = null;
-  const REGISTRY_TTL = 5 * 60 * 1000; // 5 minutes
-
+  // ── Plugin registry (Discover) ──────────────────────────────────
   app.get('/registry', async (_request, reply) => {
     try {
       const now = Date.now();
@@ -172,25 +140,24 @@ export async function pluginRoutes(app: FastifyInstance) {
         return registryCache.data;
       }
 
-      // Fetch the plugin directory
-      const res = await fetch(REGISTRY_URL);
+      const headers: Record<string, string> = { 'Accept': 'application/json' };
+      const ghToken = process.env.GITHUB_TOKEN;
+      if (ghToken) headers['Authorization'] = `Bearer ${ghToken}`;
+
+      const res = await fetch(REGISTRY_URL, { headers });
       if (!res.ok) throw new Error(`Registry fetch failed: ${res.status}`);
       const registry = await res.json() as { plugins: { repository: string; category?: string }[] };
 
-      // Fetch manifest.json from each plugin repo in parallel
       const plugins = await Promise.allSettled(
         registry.plugins.map(async (entry) => {
           const manifestUrl = `https://raw.githubusercontent.com/${entry.repository}/main/manifest.json`;
-          const mRes = await fetch(manifestUrl);
+          const mRes = await fetch(manifestUrl, { headers });
           if (!mRes.ok) return null;
           const manifest = await mRes.json() as Record<string, unknown>;
 
-          // Fetch repo metadata (description, stars, etc.)
           let repoMeta: Record<string, unknown> = {};
           try {
-            const repoRes = await fetch(`https://api.github.com/repos/${entry.repository}`, {
-              headers: { 'Accept': 'application/vnd.github.v3+json' },
-            });
+            const repoRes = await fetch(`https://api.github.com/repos/${entry.repository}`, { headers });
             if (repoRes.ok) repoMeta = await repoRes.json() as Record<string, unknown>;
           } catch { /* ignore */ }
 

--- a/packages/backend/src/plugins/routes.ts
+++ b/packages/backend/src/plugins/routes.ts
@@ -167,7 +167,13 @@ export async function pluginRoutes(app: FastifyInstance) {
       const ghToken = process.env.GITHUB_TOKEN;
       if (ghToken) headers['Authorization'] = `Bearer ${ghToken}`;
 
-      const res = await fetch(REGISTRY_URL, { headers });
+      const fetchWithTimeout = (url: string, opts: RequestInit = {}, timeoutMs = 5000) => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        return fetch(url, { ...opts, signal: controller.signal }).finally(() => clearTimeout(timer));
+      };
+
+      const res = await fetchWithTimeout(REGISTRY_URL, { headers });
       if (!res.ok) throw new Error(`Registry fetch failed: ${res.status}`);
       const registry = await res.json() as { plugins: { repository: string; category?: string }[] };
 
@@ -184,13 +190,13 @@ export async function pluginRoutes(app: FastifyInstance) {
       const plugins = await Promise.allSettled(
         validEntries.map(async (entry) => {
           const manifestUrl = `https://raw.githubusercontent.com/${entry.repository}/main/manifest.json`;
-          const mRes = await fetch(manifestUrl, { headers });
+          const mRes = await fetchWithTimeout(manifestUrl, { headers });
           if (!mRes.ok) return null;
           const manifest = await mRes.json() as Record<string, unknown>;
 
           let repoMeta: Record<string, unknown> = {};
           try {
-            const repoRes = await fetch(`https://api.github.com/repos/${entry.repository}`, { headers });
+            const repoRes = await fetchWithTimeout(`https://api.github.com/repos/${entry.repository}`, { headers });
             if (repoRes.ok) repoMeta = await repoRes.json() as Record<string, unknown>;
           } catch { /* ignore */ }
 

--- a/packages/backend/src/plugins/routes.ts
+++ b/packages/backend/src/plugins/routes.ts
@@ -111,7 +111,8 @@ export async function pluginRoutes(app: FastifyInstance) {
     const fullPath = resolve(join(plugin.dir, 'dist', 'frontend', safePath));
 
     // Path traversal check using relative path
-    const rel = relative(resolve(plugin.dir), fullPath);
+    const frontendRoot = resolve(plugin.dir, 'dist', 'frontend');
+    const rel = relative(frontendRoot, fullPath);
     if (rel.startsWith('..') || rel.includes(`..${sep}`)) {
       return reply.status(403).send({ error: 'Access denied' });
     }
@@ -148,7 +149,7 @@ export async function pluginRoutes(app: FastifyInstance) {
       const logs = await prisma.pluginLog.findMany({
         where: { pluginId: id },
         orderBy: { createdAt: 'desc' },
-        take: Math.min(parseInt(limit), 500),
+        take: Math.min(parseInt(limit, 10) || 100, 500),
       });
       return logs;
     }
@@ -170,8 +171,18 @@ export async function pluginRoutes(app: FastifyInstance) {
       if (!res.ok) throw new Error(`Registry fetch failed: ${res.status}`);
       const registry = await res.json() as { plugins: { repository: string; category?: string }[] };
 
+      // Validate repository format before fetching
+      const validRepo = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+      const validEntries = registry.plugins.filter(entry => {
+        if (!validRepo.test(entry.repository)) {
+          console.warn(`[Registry] Skipping invalid repository: ${entry.repository}`);
+          return false;
+        }
+        return true;
+      });
+
       const plugins = await Promise.allSettled(
-        registry.plugins.map(async (entry) => {
+        validEntries.map(async (entry) => {
           const manifestUrl = `https://raw.githubusercontent.com/${entry.repository}/main/manifest.json`;
           const mRes = await fetch(manifestUrl, { headers });
           if (!mRes.ok) return null;

--- a/packages/backend/src/plugins/routes.ts
+++ b/packages/backend/src/plugins/routes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { join, extname, resolve, sep, relative } from 'path';
 import { existsSync, createReadStream } from 'fs';
 import { pluginEngine } from './engine.js';
+import { prisma } from '../utils/prisma.js';
 
 // ── Registry cache (module scope) ───────────────────────────────────
 const REGISTRY_URL = 'https://raw.githubusercontent.com/arediss/Oscarr-Plugin-Registry/main/plugins.json';
@@ -131,6 +132,27 @@ export async function pluginRoutes(app: FastifyInstance) {
     reply.header('cache-control', process.env.NODE_ENV === 'production' ? 'public, max-age=3600' : 'no-cache');
     return reply.send(createReadStream(fullPath));
   });
+
+  // ── Plugin logs ─────────────────────────────────────────────────
+  app.get<{ Params: { id: string } }>(
+    '/:id/logs',
+    {
+      schema: { params: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } } },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+      const { limit = '100' } = request.query as Record<string, string>;
+      const plugin = pluginEngine.getPlugin(id);
+      if (!plugin) return reply.status(404).send({ error: 'Plugin not found' });
+
+      const logs = await prisma.pluginLog.findMany({
+        where: { pluginId: id },
+        orderBy: { createdAt: 'desc' },
+        take: Math.min(parseInt(limit), 500),
+      });
+      return logs;
+    }
+  );
 
   // ── Plugin registry (Discover) ──────────────────────────────────
   app.get('/registry', async (_request, reply) => {

--- a/packages/backend/src/plugins/routes.ts
+++ b/packages/backend/src/plugins/routes.ts
@@ -158,4 +158,66 @@ export async function pluginRoutes(app: FastifyInstance) {
   app.get('/features', async () => {
     return pluginEngine.getAllFeatureFlags();
   });
+
+  // ── Plugin Registry (Discover) ───────────────────────────────────
+
+  const REGISTRY_URL = 'https://raw.githubusercontent.com/arediss/Oscarr-Plugin-Registry/main/plugins.json';
+  let registryCache: { data: unknown; timestamp: number } | null = null;
+  const REGISTRY_TTL = 5 * 60 * 1000; // 5 minutes
+
+  app.get('/registry', async (_request, reply) => {
+    try {
+      const now = Date.now();
+      if (registryCache && now - registryCache.timestamp < REGISTRY_TTL) {
+        return registryCache.data;
+      }
+
+      // Fetch the plugin directory
+      const res = await fetch(REGISTRY_URL);
+      if (!res.ok) throw new Error(`Registry fetch failed: ${res.status}`);
+      const registry = await res.json() as { plugins: { repository: string; category?: string }[] };
+
+      // Fetch manifest.json from each plugin repo in parallel
+      const plugins = await Promise.allSettled(
+        registry.plugins.map(async (entry) => {
+          const manifestUrl = `https://raw.githubusercontent.com/${entry.repository}/main/manifest.json`;
+          const mRes = await fetch(manifestUrl);
+          if (!mRes.ok) return null;
+          const manifest = await mRes.json() as Record<string, unknown>;
+
+          // Fetch repo metadata (description, stars, etc.)
+          let repoMeta: Record<string, unknown> = {};
+          try {
+            const repoRes = await fetch(`https://api.github.com/repos/${entry.repository}`, {
+              headers: { 'Accept': 'application/vnd.github.v3+json' },
+            });
+            if (repoRes.ok) repoMeta = await repoRes.json() as Record<string, unknown>;
+          } catch { /* ignore */ }
+
+          return {
+            id: manifest.id,
+            name: manifest.name,
+            version: manifest.version,
+            apiVersion: manifest.apiVersion,
+            description: manifest.description || repoMeta.description || '',
+            author: manifest.author || '',
+            repository: entry.repository,
+            category: entry.category || 'utilities',
+            url: `https://github.com/${entry.repository}`,
+            stars: repoMeta.stargazers_count ?? 0,
+            updatedAt: repoMeta.pushed_at || null,
+          };
+        })
+      );
+
+      const result = plugins
+        .filter(p => p.status === 'fulfilled' && p.value !== null)
+        .map(p => (p as PromiseFulfilledResult<any>).value);
+
+      registryCache = { data: result, timestamp: now };
+      return result;
+    } catch (err) {
+      return reply.status(502).send({ error: 'Failed to fetch plugin registry' });
+    }
+  });
 }

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -81,6 +81,8 @@ export interface PluginRegistration {
   registerGuards?(ctx: PluginContext): Record<string, (userId: number) => Promise<PluginGuardResult | null>>;
   registerNotificationProviders?(registry: NotificationRegistry): void;
   onInstall?(ctx: PluginContext): Promise<void>;
+  onEnable?(ctx: PluginContext): Promise<void>;
+  onDisable?(ctx: PluginContext): Promise<void>;
 }
 
 // ─── Internal types ─────────────────────────────────────────────────

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -63,6 +63,11 @@ export interface PluginContext {
   getServiceConfig(serviceType: string): Promise<{ url: string; apiKey: string } | null>;
   registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }): void;
   registerPluginPermission(permission: string, description?: string): void;
+  events: {
+    on(event: string, handler: (data: unknown) => void | Promise<void>): void;
+    off(event: string, handler: (data: unknown) => void | Promise<void>): void;
+    emit(event: string, data: unknown): Promise<void>;
+  };
 }
 
 // ─── Plugin Registration (what register() returns) ──────────────────

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -55,6 +55,7 @@ export interface PluginContext {
   sendUserNotification(userId: number, payload: { type: string; title: string; message: string; metadata?: Record<string, unknown> }): Promise<void>;
   notificationRegistry: NotificationRegistry;
   getArrClient(serviceType: string): Promise<ArrClient>;
+  getServiceConfig(serviceType: string): Promise<{ url: string; apiKey: string } | null>;
 }
 
 // ─── Plugin Registration (what register() returns) ──────────────────

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -43,12 +43,17 @@ export interface UIContribution {
   order?: number;
 }
 
+/** UIContribution enriched with the owning plugin's id (returned by engine) */
+export interface LoadedUIContribution extends UIContribution {
+  pluginId: string;
+}
+
 // ─── Plugin Context (V1 API passed to plugins) ──────────────────────
 
 export interface PluginContext {
+  log: FastifyBaseLogger;
   getUser(userId: number): Promise<{ id: number; email: string; displayName: string | null; role: string } | null>;
   getAppSettings(): Promise<Record<string, unknown>>;
-  log: FastifyBaseLogger;
   getSetting(key: string): Promise<unknown>;
   setSetting(key: string, value: unknown): Promise<void>;
   sendNotification(type: string, data: NotificationPayload): Promise<void>;
@@ -56,6 +61,8 @@ export interface PluginContext {
   notificationRegistry: NotificationRegistry;
   getArrClient(serviceType: string): Promise<ArrClient>;
   getServiceConfig(serviceType: string): Promise<{ url: string; apiKey: string } | null>;
+  registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }): void;
+  registerPluginPermission(permission: string, description?: string): void;
 }
 
 // ─── Plugin Registration (what register() returns) ──────────────────
@@ -86,6 +93,7 @@ export interface LoadedPlugin {
   error?: string;
 }
 
+/** Public shape returned by getPluginList() — consumed by the frontend */
 export interface PluginInfo {
   id: string;
   name: string;

--- a/packages/backend/src/routes/admin/index.ts
+++ b/packages/backend/src/routes/admin/index.ts
@@ -29,4 +29,11 @@ export async function adminRoutes(app: FastifyInstance) {
   await keywordsRoutes(app);
   await blacklistRoutes(app);
   await backupRoutes(app);
+
+  // Graceful restart — used by "Reload plugins" in admin UI
+  app.post('/restart', async (_request, reply) => {
+    reply.send({ ok: true, message: 'Server restarting...' });
+    // Delay exit so the HTTP response is sent first
+    setTimeout(() => process.exit(0), 500);
+  });
 }

--- a/packages/backend/src/services/scheduler.ts
+++ b/packages/backend/src/services/scheduler.ts
@@ -39,6 +39,8 @@ const DEFAULT_JOBS = [
 ];
 
 const activeTasks = new Map<string, ScheduledTask>();
+const pluginJobKeys = new Set<string>(); // Track which job keys belong to plugins
+let _pluginEngine: PluginEngine | null = null;
 
 async function seedJobs() {
   for (const job of DEFAULT_JOBS) {
@@ -53,6 +55,18 @@ async function seedJobs() {
 async function runJob(key: string) {
   const handler = JOB_HANDLERS[key];
   if (!handler) return;
+
+  // Guard: skip plugin jobs if their plugin is disabled
+  if (pluginJobKeys.has(key) && _pluginEngine) {
+    const pluginList = _pluginEngine.getPluginList();
+    const ownerPlugin = pluginList.find(p =>
+      _pluginEngine!.getPlugin(p.id)?.manifest.hooks?.jobs?.some(j => j.key === key)
+    );
+    if (ownerPlugin && !ownerPlugin.enabled) {
+      logEvent('debug', 'Job', `Skipping job "${sanitize(key)}" — plugin "${ownerPlugin.id}" is disabled`);
+      return;
+    }
+  }
 
   const wasFirstSync = !(await hasCompletedFirstSync());
 
@@ -134,11 +148,13 @@ async function startAllJobs() {
 export async function initScheduler(pluginEngine?: PluginEngine) {
   // Register plugin job handlers and seed their definitions
   if (pluginEngine) {
+    _pluginEngine = pluginEngine;
     const pluginHandlers = pluginEngine.getJobHandlers();
     Object.assign(JOB_HANDLERS, pluginHandlers);
 
     const pluginJobDefs = pluginEngine.getJobDefs();
     for (const job of pluginJobDefs) {
+      pluginJobKeys.add(job.key);
       await prisma.cronJob.upsert({
         where: { key: job.key },
         update: {},

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -9,6 +9,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
     <title>Oscarr</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "/_plugin-runtime/react.js",
+          "react/jsx-runtime": "/_plugin-runtime/react-jsx-runtime.js",
+          "react-dom": "/_plugin-runtime/react-dom.js"
+        }
+      }
+    </script>
   </head>
   <body class="bg-ndp-bg text-ndp-text antialiased">
     <div id="root"></div>

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -14,7 +14,8 @@
         "imports": {
           "react": "/_plugin-runtime/react.js",
           "react/jsx-runtime": "/_plugin-runtime/react-jsx-runtime.js",
-          "react-dom": "/_plugin-runtime/react-dom.js"
+          "react-dom": "/_plugin-runtime/react-dom.js",
+          "@oscarr/sdk": "/_plugin-runtime/oscarr.js"
         }
       }
     </script>

--- a/packages/frontend/public/_plugin-runtime/oscarr.js
+++ b/packages/frontend/public/_plugin-runtime/oscarr.js
@@ -1,0 +1,93 @@
+/**
+ * Oscarr Plugin SDK
+ * Lightweight helpers for plugin developers.
+ * Import with: import { api, apiPost, formatSize, showToast } from '@oscarr/sdk';
+ */
+
+// ── API helpers ─────────────────────────────────────────────────────
+
+/** GET request to an Oscarr API endpoint. Returns parsed JSON. */
+export async function api(path, options = {}) {
+  const res = await fetch(path, { credentials: 'include', ...options });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const err = new Error(body.error || `HTTP ${res.status}`);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return res.json();
+}
+
+/** POST request with JSON body. */
+export async function apiPost(path, body) {
+  return api(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** PUT request with JSON body. */
+export async function apiPut(path, body) {
+  return api(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** DELETE request. */
+export async function apiDelete(path) {
+  return api(path, { method: 'DELETE' });
+}
+
+// ── Formatting helpers ──────────────────────────────────────────────
+
+/** Format bytes to human-readable string (e.g. 1.5 GB). */
+export function formatSize(bytes) {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const val = bytes / Math.pow(1024, i);
+  return `${val.toFixed(i > 1 ? 1 : 0)} ${units[i]}`;
+}
+
+/** Format a date string to localized short date. */
+export function formatDate(dateStr) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleDateString();
+}
+
+/** Format a date string to relative time (e.g. "2 hours ago"). */
+export function formatRelative(dateStr) {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return formatDate(dateStr);
+}
+
+// ── LocalStorage helpers (namespaced per plugin) ────────────────────
+
+/** Get a value from localStorage, namespaced by plugin ID. */
+export function storageGet(pluginId, key, fallback = null) {
+  try {
+    const raw = localStorage.getItem(`plugin-${pluginId}-${key}`);
+    return raw !== null ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Set a value in localStorage, namespaced by plugin ID. */
+export function storageSet(pluginId, key, value) {
+  try {
+    localStorage.setItem(`plugin-${pluginId}-${key}`, JSON.stringify(value));
+  } catch { /* quota exceeded or private mode */ }
+}

--- a/packages/frontend/public/_plugin-runtime/oscarr.js
+++ b/packages/frontend/public/_plugin-runtime/oscarr.js
@@ -1,7 +1,7 @@
 /**
  * Oscarr Plugin SDK
  * Lightweight helpers for plugin developers.
- * Import with: import { api, apiPost, formatSize, showToast } from '@oscarr/sdk';
+ * Import with: import { api, apiPost, apiPut, apiDelete, formatSize, formatDate, formatRelative, storageGet, storageSet } from '@oscarr/sdk';
  */
 
 // ── API helpers ─────────────────────────────────────────────────────

--- a/packages/frontend/public/_plugin-runtime/react-dom.js
+++ b/packages/frontend/public/_plugin-runtime/react-dom.js
@@ -1,3 +1,3 @@
-const R = window.ReactDOM;
+const R = window.__OSCARR_REACT_DOM__;
 export default R;
-export const { createPortal, flushSync, createRoot, hydrateRoot } = R;
+export const { createPortal, flushSync } = R;

--- a/packages/frontend/public/_plugin-runtime/react-dom.js
+++ b/packages/frontend/public/_plugin-runtime/react-dom.js
@@ -1,0 +1,3 @@
+const R = window.ReactDOM;
+export default R;
+export const { createPortal, flushSync, createRoot, hydrateRoot } = R;

--- a/packages/frontend/public/_plugin-runtime/react-jsx-runtime.js
+++ b/packages/frontend/public/_plugin-runtime/react-jsx-runtime.js
@@ -1,3 +1,3 @@
-const R = window._jsx_runtime;
+const R = window.__OSCARR_JSX_RUNTIME__;
 export default R;
 export const { jsx, jsxs, Fragment } = R;

--- a/packages/frontend/public/_plugin-runtime/react-jsx-runtime.js
+++ b/packages/frontend/public/_plugin-runtime/react-jsx-runtime.js
@@ -1,0 +1,3 @@
+const R = window._jsx_runtime;
+export default R;
+export const { jsx, jsxs, Fragment } = R;

--- a/packages/frontend/public/_plugin-runtime/react.js
+++ b/packages/frontend/public/_plugin-runtime/react.js
@@ -1,4 +1,4 @@
-const R = window.React;
+const R = window.__OSCARR_REACT__;
 export default R;
 export const {
   useState, useEffect, useCallback, useMemo, useRef, useContext,
@@ -6,4 +6,5 @@ export const {
   lazy, Suspense, startTransition, useId, useReducer,
   useLayoutEffect, useImperativeHandle, useDebugValue,
   useSyncExternalStore, useTransition, useDeferredValue,
+  useInsertionEffect,
 } = R;

--- a/packages/frontend/public/_plugin-runtime/react.js
+++ b/packages/frontend/public/_plugin-runtime/react.js
@@ -1,0 +1,9 @@
+const R = window.React;
+export default R;
+export const {
+  useState, useEffect, useCallback, useMemo, useRef, useContext,
+  createElement, Fragment, Children, createContext, forwardRef, memo,
+  lazy, Suspense, startTransition, useId, useReducer,
+  useLayoutEffect, useImperativeHandle, useDebugValue,
+  useSyncExternalStore, useTransition, useDeferredValue,
+} = R;

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -9,9 +9,9 @@ import './i18n';
 import './index.css';
 
 // Expose React globally for plugin ESM modules (shim pattern)
-(window as any).React = React;
-(window as any).ReactDOM = ReactDOM;
-(window as any)._jsx_runtime = jsxRuntime;
+(window as any).__OSCARR_REACT__ = React;
+(window as any).__OSCARR_REACT_DOM__ = ReactDOM;
+(window as any).__OSCARR_JSX_RUNTIME__ = jsxRuntime;
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -104,11 +104,11 @@ export default function AdminPage() {
   );
 
   return (
-    <div className="max-w-[1800px] mx-auto px-4 sm:px-8 py-8">
-      {/* Header */}
-      <div className="flex items-center gap-3 mb-6">
-        <Shield className="w-6 h-6 text-ndp-accent" />
-        <h1 className="text-2xl font-bold text-ndp-text">{t('admin.title')}</h1>
+    <div className="max-w-[1800px] mx-auto px-4 sm:px-8 py-6">
+      {/* Mobile: header + horizontal tabs */}
+      <div className="md:hidden flex items-center gap-3 mb-4">
+        <Shield className="w-5 h-5 text-ndp-accent" />
+        <h1 className="text-xl font-bold text-ndp-text">{t('admin.title')}</h1>
       </div>
 
       {/* Mobile: horizontal tabs */}
@@ -149,18 +149,23 @@ export default function AdminPage() {
         {/* Desktop: sidebar */}
         <aside className="hidden md:block w-56 flex-shrink-0">
           <nav className="sticky top-24 space-y-0.5">
+            <div className="flex items-center gap-2.5 px-3 mb-4">
+              <Shield className="w-5 h-5 text-ndp-accent flex-shrink-0" />
+              <h1 className="text-lg font-bold text-ndp-text">{t('admin.title')}</h1>
+            </div>
             {TABS.map(({ id, label, icon: Icon }) =>
               renderSidebarItem(id, t(label), <Icon className="w-4 h-4 flex-shrink-0" />)
             )}
 
             {pluginTabItems.length > 0 && (
-              <>
-                <div className="border-t border-white/5 my-3" />
-                <p className="text-[10px] text-ndp-text-dim uppercase tracking-wider px-3 mb-1 font-semibold">{t('admin.tab.plugins')}</p>
-                {pluginTabItems.map((tab) =>
-                  renderSidebarItem(tab.id, tab.label, <DynamicIcon name={tab.pluginIcon} className="w-4 h-4 flex-shrink-0" />, true)
-                )}
-              </>
+              <div className="mt-6 pt-5 border-t border-white/5 mx-1">
+                <p className="text-[10px] text-ndp-text-dim uppercase tracking-wider px-2 mb-3 font-semibold">{t('admin.tab.plugins')}</p>
+                <div className="space-y-0.5">
+                  {pluginTabItems.map((tab) =>
+                    renderSidebarItem(tab.id, tab.label, <DynamicIcon name={tab.pluginIcon} className="w-4 h-4 flex-shrink-0" />, true)
+                  )}
+                </div>
+              </div>
             )}
           </nav>
         </aside>

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -67,9 +67,9 @@ export default function AdminPage() {
 
   const pluginTabItems = useMemo(() =>
     pluginTabs.map((c) => ({
-      id: `plugin:${c.pluginId}` as string,
-      label: c.props.label as string,
-      pluginIcon: c.props.icon as string,
+      id: `plugin:${c.pluginId}`,
+      label: typeof c.props.label === 'string' ? c.props.label : c.pluginId,
+      pluginIcon: typeof c.props.icon === 'string' ? c.props.icon : 'Puzzle',
     })),
     [pluginTabs]
   );

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useMemo } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -65,11 +65,14 @@ export default function AdminPage() {
   const currentTab = searchParams.get('tab');
   useEffect(() => { refreshWarnings(); }, [currentTab, refreshWarnings]);
 
-  const pluginTabItems = pluginTabs.map((c) => ({
-    id: `plugin:${c.pluginId}` as string,
-    label: c.props.label as string,
-    pluginIcon: c.props.icon as string,
-  }));
+  const pluginTabItems = useMemo(() =>
+    pluginTabs.map((c) => ({
+      id: `plugin:${c.pluginId}` as string,
+      label: c.props.label as string,
+      pluginIcon: c.props.icon as string,
+    })),
+    [pluginTabs]
+  );
 
   const tabFromUrl = searchParams.get('tab') as string | null;
   const allTabIds = [...TABS.map(t => t.id), ...pluginTabItems.map(t => t.id)];

--- a/packages/frontend/src/pages/admin/PluginsTab.tsx
+++ b/packages/frontend/src/pages/admin/PluginsTab.tsx
@@ -5,17 +5,18 @@ import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, Chevron
 import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
+import type { PluginInfo } from '@/plugins/types';
 
-interface InstalledPlugin {
-  id: string;
-  name: string;
-  version: string;
-  description?: string;
-  author?: string;
-  enabled: boolean;
-  hasSettings: boolean;
-  hasFrontend: boolean;
-  error?: string;
+function isNewerVersion(remote: string, local: string): boolean {
+  const r = remote.split('.').map(Number);
+  const l = local.split('.').map(Number);
+  for (let i = 0; i < Math.max(r.length, l.length); i++) {
+    const rv = r[i] || 0;
+    const lv = l[i] || 0;
+    if (rv > lv) return true;
+    if (rv < lv) return false;
+  }
+  return false;
 }
 
 interface RegistryPlugin {
@@ -69,7 +70,7 @@ function PluginInitial({ name }: { name: string }) {
 export function PluginsTab() {
   const { t } = useTranslation();
   const [subTab, setSubTab] = useState<SubTab>('installed');
-  const [plugins, setPlugins] = useState<InstalledPlugin[]>([]);
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
   const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
   const [loading, setLoading] = useState(true);
   const [registryLoading, setRegistryLoading] = useState(false);
@@ -91,7 +92,12 @@ export function PluginsTab() {
       .finally(() => setRegistryLoading(false));
   }, []);
 
-  useEffect(() => { fetchPlugins(); fetchRegistry(); }, [fetchPlugins, fetchRegistry]);
+  useEffect(() => { fetchPlugins(); }, [fetchPlugins]);
+  useEffect(() => {
+    if (subTab === 'discover' && registry.length === 0 && !registryLoading) {
+      fetchRegistry();
+    }
+  }, [subTab, registry.length, registryLoading, fetchRegistry]);
 
   const handleToggle = async (id: string, enabled: boolean) => {
     setToggling(id);
@@ -113,7 +119,7 @@ export function PluginsTab() {
   // Count available updates
   const updatesAvailable = plugins.filter(p => {
     const rv = registryVersions.get(p.id);
-    return rv && rv.version !== p.version;
+    return rv && isNewerVersion(rv.version, p.version);
   }).length;
 
   if (loading) return <Spinner />;
@@ -174,7 +180,7 @@ export function PluginsTab() {
           ) : (
             plugins.map((plugin) => {
               const rv = registryVersions.get(plugin.id);
-              const hasUpdate = rv && rv.version !== plugin.version;
+              const hasUpdate = rv && isNewerVersion(rv.version, plugin.version);
               return (
                 <div key={plugin.id} className="card p-5 flex items-center gap-4">
                   <PluginInitial name={plugin.name} />

--- a/packages/frontend/src/pages/admin/PluginsTab.tsx
+++ b/packages/frontend/src/pages/admin/PluginsTab.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { clsx } from 'clsx';
-import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, ChevronDown, ChevronUp, BookOpen, Copy, Check } from 'lucide-react';
+import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, ChevronDown, ChevronUp, BookOpen, Copy, Check, RefreshCw } from 'lucide-react';
 import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
@@ -78,6 +78,32 @@ export function PluginsTab() {
   const [toggling, setToggling] = useState<string | null>(null);
   const [expandedInstall, setExpandedInstall] = useState<string | null>(null);
   const [showHowTo, setShowHowTo] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
+
+  const handleRestart = async () => {
+    setShowRestartConfirm(false);
+    setRestarting(true);
+    try {
+      await api.post('/admin/restart');
+    } catch { /* server is shutting down, expected */ }
+
+    // Poll until server is back
+    const poll = async () => {
+      for (let i = 0; i < 30; i++) {
+        await new Promise(r => setTimeout(r, 1000));
+        try {
+          await api.get('/app/features');
+          window.location.reload();
+          return;
+        } catch { /* still down */ }
+      }
+      // Give up after 30s
+      setRestarting(false);
+      alert('Server did not come back after 30 seconds. Check the logs.');
+    };
+    poll();
+  };
 
   const fetchPlugins = useCallback(() => {
     api.get('/plugins').then(({ data }) => setPlugins(data)).catch(() => {}).finally(() => setLoading(false));
@@ -159,7 +185,45 @@ export function PluginsTab() {
           <Download className="w-4 h-4" />
           Discover
         </button>
+        <button
+          onClick={() => setShowRestartConfirm(true)}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-ndp-text-muted hover:text-ndp-text hover:bg-white/5 transition-all ml-auto"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Reload plugins
+        </button>
       </div>
+
+      {/* Restart confirmation modal */}
+      {showRestartConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowRestartConfirm(false)}>
+          <div className="card p-6 max-w-md mx-4" onClick={e => e.stopPropagation()}>
+            <h3 className="text-ndp-text font-semibold mb-2">Reload plugins</h3>
+            <p className="text-sm text-ndp-text-muted mb-4">
+              This will restart the Oscarr server to discover and load new plugins. The app will be unavailable for a few seconds.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button onClick={() => setShowRestartConfirm(false)} className="px-4 py-2 text-sm text-ndp-text-dim hover:text-ndp-text transition-colors">
+                Cancel
+              </button>
+              <button onClick={handleRestart} className="px-4 py-2 bg-ndp-accent text-white rounded-lg text-sm font-medium hover:bg-ndp-accent/90 transition-colors">
+                Restart now
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Restarting overlay */}
+      {restarting && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-4">
+            <Loader2 className="w-8 h-8 animate-spin text-ndp-accent" />
+            <p className="text-ndp-text font-medium">Restarting Oscarr...</p>
+            <p className="text-sm text-ndp-text-dim">This usually takes a few seconds</p>
+          </div>
+        </div>
+      )}
 
       {/* ═══ Installed tab ═══ */}
       {subTab === 'installed' && (

--- a/packages/frontend/src/pages/admin/PluginsTab.tsx
+++ b/packages/frontend/src/pages/admin/PluginsTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { clsx } from 'clsx';
 import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, ChevronDown, ChevronUp, BookOpen, Copy, Check, RefreshCw } from 'lucide-react';
 import api from '@/lib/api';
+import { invalidatePluginUICache } from '@/plugins/usePlugins';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import type { PluginInfo } from '@/plugins/types';
@@ -130,6 +131,7 @@ export function PluginsTab() {
     try {
       await api.put(`/plugins/${id}/toggle`, { enabled });
       setPlugins(prev => prev.map(p => p.id === id ? { ...p, enabled } : p));
+      invalidatePluginUICache(); // Refresh plugin UI contributions (sidebar, hooks)
     } catch { /* ignore */ }
     setToggling(null);
   };

--- a/packages/frontend/src/pages/admin/PluginsTab.tsx
+++ b/packages/frontend/src/pages/admin/PluginsTab.tsx
@@ -1,22 +1,97 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { clsx } from 'clsx';
-import { Plug } from 'lucide-react';
+import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, ChevronDown, ChevronUp, BookOpen, Copy, Check } from 'lucide-react';
 import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 
+interface InstalledPlugin {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  enabled: boolean;
+  hasSettings: boolean;
+  hasFrontend: boolean;
+  error?: string;
+}
+
+interface RegistryPlugin {
+  id: string;
+  name: string;
+  version: string;
+  apiVersion: string;
+  description: string;
+  author: string;
+  repository: string;
+  category: string;
+  url: string;
+  stars: number;
+  updatedAt: string | null;
+}
+
+type SubTab = 'installed' | 'discover';
+
+const CATEGORY_CONFIG: Record<string, { label: string; color: string }> = {
+  bots: { label: 'Bot', color: 'bg-indigo-500/15 text-indigo-400' },
+  notifications: { label: 'Notifications', color: 'bg-amber-500/15 text-amber-400' },
+  automation: { label: 'Automation', color: 'bg-cyan-500/15 text-cyan-400' },
+  'requests-workflow': { label: 'Requests', color: 'bg-pink-500/15 text-pink-400' },
+  'ui-themes': { label: 'Themes', color: 'bg-purple-500/15 text-purple-400' },
+  analytics: { label: 'Analytics', color: 'bg-emerald-500/15 text-emerald-400' },
+  utilities: { label: 'Utilities', color: 'bg-slate-500/15 text-slate-400' },
+};
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => { navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
+      className="text-ndp-text-dim hover:text-ndp-text transition-colors"
+      title="Copy"
+    >
+      {copied ? <Check className="w-3.5 h-3.5 text-ndp-success" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  );
+}
+
+function PluginInitial({ name }: { name: string }) {
+  const letter = name.charAt(0).toUpperCase();
+  return (
+    <div className="w-12 h-12 rounded-xl bg-ndp-accent/15 flex items-center justify-center text-ndp-accent font-bold text-lg flex-shrink-0">
+      {letter}
+    </div>
+  );
+}
+
 export function PluginsTab() {
   const { t } = useTranslation();
-  const [plugins, setPlugins] = useState<{ id: string; name: string; version: string; description?: string; author?: string; enabled: boolean; hasSettings: boolean; hasFrontend: boolean; error?: string }[]>([]);
+  const [subTab, setSubTab] = useState<SubTab>('installed');
+  const [plugins, setPlugins] = useState<InstalledPlugin[]>([]);
+  const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
   const [loading, setLoading] = useState(true);
+  const [registryLoading, setRegistryLoading] = useState(false);
+  const [registryError, setRegistryError] = useState<string | null>(null);
   const [toggling, setToggling] = useState<string | null>(null);
+  const [expandedInstall, setExpandedInstall] = useState<string | null>(null);
+  const [showHowTo, setShowHowTo] = useState(false);
 
   const fetchPlugins = useCallback(() => {
     api.get('/plugins').then(({ data }) => setPlugins(data)).catch(() => {}).finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { fetchPlugins(); }, [fetchPlugins]);
+  const fetchRegistry = useCallback(() => {
+    setRegistryLoading(true);
+    setRegistryError(null);
+    api.get('/plugins/registry')
+      .then(({ data }) => setRegistry(data))
+      .catch(() => setRegistryError('Failed to load plugin registry'))
+      .finally(() => setRegistryLoading(false));
+  }, []);
+
+  useEffect(() => { fetchPlugins(); fetchRegistry(); }, [fetchPlugins, fetchRegistry]);
 
   const handleToggle = async (id: string, enabled: boolean) => {
     setToggling(id);
@@ -27,59 +102,343 @@ export function PluginsTab() {
     setToggling(null);
   };
 
-  if (loading) return <Spinner />;
+  const installedIds = new Set(plugins.map(p => p.id));
 
-  if (plugins.length === 0) {
-    return (
-      <AdminTabLayout title={t('admin.tab.plugins')} count={0}>
-        <div className="card p-8 text-center">
-          <Plug className="w-10 h-10 text-ndp-text-dim mx-auto mb-3" />
-          <p className="text-ndp-text-muted">{t('admin.plugins.no_plugins')}</p>
-          <p className="text-sm text-ndp-text-dim mt-1" dangerouslySetInnerHTML={{ __html: t('admin.plugins.no_plugins_help') }} />
-        </div>
-      </AdminTabLayout>
-    );
+  // Build a map of registry versions for update detection
+  const registryVersions = new Map<string, { version: string; url: string; repository: string }>();
+  for (const rp of registry) {
+    registryVersions.set(rp.id, { version: rp.version, url: rp.url, repository: rp.repository });
   }
+
+  // Count available updates
+  const updatesAvailable = plugins.filter(p => {
+    const rv = registryVersions.get(p.id);
+    return rv && rv.version !== p.version;
+  }).length;
+
+  if (loading) return <Spinner />;
 
   return (
     <AdminTabLayout title={t('admin.tab.plugins')} count={plugins.length}>
-      <div className="space-y-3">
-      {plugins.map((plugin) => (
-        <div key={plugin.id} className="card p-5 flex items-center justify-between gap-4">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-semibold text-ndp-text">{plugin.name}</h3>
-              <span className="text-xs text-ndp-text-dim">v{plugin.version}</span>
-              {plugin.error && (
-                <span className="text-xs bg-ndp-danger/10 text-ndp-danger px-2 py-0.5 rounded-full">{t('common.error')}</span>
-              )}
+      {/* Sub-tabs */}
+      <div className="flex gap-1 mb-6 bg-white/5 rounded-xl p-1 w-fit">
+        <button
+          onClick={() => setSubTab('installed')}
+          className={clsx(
+            'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+            subTab === 'installed' ? 'bg-ndp-accent text-white' : 'text-ndp-text-muted hover:text-ndp-text'
+          )}
+        >
+          <Package className="w-4 h-4" />
+          Installed
+          {plugins.length > 0 && (
+            <span className={clsx(
+              'text-xs px-1.5 py-0.5 rounded-full',
+              subTab === 'installed' ? 'bg-white/20' : 'bg-white/10'
+            )}>{plugins.length}</span>
+          )}
+          {updatesAvailable > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded-full bg-ndp-accent/80 text-white">
+              {updatesAvailable} update{updatesAvailable > 1 ? 's' : ''}
+            </span>
+          )}
+        </button>
+        <button
+          onClick={() => setSubTab('discover')}
+          className={clsx(
+            'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all',
+            subTab === 'discover' ? 'bg-ndp-accent text-white' : 'text-ndp-text-muted hover:text-ndp-text'
+          )}
+        >
+          <Download className="w-4 h-4" />
+          Discover
+        </button>
+      </div>
+
+      {/* ═══ Installed tab ═══ */}
+      {subTab === 'installed' && (
+        <div className="space-y-3">
+          {plugins.length === 0 ? (
+            <div className="card p-10 text-center">
+              <Plug className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
+              <p className="text-ndp-text font-medium">{t('admin.plugins.no_plugins')}</p>
+              <p className="text-sm text-ndp-text-dim mt-1.5 max-w-md mx-auto">{t('admin.plugins.no_plugins_help')}</p>
+              <button
+                onClick={() => setSubTab('discover')}
+                className="mt-5 px-5 py-2.5 bg-ndp-accent text-white rounded-xl text-sm font-medium hover:bg-ndp-accent/90 transition-colors inline-flex items-center gap-2"
+              >
+                <Download className="w-4 h-4" />
+                Browse plugins
+              </button>
             </div>
-            {plugin.description && (
-              <p className="text-sm text-ndp-text-muted mt-0.5">{plugin.description}</p>
-            )}
-            {plugin.author && (
-              <p className="text-xs text-ndp-text-dim mt-0.5">{t('common.by')} {plugin.author}</p>
-            )}
-            {plugin.error && (
-              <p className="text-xs text-ndp-danger mt-1">{plugin.error}</p>
+          ) : (
+            plugins.map((plugin) => {
+              const rv = registryVersions.get(plugin.id);
+              const hasUpdate = rv && rv.version !== plugin.version;
+              return (
+                <div key={plugin.id} className="card p-5 flex items-center gap-4">
+                  <PluginInitial name={plugin.name} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="text-sm font-semibold text-ndp-text">{plugin.name}</h3>
+                      <span className="text-xs text-ndp-text-dim">v{plugin.version}</span>
+                      {hasUpdate && (
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-accent/15 text-ndp-accent font-medium">
+                          v{rv.version} available
+                        </span>
+                      )}
+                      {plugin.error && (
+                        <span className="text-xs bg-ndp-danger/10 text-ndp-danger px-2 py-0.5 rounded-full">{t('common.error')}</span>
+                      )}
+                    </div>
+                    {plugin.description && (
+                      <p className="text-sm text-ndp-text-muted mt-0.5 line-clamp-1">{plugin.description}</p>
+                    )}
+                    <div className="flex items-center gap-3 mt-0.5">
+                      {plugin.author && (
+                        <span className="text-xs text-ndp-text-dim">{t('common.by')} {plugin.author}</span>
+                      )}
+                      {hasUpdate && rv.url && (
+                        <a
+                          href={rv.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-ndp-accent hover:underline inline-flex items-center gap-1"
+                        >
+                          View update <ExternalLink className="w-3 h-3" />
+                        </a>
+                      )}
+                    </div>
+                    {plugin.error && (
+                      <p className="text-xs text-ndp-danger mt-1 line-clamp-2">{plugin.error}</p>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => handleToggle(plugin.id, !plugin.enabled)}
+                    disabled={toggling === plugin.id}
+                    className={clsx(
+                      'relative w-12 h-6 rounded-full transition-colors flex-shrink-0',
+                      plugin.enabled ? 'bg-ndp-accent' : 'bg-white/10'
+                    )}
+                  >
+                    <span className={clsx(
+                      'absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform',
+                      plugin.enabled && 'translate-x-6'
+                    )} />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+
+      {/* ═══ Discover tab ═══ */}
+      {subTab === 'discover' && (
+        <div className="space-y-5">
+          {registryLoading && (
+            <div className="flex justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-ndp-accent" />
+            </div>
+          )}
+
+          {registryError && (
+            <div className="card p-6 text-center">
+              <p className="text-ndp-error text-sm">{registryError}</p>
+              <button
+                onClick={fetchRegistry}
+                className="mt-3 px-4 py-2 bg-ndp-accent text-white rounded-lg text-sm font-medium hover:bg-ndp-accent/90 transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!registryLoading && !registryError && registry.length === 0 && (
+            <div className="card p-10 text-center">
+              <Download className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
+              <p className="text-ndp-text font-medium">No plugins available yet</p>
+              <p className="text-sm text-ndp-text-dim mt-1.5">Community plugins will appear here once published.</p>
+            </div>
+          )}
+
+          {!registryLoading && registry.length > 0 && (
+            <>
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-ndp-text-dim">
+                  {registry.length} plugin{registry.length !== 1 ? 's' : ''} available
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                {registry.map((plugin) => {
+                  const isInstalled = installedIds.has(plugin.id);
+                  const cat = CATEGORY_CONFIG[plugin.category] || { label: plugin.category, color: 'bg-white/5 text-ndp-text-dim' };
+                  const isExpanded = expandedInstall === plugin.id;
+                  const installCmd = `cd packages/plugins && git clone ${plugin.url}.git ${plugin.id}`;
+                  const npmCmd = `cd packages/plugins/${plugin.id} && npm install --production`;
+
+                  return (
+                    <div key={plugin.id} className="card overflow-hidden">
+                      <div className="p-5 flex items-start gap-4">
+                        <PluginInitial name={plugin.name} />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <h3 className="text-sm font-semibold text-ndp-text">{plugin.name}</h3>
+                            <span className="text-xs text-ndp-text-dim">v{plugin.version}</span>
+                            <span className={clsx('text-xs px-2 py-0.5 rounded-full font-medium', cat.color)}>
+                              {cat.label}
+                            </span>
+                            {isInstalled && (
+                              <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-success/15 text-ndp-success font-medium">
+                                Installed
+                              </span>
+                            )}
+                          </div>
+                          {plugin.description && (
+                            <p className="text-sm text-ndp-text-muted mt-1.5">{plugin.description}</p>
+                          )}
+                          <div className="flex items-center gap-4 mt-2 text-xs text-ndp-text-dim">
+                            {plugin.author && <span>{t('common.by')} {plugin.author}</span>}
+                            {plugin.stars > 0 && (
+                              <span className="flex items-center gap-1">
+                                <Star className="w-3 h-3" />
+                                {plugin.stars}
+                              </span>
+                            )}
+                            {plugin.updatedAt && (
+                              <span>Updated {new Date(plugin.updatedAt).toLocaleDateString()}</span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          {!isInstalled && (
+                            <button
+                              onClick={() => setExpandedInstall(isExpanded ? null : plugin.id)}
+                              className="flex items-center gap-2 px-4 py-2 bg-ndp-accent hover:bg-ndp-accent/90 rounded-lg text-sm text-white font-medium transition-colors"
+                            >
+                              <Terminal className="w-4 h-4" />
+                              Install
+                              {isExpanded ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+                            </button>
+                          )}
+                          <a
+                            href={plugin.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-ndp-text-dim hover:text-ndp-text transition-colors"
+                            title="View on GitHub"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                          </a>
+                        </div>
+                      </div>
+
+                      {/* Install instructions (expandable) */}
+                      {isExpanded && (
+                        <div className="border-t border-white/5 bg-white/[0.02] px-5 py-4 space-y-3">
+                          <p className="text-xs text-ndp-text-dim font-medium uppercase tracking-wider">Installation</p>
+                          <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">1</span>
+                              <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
+                                {installCmd}
+                              </code>
+                              <CopyButton text={installCmd} />
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">2</span>
+                              <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
+                                {npmCmd}
+                              </code>
+                              <CopyButton text={npmCmd} />
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">3</span>
+                              <span className="flex-1 text-xs text-ndp-text-dim px-3 py-2">
+                                Restart Oscarr and enable the plugin in the Installed tab
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {/* How to section */}
+          <div className="card overflow-hidden">
+            <button
+              onClick={() => setShowHowTo(!showHowTo)}
+              className="w-full px-5 py-4 flex items-center justify-between hover:bg-white/[0.02] transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                <BookOpen className="w-5 h-5 text-ndp-accent" />
+                <span className="text-sm font-medium text-ndp-text">How to develop a plugin</span>
+              </div>
+              {showHowTo ? <ChevronUp className="w-4 h-4 text-ndp-text-dim" /> : <ChevronDown className="w-4 h-4 text-ndp-text-dim" />}
+            </button>
+            {showHowTo && (
+              <div className="border-t border-white/5 px-5 py-4 space-y-4 text-sm text-ndp-text-muted">
+                <p>
+                  Oscarr plugins are Node.js modules that extend the backend and/or frontend.
+                  Each plugin lives in its own folder under <code className="text-ndp-text bg-black/30 px-1.5 py-0.5 rounded text-xs">packages/plugins/</code>.
+                </p>
+
+                <div>
+                  <p className="text-ndp-text font-medium mb-2">Minimal structure</p>
+                  <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
+{`my-plugin/
+├── manifest.json    # Plugin metadata
+├── package.json     # Dependencies
+├── index.js         # Entry point (register function)
+└── src/             # Your code`}
+                  </pre>
+                </div>
+
+                <div>
+                  <p className="text-ndp-text font-medium mb-2">manifest.json</p>
+                  <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
+{`{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "entry": "index.js",
+  "description": "What it does",
+  "author": "Your name"
+}`}
+                  </pre>
+                </div>
+
+                <div className="flex items-center gap-3 pt-1">
+                  <a
+                    href="https://github.com/arediss/Oscarr/blob/main/docs/plugins.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-ndp-text transition-colors"
+                  >
+                    <BookOpen className="w-4 h-4" />
+                    Full documentation
+                  </a>
+                  <a
+                    href="https://github.com/arediss/Oscarr-Plugin-Registry"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-ndp-text transition-colors"
+                  >
+                    <Download className="w-4 h-4" />
+                    Submit your plugin
+                  </a>
+                </div>
+              </div>
             )}
           </div>
-          <button
-            onClick={() => handleToggle(plugin.id, !plugin.enabled)}
-            disabled={toggling === plugin.id}
-            className={clsx(
-              'relative w-12 h-6 rounded-full transition-colors flex-shrink-0',
-              plugin.enabled ? 'bg-ndp-accent' : 'bg-white/10'
-            )}
-          >
-            <span className={clsx(
-              'absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform',
-              plugin.enabled && 'translate-x-6'
-            )} />
-          </button>
         </div>
-      ))}
-      </div>
+      )}
     </AdminTabLayout>
   );
 }

--- a/packages/frontend/src/plugins/DynamicIcon.tsx
+++ b/packages/frontend/src/plugins/DynamicIcon.tsx
@@ -1,11 +1,26 @@
-import * as Icons from 'lucide-react';
+import {
+  Film, Settings, Users, Shield, Server, Bell, RefreshCw, ScrollText, Plug,
+  ExternalLink, MessageSquare, Puzzle, BarChart3, Zap, Code, Palette, Bot,
+  Download, Package, Star, Loader2, BookOpen, Terminal, ChevronDown, ChevronUp,
+  Copy, Check, Power, Search, Trash2, Eye, EyeOff, Play, type LucideIcon,
+} from 'lucide-react';
 
-interface DynamicIconProps extends Icons.LucideProps {
+const ICON_MAP: Record<string, LucideIcon> = {
+  Film, Settings, Users, Shield, Server, Bell, RefreshCw, ScrollText, Plug,
+  ExternalLink, MessageSquare, Puzzle, BarChart3, Zap, Code, Palette, Bot,
+  Download, Package, Star, Loader2, BookOpen, Terminal, ChevronDown, ChevronUp,
+  Copy, Check, Power, Search, Trash2, Eye, EyeOff, Play,
+};
+
+interface DynamicIconProps {
   name: string;
+  className?: string;
 }
 
-export function DynamicIcon({ name, ...props }: DynamicIconProps) {
-  const Icon = (Icons as unknown as Record<string, Icons.LucideIcon>)[name];
-  if (!Icon) return null;
-  return <Icon {...props} />;
+export function DynamicIcon({ name, className }: DynamicIconProps) {
+  const Icon = ICON_MAP[name];
+  if (!Icon) {
+    return <Puzzle className={className} />;
+  }
+  return <Icon className={className} />;
 }

--- a/packages/frontend/src/plugins/PluginAdminTab.tsx
+++ b/packages/frontend/src/plugins/PluginAdminTab.tsx
@@ -5,6 +5,7 @@ import api from '@/lib/api';
 import type { PluginSettings } from './types';
 import { loadPluginModule, hasLoaded, getCached, pluginFrontendUrl } from './pluginModuleCache';
 import type { ComponentType } from 'react';
+import { PluginErrorBoundary } from './PluginErrorBoundary';
 
 interface PluginAdminTabProps {
   pluginId: string;
@@ -77,7 +78,11 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   }
 
   if (FrontendComp) {
-    return <FrontendComp />;
+    return (
+      <PluginErrorBoundary pluginId={pluginId}>
+        <FrontendComp />
+      </PluginErrorBoundary>
+    );
   }
 
   if (error && !settings) {

--- a/packages/frontend/src/plugins/PluginAdminTab.tsx
+++ b/packages/frontend/src/plugins/PluginAdminTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Save, Loader2 } from 'lucide-react';
 import api from '@/lib/api';
@@ -15,9 +15,10 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   const { t } = useTranslation();
   const url = pluginFrontendUrl(pluginId);
 
-  const [FrontendComp, setFrontendComp] = useState<ComponentType<any> | null>(getCached(url));
-  const [frontendLoading, setFrontendLoading] = useState(!hasLoaded(url));
-  const [frontendTried, setFrontendTried] = useState(hasLoaded(url));
+  // ALL hooks declared unconditionally at the top — no early returns before hooks
+  const [FrontendComp, setFrontendComp] = useState<ComponentType<any> | null>(() => getCached(url));
+  const [frontendLoading, setFrontendLoading] = useState(() => !hasLoaded(url));
+  const [frontendTried, setFrontendTried] = useState(() => hasLoaded(url));
 
   const [settings, setSettings] = useState<PluginSettings | null>(null);
   const [values, setValues] = useState<Record<string, unknown>>({});
@@ -54,7 +55,7 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
       .catch((err) => setError(err.response?.data?.error || t('plugin.load_error')));
   }, [pluginId, frontendTried, FrontendComp]);
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     setSaving(true);
     setSaved(false);
     setError(null);
@@ -67,8 +68,11 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
     } finally {
       setSaving(false);
     }
-  };
+  }, [pluginId, values]);
 
+  // ── Single return — all branching in JSX ──────────────────────────
+
+  // Loading frontend
   if (frontendLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -77,6 +81,7 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
     );
   }
 
+  // Frontend loaded — render it
   if (FrontendComp) {
     return (
       <PluginErrorBoundary pluginId={pluginId}>
@@ -85,6 +90,7 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
     );
   }
 
+  // Fallback: settings form
   if (error && !settings) {
     return <div className="card p-6 text-center text-ndp-text-muted">{error}</div>;
   }

--- a/packages/frontend/src/plugins/PluginAdminTab.tsx
+++ b/packages/frontend/src/plugins/PluginAdminTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ComponentType } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Save, Loader2 } from 'lucide-react';
 import api from '@/lib/api';
@@ -8,6 +8,8 @@ interface PluginAdminTabProps {
   pluginId: string;
 }
 
+const frontendCache = new Map<string, ComponentType<any> | null>();
+
 export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   const { t } = useTranslation();
   const [settings, setSettings] = useState<PluginSettings | null>(null);
@@ -16,6 +18,33 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Try loading plugin frontend component
+  const [FrontendComponent, setFrontendComponent] = useState<ComponentType<any> | null>(
+    frontendCache.has(pluginId) ? frontendCache.get(pluginId)! : null
+  );
+  const [frontendLoading, setFrontendLoading] = useState(!frontendCache.has(pluginId));
+  const [frontendFailed, setFrontendFailed] = useState(false);
+
+  useEffect(() => {
+    if (frontendCache.has(pluginId)) {
+      setFrontendLoading(false);
+      return;
+    }
+
+    import(/* @vite-ignore */ `/api/plugins/${pluginId}/frontend/index.js`)
+      .then((mod) => {
+        const comp = mod.default || null;
+        frontendCache.set(pluginId, comp);
+        setFrontendComponent(() => comp);
+      })
+      .catch(() => {
+        frontendCache.set(pluginId, null);
+        setFrontendFailed(true);
+      })
+      .finally(() => setFrontendLoading(false));
+  }, [pluginId]);
+
+  // Load settings (for fallback settings UI)
   useEffect(() => {
     api.get<PluginSettings>(`/plugins/${pluginId}/settings`)
       .then(({ data }) => {
@@ -25,21 +54,20 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
       .catch((err) => setError(err.response?.data?.error || t('plugin.load_error')));
   }, [pluginId]);
 
-  const handleSave = async () => {
-    setSaving(true);
-    setSaved(false);
-    setError(null);
-    try {
-      await api.put(`/plugins/${pluginId}/settings`, values);
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    } catch (err: any) {
-      setError(err.response?.data?.error || t('plugin.save_error'));
-    } finally {
-      setSaving(false);
-    }
-  };
+  // If frontend component loaded, render it instead of settings
+  if (frontendLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-ndp-accent" />
+      </div>
+    );
+  }
 
+  if (FrontendComponent) {
+    return <FrontendComponent />;
+  }
+
+  // Fallback: settings form (original behavior)
   if (error && !settings) {
     return (
       <div className="card p-6 text-center text-ndp-text-muted">
@@ -109,4 +137,19 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
       </button>
     </div>
   );
+
+  async function handleSave() {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      await api.put(`/plugins/${pluginId}/settings`, values);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err: any) {
+      setError(err.response?.data?.error || t('plugin.save_error'));
+    } finally {
+      setSaving(false);
+    }
+  }
 }

--- a/packages/frontend/src/plugins/PluginAdminTab.tsx
+++ b/packages/frontend/src/plugins/PluginAdminTab.tsx
@@ -1,60 +1,73 @@
-import { useState, useEffect, type ComponentType } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Save, Loader2 } from 'lucide-react';
 import api from '@/lib/api';
 import type { PluginSettings } from './types';
+import { loadPluginModule, hasLoaded, getCached, pluginFrontendUrl } from './pluginModuleCache';
+import type { ComponentType } from 'react';
 
 interface PluginAdminTabProps {
   pluginId: string;
 }
 
-const frontendCache = new Map<string, ComponentType<any> | null>();
-
 export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   const { t } = useTranslation();
+  const url = pluginFrontendUrl(pluginId);
+
+  const [FrontendComp, setFrontendComp] = useState<ComponentType<any> | null>(getCached(url));
+  const [frontendLoading, setFrontendLoading] = useState(!hasLoaded(url));
+  const [frontendTried, setFrontendTried] = useState(hasLoaded(url));
+
   const [settings, setSettings] = useState<PluginSettings | null>(null);
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Try loading plugin frontend component
-  const [FrontendComponent, setFrontendComponent] = useState<ComponentType<any> | null>(
-    frontendCache.has(pluginId) ? frontendCache.get(pluginId)! : null
-  );
-  const [frontendLoading, setFrontendLoading] = useState(!frontendCache.has(pluginId));
-  const [frontendFailed, setFrontendFailed] = useState(false);
-
+  // Try loading frontend component
   useEffect(() => {
-    if (frontendCache.has(pluginId)) {
+    if (hasLoaded(url)) {
+      setFrontendComp(() => getCached(url));
       setFrontendLoading(false);
+      setFrontendTried(true);
       return;
     }
 
-    import(/* @vite-ignore */ `/api/plugins/${pluginId}/frontend/index.js`)
-      .then((mod) => {
-        const comp = mod.default || null;
-        frontendCache.set(pluginId, comp);
-        setFrontendComponent(() => comp);
-      })
-      .catch(() => {
-        frontendCache.set(pluginId, null);
-        setFrontendFailed(true);
-      })
-      .finally(() => setFrontendLoading(false));
-  }, [pluginId]);
+    let cancelled = false;
+    setFrontendLoading(true);
+    loadPluginModule(url).then((comp) => {
+      if (cancelled) return;
+      setFrontendComp(() => comp);
+      setFrontendLoading(false);
+      setFrontendTried(true);
+    });
+    return () => { cancelled = true; };
+  }, [pluginId, url]);
 
-  // Load settings (for fallback settings UI)
+  // Load settings only if frontend failed or doesn't exist
   useEffect(() => {
-    api.get<PluginSettings>(`/plugins/${pluginId}/settings`)
-      .then(({ data }) => {
-        setSettings(data);
-        setValues(data.values);
-      })
-      .catch((err) => setError(err.response?.data?.error || t('plugin.load_error')));
-  }, [pluginId]);
+    if (!frontendTried || FrontendComp) return;
 
-  // If frontend component loaded, render it instead of settings
+    api.get<PluginSettings>(`/plugins/${pluginId}/settings`)
+      .then(({ data }) => { setSettings(data); setValues(data.values); })
+      .catch((err) => setError(err.response?.data?.error || t('plugin.load_error')));
+  }, [pluginId, frontendTried, FrontendComp]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      await api.put(`/plugins/${pluginId}/settings`, values);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err: any) {
+      setError(err.response?.data?.error || t('plugin.save_error'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (frontendLoading) {
     return (
       <div className="flex justify-center py-12">
@@ -63,17 +76,12 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
     );
   }
 
-  if (FrontendComponent) {
-    return <FrontendComponent />;
+  if (FrontendComp) {
+    return <FrontendComp />;
   }
 
-  // Fallback: settings form (original behavior)
   if (error && !settings) {
-    return (
-      <div className="card p-6 text-center text-ndp-text-muted">
-        {error}
-      </div>
-    );
+    return <div className="card p-6 text-center text-ndp-text-muted">{error}</div>;
   }
 
   if (!settings) {
@@ -85,11 +93,7 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
   }
 
   if (!settings.schema || settings.schema.length === 0) {
-    return (
-      <div className="card p-6 text-center text-ndp-text-muted">
-        {t('plugin.no_settings')}
-      </div>
-    );
+    return <div className="card p-6 text-center text-ndp-text-muted">{t('plugin.no_settings')}</div>;
   }
 
   return (
@@ -103,22 +107,15 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
           {field.type === 'boolean' ? (
             <button
               onClick={() => setValues({ ...values, [field.key]: !values[field.key] })}
-              className={`relative w-12 h-6 rounded-full transition-colors ${
-                values[field.key] ? 'bg-ndp-accent' : 'bg-white/10'
-              }`}
+              className={`relative w-12 h-6 rounded-full transition-colors ${values[field.key] ? 'bg-ndp-accent' : 'bg-white/10'}`}
             >
-              <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
-                values[field.key] ? 'translate-x-6' : ''
-              }`} />
+              <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${values[field.key] ? 'translate-x-6' : ''}`} />
             </button>
           ) : (
             <input
               type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
               value={(values[field.key] as string | number) ?? field.default ?? ''}
-              onChange={(e) => setValues({
-                ...values,
-                [field.key]: field.type === 'number' ? Number(e.target.value) : e.target.value,
-              })}
+              onChange={(e) => setValues({ ...values, [field.key]: field.type === 'number' ? Number(e.target.value) : e.target.value })}
               className="w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-sm text-ndp-text focus:outline-none focus:ring-2 focus:ring-ndp-accent/40"
             />
           )}
@@ -137,19 +134,4 @@ export function PluginAdminTab({ pluginId }: PluginAdminTabProps) {
       </button>
     </div>
   );
-
-  async function handleSave() {
-    setSaving(true);
-    setSaved(false);
-    setError(null);
-    try {
-      await api.put(`/plugins/${pluginId}/settings`, values);
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    } catch (err: any) {
-      setError(err.response?.data?.error || t('plugin.save_error'));
-    } finally {
-      setSaving(false);
-    }
-  }
 }

--- a/packages/frontend/src/plugins/PluginErrorBoundary.tsx
+++ b/packages/frontend/src/plugins/PluginErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import React, { Component as ReactComponent } from 'react';
+
+interface Props {
+  pluginId: string;
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class PluginErrorBoundary extends ReactComponent<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(`[Plugin:${this.props.pluginId}] Frontend crashed:`, error.message);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="card p-6 text-center">
+          <p className="text-ndp-error text-sm font-medium">Plugin error</p>
+          <p className="text-ndp-text-dim text-xs mt-1">
+            The plugin "{this.props.pluginId}" encountered an error.
+          </p>
+          {this.state.error && (
+            <p className="text-ndp-text-dim text-xs mt-2 font-mono opacity-60">
+              {this.state.error.message}
+            </p>
+          )}
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            className="mt-3 text-xs text-ndp-accent hover:underline"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/frontend/src/plugins/PluginErrorBoundary.tsx
+++ b/packages/frontend/src/plugins/PluginErrorBoundary.tsx
@@ -18,7 +18,7 @@ export class PluginErrorBoundary extends ReactComponent<Props, State> {
   }
 
   componentDidCatch(error: Error) {
-    console.warn(`[Plugin:${this.props.pluginId}] Frontend crashed:`, error.message);
+    console.warn('[Plugin] Frontend crashed:', this.props.pluginId, error.message);
   }
 
   render() {

--- a/packages/frontend/src/plugins/PluginHookComponent.tsx
+++ b/packages/frontend/src/plugins/PluginHookComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, Component as ReactComponent } from 'react';
 import type { PluginUIContribution } from './types';
+import { loadPluginModule, hasLoaded, getCached, pluginHookUrl } from './pluginModuleCache';
 
 interface Props {
   pluginId: string;
@@ -8,18 +9,6 @@ interface Props {
   contribution: PluginUIContribution;
 }
 
-const componentCache = new Map<string, React.ComponentType<any> | null>();
-
-async function loadPluginModule(pluginId: string, path: string): Promise<React.ComponentType<any> | null> {
-  try {
-    const module = await import(/* @vite-ignore */ `/api/plugins/${pluginId}/frontend/${path}.js`);
-    return module.default || null;
-  } catch {
-    return null;
-  }
-}
-
-// Error boundary — plugin crash never breaks the host app
 class PluginErrorBoundary extends ReactComponent<{ children: React.ReactNode }, { hasError: boolean }> {
   state = { hasError: false };
   static getDerivedStateFromError() { return { hasError: true }; }
@@ -32,42 +21,31 @@ class PluginErrorBoundary extends ReactComponent<{ children: React.ReactNode }, 
   }
 }
 
-function PluginRenderer({ component: Comp, contribution, context }: {
-  component: React.ComponentType<any>;
-  contribution: PluginUIContribution;
-  context: Record<string, unknown>;
-}) {
+export function PluginHookComponent({ pluginId, hookPoint, context, contribution }: Props) {
+  const url = pluginHookUrl(pluginId, hookPoint);
+  const [Comp, setComp] = useState<React.ComponentType<any> | null>(getCached(url));
+  const [ready, setReady] = useState(hasLoaded(url));
+
+  useEffect(() => {
+    if (hasLoaded(url)) {
+      setComp(() => getCached(url));
+      setReady(true);
+      return;
+    }
+    let cancelled = false;
+    loadPluginModule(url).then((loaded) => {
+      if (cancelled) return;
+      if (loaded) setComp(() => loaded);
+      setReady(true);
+    });
+    return () => { cancelled = true; };
+  }, [pluginId, hookPoint, url]);
+
+  if (!ready || !Comp) return null;
+
   return (
     <PluginErrorBoundary>
       <Comp contribution={contribution} context={context} />
     </PluginErrorBoundary>
   );
-}
-
-export function PluginHookComponent({ pluginId, hookPoint, context, contribution }: Props) {
-  const cacheKey = `${pluginId}:${hookPoint}`;
-  const [ready, setReady] = useState(false);
-  const [Comp, setComp] = useState<React.ComponentType<any> | null>(null);
-
-  useEffect(() => {
-    const cached = componentCache.get(cacheKey);
-    if (cached) {
-      setComp(() => cached);
-      setReady(true);
-      return;
-    }
-
-    let cancelled = false;
-    loadPluginModule(pluginId, `hooks/${hookPoint}`).then((loaded) => {
-      if (cancelled) return;
-      componentCache.set(cacheKey, loaded);
-      if (loaded) setComp(() => loaded);
-      setReady(true);
-    });
-    return () => { cancelled = true; };
-  }, [pluginId, hookPoint]);
-
-  if (!ready || !Comp) return null;
-
-  return <PluginRenderer component={Comp} contribution={contribution} context={context} />;
 }

--- a/packages/frontend/src/plugins/PluginPage.tsx
+++ b/packages/frontend/src/plugins/PluginPage.tsx
@@ -1,47 +1,41 @@
 import { useParams } from 'react-router-dom';
-import { useState, useEffect, type ComponentType } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-
-const pageCache = new Map<string, ComponentType<any> | null>();
+import type { ComponentType } from 'react';
+import { loadPluginModule, hasLoaded, getCached, pluginFrontendUrl } from './pluginModuleCache';
 
 export function PluginPage() {
   const { pluginId } = useParams<{ pluginId: string }>();
   const { t } = useTranslation();
-  const [Component, setComponent] = useState<ComponentType<any> | null>(
-    pluginId && pageCache.has(pluginId) ? pageCache.get(pluginId)! : null
-  );
-  const [loading, setLoading] = useState(!pageCache.has(pluginId || ''));
+
+  const url = pluginId ? pluginFrontendUrl(pluginId) : '';
+  const [Component, setComponent] = useState<ComponentType<any> | null>(url ? getCached(url) : null);
+  const [loading, setLoading] = useState(url ? !hasLoaded(url) : false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
-    if (!pluginId || pageCache.has(pluginId)) return;
+    if (!url) return;
+    if (hasLoaded(url)) {
+      setComponent(() => getCached(url));
+      setError(!getCached(url) && hasLoaded(url));
+      setLoading(false);
+      return;
+    }
+
     let cancelled = false;
-
-    import(/* @vite-ignore */ `/api/plugins/${pluginId}/frontend/index.js`)
-      .then((mod) => {
-        if (cancelled) return;
-        const comp = mod.default || null;
-        pageCache.set(pluginId, comp);
-        setComponent(() => comp);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        pageCache.set(pluginId, null);
-        setError(true);
-      })
-      .finally(() => { if (!cancelled) setLoading(false); });
-
+    setLoading(true);
+    loadPluginModule(url).then((comp) => {
+      if (cancelled) return;
+      setComponent(() => comp);
+      setError(!comp);
+      setLoading(false);
+    });
     return () => { cancelled = true; };
-  }, [pluginId]);
+  }, [url]);
 
   if (!pluginId) {
-    return (
-      <div className="flex items-center justify-center h-64 text-ndp-text-muted">
-        {t('plugin.not_found')}
-      </div>
-    );
+    return <div className="flex items-center justify-center h-64 text-ndp-text-muted">{t('plugin.not_found')}</div>;
   }
-
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -49,14 +43,22 @@ export function PluginPage() {
       </div>
     );
   }
-
   if (error || !Component) {
     return (
-      <div className="flex items-center justify-center h-64 text-ndp-text-muted">
-        {t('plugin.frontend_unavailable', { pluginId })}
+      <div className="flex flex-col items-center justify-center h-64 gap-3">
+        <p className="text-ndp-text-muted">{t('plugin.frontend_unavailable', { pluginId })}</p>
+        <button
+          onClick={() => {
+            setError(false);
+            setLoading(true);
+            loadPluginModule(url).then(c => { setComponent(() => c); setError(!c); setLoading(false); });
+          }}
+          className="text-sm text-ndp-accent hover:underline"
+        >
+          Retry
+        </button>
       </div>
     );
   }
-
   return <Component />;
 }

--- a/packages/frontend/src/plugins/PluginPage.tsx
+++ b/packages/frontend/src/plugins/PluginPage.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ComponentType } from 'react';
 import { loadPluginModule, hasLoaded, getCached, pluginFrontendUrl } from './pluginModuleCache';
+import { PluginErrorBoundary } from './PluginErrorBoundary';
 
 export function PluginPage() {
   const { pluginId } = useParams<{ pluginId: string }>();
@@ -60,5 +61,9 @@ export function PluginPage() {
       </div>
     );
   }
-  return <Component />;
+  return (
+    <PluginErrorBoundary pluginId={pluginId}>
+      <Component />
+    </PluginErrorBoundary>
+  );
 }

--- a/packages/frontend/src/plugins/pluginModuleCache.ts
+++ b/packages/frontend/src/plugins/pluginModuleCache.ts
@@ -18,7 +18,7 @@ export async function loadPluginModule(url: string): Promise<ComponentType<any> 
     cache.set(url, { component, loadedAt: Date.now() });
     return component;
   } catch {
-    cache.set(url, { component: null, loadedAt: Date.now() });
+    // Don't cache failures — allow retry on next call
     return null;
   }
 }

--- a/packages/frontend/src/plugins/pluginModuleCache.ts
+++ b/packages/frontend/src/plugins/pluginModuleCache.ts
@@ -1,0 +1,56 @@
+import type { ComponentType } from 'react';
+
+interface CacheEntry {
+  component: ComponentType<any> | null;
+  loadedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Load a plugin ESM module from a URL. Returns the default export as a React component. */
+export async function loadPluginModule(url: string): Promise<ComponentType<any> | null> {
+  const cached = cache.get(url);
+  if (cached) return cached.component;
+
+  try {
+    const mod = await import(/* @vite-ignore */ url);
+    const component = mod.default || null;
+    cache.set(url, { component, loadedAt: Date.now() });
+    return component;
+  } catch {
+    cache.set(url, { component: null, loadedAt: Date.now() });
+    return null;
+  }
+}
+
+/** Check if a URL has been loaded (hit or miss). */
+export function hasLoaded(url: string): boolean {
+  return cache.has(url);
+}
+
+/** Get a previously loaded component (or null). */
+export function getCached(url: string): ComponentType<any> | null {
+  return cache.get(url)?.component ?? null;
+}
+
+/** Invalidate cache for a specific plugin (by pluginId prefix) or all entries. */
+export function invalidate(pluginId?: string): void {
+  if (!pluginId) {
+    cache.clear();
+    return;
+  }
+  const prefix = `/api/plugins/${pluginId}/`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}
+
+/** Build the standard URL for a plugin's main frontend module. */
+export function pluginFrontendUrl(pluginId: string): string {
+  return `/api/plugins/${pluginId}/frontend/index.js`;
+}
+
+/** Build the standard URL for a plugin's hook component. */
+export function pluginHookUrl(pluginId: string, hookPoint: string): string {
+  return `/api/plugins/${pluginId}/frontend/hooks/${hookPoint}.js`;
+}

--- a/packages/frontend/src/plugins/types.ts
+++ b/packages/frontend/src/plugins/types.ts
@@ -1,3 +1,4 @@
+/** UI contribution from a plugin, enriched with pluginId by the engine */
 export interface PluginUIContribution {
   pluginId: string;
   hookPoint: string;
@@ -5,6 +6,7 @@ export interface PluginUIContribution {
   order?: number;
 }
 
+/** Public plugin info as returned by GET /api/plugins/ */
 export interface PluginInfo {
   id: string;
   name: string;

--- a/packages/frontend/src/plugins/usePlugins.ts
+++ b/packages/frontend/src/plugins/usePlugins.ts
@@ -7,14 +7,20 @@ const CACHE_TTL = 60_000;
 
 export function usePluginUI(hookPoint: string) {
   const cached = cache.get(hookPoint);
-  const hasFresh = cached && Date.now() - cached.fetchedAt < CACHE_TTL;
+  const hasFreshOnMount = !!cached && Date.now() - cached.fetchedAt < CACHE_TTL;
 
-  const [contributions, setContributions] = useState<PluginUIContribution[]>(hasFresh ? cached.data : []);
-  const [loading, setLoading] = useState(!hasFresh);
+  const [contributions, setContributions] = useState<PluginUIContribution[]>(hasFreshOnMount ? cached.data : []);
+  const [loading, setLoading] = useState(!hasFreshOnMount);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (hasFresh) return;
+    // Re-check freshness inside the effect to avoid stale closure
+    const entry = cache.get(hookPoint);
+    if (entry && Date.now() - entry.fetchedAt < CACHE_TTL) {
+      setContributions(entry.data);
+      setLoading(false);
+      return;
+    }
 
     let cancelled = false;
     setLoading(true);

--- a/packages/frontend/src/plugins/usePlugins.ts
+++ b/packages/frontend/src/plugins/usePlugins.ts
@@ -3,37 +3,47 @@ import api from '../lib/api';
 import type { PluginUIContribution } from './types';
 
 const cache = new Map<string, { data: PluginUIContribution[]; fetchedAt: number }>();
-const CACHE_TTL = 60_000; // 1 minute
+const CACHE_TTL = 60_000;
 
 export function usePluginUI(hookPoint: string) {
-  const [contributions, setContributions] = useState<PluginUIContribution[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cached = cache.get(hookPoint);
+  const hasFresh = cached && Date.now() - cached.fetchedAt < CACHE_TTL;
+
+  const [contributions, setContributions] = useState<PluginUIContribution[]>(hasFresh ? cached.data : []);
+  const [loading, setLoading] = useState(!hasFresh);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const cached = cache.get(hookPoint);
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) {
-      setContributions(cached.data);
-      setLoading(false);
-      return;
-    }
+    if (hasFresh) return;
 
     let cancelled = false;
+    setLoading(true);
+    setError(null);
+
     api.get<PluginUIContribution[]>(`/plugins/ui/${hookPoint}`)
       .then((res) => {
         if (cancelled) return;
         cache.set(hookPoint, { data: res.data, fetchedAt: Date.now() });
         setContributions(res.data);
       })
-      .catch(() => {
+      .catch((err) => {
         if (cancelled) return;
         setContributions([]);
+        setError(err.message || 'Failed to load plugin contributions');
       })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      .finally(() => { if (!cancelled) setLoading(false); });
 
     return () => { cancelled = true; };
   }, [hookPoint]);
 
-  return { contributions, loading };
+  return { contributions, loading, error };
+}
+
+/** Invalidate the UI contribution cache (e.g. after toggling a plugin). */
+export function invalidatePluginUICache(hookPoint?: string): void {
+  if (hookPoint) {
+    cache.delete(hookPoint);
+  } else {
+    cache.clear();
+  }
 }

--- a/packages/plugins/leonarr
+++ b/packages/plugins/leonarr
@@ -1,0 +1,1 @@
+/Users/quentin/Oscarr/plugin-leonarr

--- a/packages/plugins/radarr
+++ b/packages/plugins/radarr
@@ -1,0 +1,1 @@
+/Users/quentin/Oscarr/plugin-radarr


### PR DESCRIPTION
## Summary

Complete rewrite of the Oscarr plugin system — engine, loader, routes, context factory, admin UI, and documentation. This is the foundation for the plugin ecosystem.

### Refactor (core rewrite)
- **types.ts** — single source of truth for all plugin types, `LoadedUIContribution`, `PluginInfo`
- **loader.ts** — `OSCARR_PLUGINS_DIR` env var, symlink support, thorough manifest validation (hooks shape, settings shape, path traversal check on entry/frontend fields)
- **engine.ts** — Fastify structured logger (no more `console.*`), in-memory settings cache with invalidation, `onInstall` tracked via DB flag (`onInstallRan`), auto-disable plugin on route registration failure
- **routes.ts** — extension whitelist on frontend file serving, module-scope registry cache (30min TTL), `GITHUB_TOKEN` support, path traversal containment tightened to `dist/frontend/`
- **context/** — versioned context factory with `Map<string, ContextFactory>` registry, v1 frozen as current contract, ready for v2 without breaking v1 plugins

### New features
- **Lifecycle hooks** — `onEnable(ctx)` / `onDisable(ctx)` called on plugin toggle (best-effort)
- **Event bus** — `ctx.events.on/off/emit` for inter-plugin pub/sub communication
- **Plugin logs** — captured to `PluginLog` DB table, `GET /api/plugins/:id/logs` endpoint (admin-only)
- **Settings validation** — required fields + type enforcement on save
- **Job stop/resume** — cron jobs automatically stopped when plugin disabled, resumed on enable, runtime guard prevents stale execution
- **Reload plugins** — admin button triggers graceful server restart with full-screen overlay + auto-reconnect
- **Plugin Discover** — registry fetch from GitHub (`arediss/Oscarr-Plugin-Registry`), version update detection with semver comparison
- **@oscarr/sdk** — lightweight frontend SDK via import map (`api`, `apiPost`, `formatSize`, `storageGet`, etc.)
- **Error boundary** — plugin frontend crashes never break the host app

### Security hardening (from 3-reviewer code audit)
- Path traversal blocked in `manifest.entry` and `manifest.frontend` fields
- SSRF blocked: `repository` field validated with regex before GitHub fetch
- RBAC: `/api/plugins/:id/logs` → `admin.plugins`, `/api/admin/restart` → `admin.*` (explicit entries)
- Frontend file serving containment: `dist/frontend/` only (not entire plugin dir)
- React globals namespaced (`__OSCARR_REACT__` etc.)
- `pluginModuleCache` no longer caches failures permanently (allows retry)
- `parseInt` NaN guard on logs limit parameter

### Frontend cleanup
- 3 separate module caches → 1 unified `pluginModuleCache.ts`
- `usePluginUI` stale closure fixed, error state added, `invalidatePluginUICache` export
- `DynamicIcon` explicit registry (tree-shakable, fallback icon on unknown names)
- `AdminPage` plugin tabs memoized, safe prop casts with fallbacks
- `PluginsTab` — deferred registry fetch, shared `PluginInfo` type, `invalidatePluginUICache` after toggle

### Documentation
- `docs/plugins.md` fully updated: all new APIs, lifecycle hooks, event bus, SDK, RBAC via context, updated schema

## Stats
- 32 files changed, +1697 / -381 lines
- 27 commits (each atomic, testable)
- 2 new DB migrations (`onInstallRan`, `PluginLog`)

## Test plan
- [ ] Backend starts, plugins discovered and loaded
- [ ] Plugin toggle works (enable/disable), jobs stop/resume
- [ ] Admin > Plugins > Installed shows plugins with toggle
- [ ] Admin > Plugins > Discover fetches registry, shows available plugins
- [ ] Reload plugins button restarts server and reconnects
- [ ] Plugin with frontend (Radarr) renders admin tab correctly
- [ ] Navigation between plugin tabs doesn't crash (hook order stable)
- [ ] Plugin logs endpoint returns entries (admin only, 403 for regular users)
- [ ] Settings validation rejects invalid/missing required fields
- [ ] Path traversal in manifest.entry is blocked at discovery time

🤖 Generated with [Claude Code](https://claude.com/claude-code)