### PR TITLE
refactor: replace isAdmin with permission-based RBAC in frontend (#99)

### DIFF
--- a/packages/backend/src/middleware/rbac.ts
+++ b/packages/backend/src/middleware/rbac.ts
@@ -171,6 +171,12 @@ export async function invalidateRoleCache(): Promise<void> {
   await loadRolesFromDb();
 }
 
+/** Return the permissions array for a given role name */
+export function getPermissionsForRole(roleName: string): string[] {
+  const permissions = roleCacheReady ? roleCache[roleName] : FALLBACK_ROLES[roleName];
+  return permissions ?? [];
+}
+
 // ── Permission descriptions (for admin UI) ─────────────────────────────────
 const PERMISSION_DESCRIPTIONS: Record<string, string> = {
   'admin.*':           'Full access to the admin panel',

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { logEvent } from '../utils/logEvent.js';
 import { registerEmail, loginEmail } from '../auth/providers/email.js';
 import { getAuthProviders, getAuthProvider, getAuthProviderConfigs } from '../providers/index.js';
 import type { AuthHelpers } from '../providers/types.js';
+import { getPermissionsForRole } from '../middleware/rbac.js';
 
 function buildHelpers(app: FastifyInstance): AuthHelpers {
   return {
@@ -262,7 +263,8 @@ export async function authRoutes(app: FastifyInstance) {
       },
     });
     if (!user) return reply.status(404).send({ error: 'User not found' });
-    return reply.send(user);
+    const permissions = getPermissionsForRole(user.role);
+    return reply.send({ ...user, permissions });
   });
 
   app.post('/logout', async (_request, reply) => {

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -36,7 +36,7 @@ const ALL_NAV = [
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
-  const { user, logout, isAdmin } = useAuth();
+  const { user, logout, hasPermission } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -57,12 +57,12 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     api.get('/app/banner').then(({ data }) => setBanner(data.banner)).catch(() => {});
   }, []);
 
-  // Fetch roles for the "view as" selector (admin only)
+  // Fetch roles for the "view as" selector
   useEffect(() => {
-    if (isAdmin) {
+    if (hasPermission('admin.roles')) {
       api.get('/admin/roles').then(({ data }) => setAvailableRoles(data)).catch(() => {});
     }
-  }, [isAdmin]);
+  }, [hasPermission]);
 
   const startViewAs = (roleName: string) => {
     sessionStorage.setItem('view-as-role', roleName);
@@ -241,7 +241,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               <PluginSlot hookPoint="header.actions" context={{ user }} />
 
               {/* Changelog notification */}
-              {isAdmin && changelog.hasNew && (
+              {hasPermission('admin.*') && changelog.hasNew && (
                 <button
                   onClick={() => { setChangelogOpen(true); changelog.dismiss(); }}
                   className="relative p-2 rounded-xl hover:bg-white/5 transition-colors"
@@ -287,33 +287,32 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                       <p className="text-xs text-ndp-text-dim truncate">{user?.email}</p>
                     </div>
 
-                    {isAdmin && (
-                      <>
-                        <Link
-                          to="/admin"
-                          className="flex items-center gap-2.5 px-4 py-2.5 text-sm text-ndp-text-muted hover:text-ndp-accent hover:bg-white/5 transition-colors"
-                        >
-                          <Shield className="w-4 h-4" />
-                          {t('nav.admin')}
-                        </Link>
+                    {hasPermission('admin.*') && (
+                      <Link
+                        to="/admin"
+                        className="flex items-center gap-2.5 px-4 py-2.5 text-sm text-ndp-text-muted hover:text-ndp-accent hover:bg-white/5 transition-colors"
+                      >
+                        <Shield className="w-4 h-4" />
+                        {t('nav.admin')}
+                      </Link>
+                    )}
 
-                        {/* View as role selector */}
-                        <div className="px-4 py-2 border-t border-white/5">
-                          <div className="flex items-center gap-2.5">
-                            <Eye className="w-4 h-4 text-ndp-text-dim flex-shrink-0" />
-                            <select
-                              value={viewAsRole || ''}
-                              onChange={(e) => e.target.value ? startViewAs(e.target.value) : stopViewAs()}
-                              className="flex-1 bg-white/5 border border-white/10 rounded-lg text-sm text-ndp-text px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-purple-500/40 cursor-pointer appearance-none"
-                            >
-                              <option value="">{t('admin.view_as.off', 'View as role...')}</option>
-                              {availableRoles.filter(r => r.name !== 'admin').map(r => (
-                                <option key={r.name} value={r.name}>{r.name}</option>
-                              ))}
-                            </select>
-                          </div>
+                    {hasPermission('admin.roles') && (
+                      <div className="px-4 py-2 border-t border-white/5">
+                        <div className="flex items-center gap-2.5">
+                          <Eye className="w-4 h-4 text-ndp-text-dim flex-shrink-0" />
+                          <select
+                            value={viewAsRole || ''}
+                            onChange={(e) => e.target.value ? startViewAs(e.target.value) : stopViewAs()}
+                            className="flex-1 bg-white/5 border border-white/10 rounded-lg text-sm text-ndp-text px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-purple-500/40 cursor-pointer appearance-none"
+                          >
+                            <option value="">{t('admin.view_as.off', 'View as role...')}</option>
+                            {availableRoles.filter(r => r.name !== 'admin').map(r => (
+                              <option key={r.name} value={r.name}>{r.name}</option>
+                            ))}
+                          </select>
                         </div>
-                      </>
+                      </div>
                     )}
 
                     <div className="px-4 py-2.5 border-t border-white/5">
@@ -334,7 +333,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                     </div>
 
                     {/* Plugin hook: avatar menu */}
-                    <PluginSlot hookPoint="avatar.menu" context={{ user, isAdmin }} />
+                    <PluginSlot hookPoint="avatar.menu" context={{ user, isAdmin: hasPermission('admin.*'), hasPermission }} />
 
                     <button
                       onClick={handleLogout}
@@ -411,7 +410,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                   </Link>
                 )}
               />
-              {isAdmin && (
+              {hasPermission('admin.*') && (
                 <Link
                   to="/admin"
                   onClick={() => setMobileMenuOpen(false)}

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -58,11 +58,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   }, []);
 
   // Fetch roles for the "view as" selector
+  const canManageRoles = hasPermission('admin.roles');
+
   useEffect(() => {
-    if (hasPermission('admin.roles')) {
+    if (canManageRoles) {
       api.get('/admin/roles').then(({ data }) => setAvailableRoles(data)).catch(() => {});
     }
-  }, [hasPermission]);
+  }, [canManageRoles]);
 
   const startViewAs = (roleName: string) => {
     sessionStorage.setItem('view-as-role', roleName);
@@ -238,7 +240,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               </button>
 
               {/* Plugin hook: header actions */}
-              <PluginSlot hookPoint="header.actions" context={{ user }} />
+              <PluginSlot hookPoint="header.actions" context={{ user, isAdmin: hasPermission('admin.*'), hasPermission }} />
 
               {/* Changelog notification */}
               {hasPermission('admin.*') && changelog.hasNew && (

--- a/packages/frontend/src/context/AuthContext.tsx
+++ b/packages/frontend/src/context/AuthContext.tsx
@@ -5,7 +5,7 @@ import type { User } from '@/types';
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  login: (token: string, user: User) => void;
+  login: (token: string, user: User) => Promise<void>;
   logout: () => Promise<void>;
   isAdmin: boolean;
   hasAccess: boolean;
@@ -38,10 +38,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     fetchUser();
   }, [fetchUser]);
 
-  const login = (_token: string, userData: User) => {
+  const login = useCallback(async (_token: string, userData: User) => {
     // Token is now stored exclusively in httpOnly cookie by the backend
     setUser(userData);
-  };
+    // Fetch full user data including permissions
+    try {
+      const { data } = await api.get('/auth/me');
+      const { permissions: perms = [], ...rest } = data;
+      setUser(rest);
+      setPermissions(perms);
+    } catch {
+      // Fallback: user is set but permissions will be empty until next page load
+    }
+  }, []);
 
   const logout = async () => {
     try {
@@ -51,7 +60,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const hasPermission = useCallback((permission: string): boolean => {
-    if (!user) return false;
+    if (permissions.length === 0) return false;
     // Admin wildcard
     if (permissions.includes('*')) return true;
     // Exact match
@@ -63,9 +72,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (permissions.includes(wildcard)) return true;
     }
     return false;
-  }, [user, permissions]);
+  }, [permissions]);
 
-  const isAdmin = permissions.includes('*') || user?.role === 'admin';
+  const isAdmin = hasPermission('admin.*');
   const hasAccess = isAdmin || (user?.providers ?? []).length > 0;
 
   return (

--- a/packages/frontend/src/context/AuthContext.tsx
+++ b/packages/frontend/src/context/AuthContext.tsx
@@ -9,6 +9,8 @@ interface AuthContextType {
   logout: () => Promise<void>;
   isAdmin: boolean;
   hasAccess: boolean;
+  permissions: string[];
+  hasPermission: (permission: string) => boolean;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -16,13 +18,17 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [permissions, setPermissions] = useState<string[]>([]);
 
   const fetchUser = useCallback(async () => {
     try {
       const { data } = await api.get('/auth/me');
-      setUser(data);
+      const { permissions: perms = [], ...userData } = data;
+      setUser(userData);
+      setPermissions(perms);
     } catch {
       setUser(null);
+      setPermissions([]);
     } finally {
       setLoading(false);
     }
@@ -44,13 +50,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   };
 
-  const isAdmin = user?.role === 'admin';
+  const hasPermission = useCallback((permission: string): boolean => {
+    if (!user) return false;
+    // Admin wildcard
+    if (permissions.includes('*')) return true;
+    // Exact match
+    if (permissions.includes(permission)) return true;
+    // Wildcard match: 'admin.*' matches 'admin.users', 'admin.roles', etc.
+    const parts = permission.split('.');
+    for (let i = parts.length - 1; i > 0; i--) {
+      const wildcard = parts.slice(0, i).join('.') + '.*';
+      if (permissions.includes(wildcard)) return true;
+    }
+    return false;
+  }, [user, permissions]);
+
+  const isAdmin = permissions.includes('*') || user?.role === 'admin';
   const hasAccess = isAdmin || (user?.providers ?? []).length > 0;
 
   return (
     <AuthContext.Provider value={{
       user, loading, login, logout,
-      isAdmin, hasAccess,
+      isAdmin, hasAccess, permissions, hasPermission,
     }}>
       {children}
     </AuthContext.Provider>

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -49,7 +49,7 @@ const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
 
 export default function AdminPage() {
   const { t } = useTranslation();
-  const { isAdmin } = useAuth();
+  const { hasPermission } = useAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { contributions: pluginTabs } = usePluginUI('admin.tabs');
@@ -82,7 +82,7 @@ export default function AdminPage() {
     setSearchParams({ tab }, { replace: true });
   };
 
-  if (!isAdmin) { navigate('/'); return null; }
+  if (!hasPermission('admin.*')) { navigate('/'); return null; }
 
   const activePluginTab = activeTab.startsWith('plugin:') ? activeTab.replace('plugin:', '') : null;
 

--- a/packages/frontend/src/pages/AdminPage.tsx
+++ b/packages/frontend/src/pages/AdminPage.tsx
@@ -49,7 +49,7 @@ const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
 
 export default function AdminPage() {
   const { t } = useTranslation();
-  const { hasPermission } = useAuth();
+  const { user, hasPermission } = useAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { contributions: pluginTabs } = usePluginUI('admin.tabs');
@@ -82,6 +82,7 @@ export default function AdminPage() {
     setSearchParams({ tab }, { replace: true });
   };
 
+  if (!user) return null; // still loading
   if (!hasPermission('admin.*')) { navigate('/'); return null; }
 
   const activePluginTab = activeTab.startsWith('plugin:') ? activeTab.replace('plugin:', '') : null;

--- a/packages/frontend/src/pages/InstallPage.tsx
+++ b/packages/frontend/src/pages/InstallPage.tsx
@@ -80,7 +80,7 @@ export default function InstallPage() {
       const { data } = await api.post('/auth/register', {
         email: adminEmail, password: adminPassword, displayName: adminDisplayName,
       });
-      login('', data.user);
+      await login('', data.user);
       setStep(2);
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
     setError('');
     try {
       const { data } = await api.post(`/auth/${providerId}/login`, { username: credUsername, password: credPassword });
-      login('', data.user);
+      await login('', data.user);
       navigate('/', { replace: true });
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
@@ -64,7 +64,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       const { data } = await api.post('/auth/login', { email, password });
-      login('', data.user);
+      await login('', data.user);
       navigate('/', { replace: true });
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
@@ -84,7 +84,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       const { data } = await api.post('/auth/register', { email, password, displayName });
-      login('', data.user);
+      await login('', data.user);
       navigate('/', { replace: true });
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;

--- a/packages/frontend/src/pages/MessagesPage.tsx
+++ b/packages/frontend/src/pages/MessagesPage.tsx
@@ -37,7 +37,7 @@ interface TicketMsg {
 
 export default function MessagesPage() {
   const { t } = useTranslation();
-  const { user, isAdmin } = useAuth();
+  const { user, hasPermission } = useAuth();
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [activeTicket, setActiveTicket] = useState<Ticket | null>(null);
   const [messages, setMessages] = useState<TicketMsg[]>([]);
@@ -218,7 +218,7 @@ export default function MessagesPage() {
                       <p className="text-sm font-medium text-ndp-text truncate">{ticket.subject}</p>
                       <span className="text-[10px] text-ndp-text-dim flex-shrink-0">{formatTime(ticket.createdAt)}</span>
                     </div>
-                    {isAdmin && (
+                    {hasPermission('support.manage') && (
                       <p className="text-[11px] text-ndp-accent mt-0.5">{ticket.user.displayName}</p>
                     )}
                     {ticket.lastMessage && (
@@ -242,10 +242,10 @@ export default function MessagesPage() {
                 <p className="text-sm font-semibold text-ndp-text truncate">{activeTicket.subject}</p>
                 <p className="text-[11px] text-ndp-text-dim">
                   {activeTicket.status === 'open' ? t('messages.open') : t('messages.closed')}
-                  {isAdmin && ` · ${activeTicket.user.displayName}`}
+                  {hasPermission('support.manage') && ` · ${activeTicket.user.displayName}`}
                 </p>
               </div>
-              {isAdmin && (
+              {hasPermission('support.manage') && (
                 <button
                   onClick={() => toggleTicketStatus(activeTicket)}
                   className={clsx('text-xs px-3 py-1 rounded-lg transition-colors',

--- a/packages/frontend/src/pages/RequestsPage.tsx
+++ b/packages/frontend/src/pages/RequestsPage.tsx
@@ -58,7 +58,7 @@ const FILTER_TABS = [
 
 export default function RequestsPage() {
   const { t } = useTranslation();
-  const { isAdmin } = useAuth();
+  const { hasPermission } = useAuth();
   const [requests, setRequests] = useState<MediaRequest[]>([]);
   const [stats, setStats] = useState<RequestStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -83,7 +83,7 @@ export default function RequestsPage() {
   useEffect(() => {
     api.get('/requests/stats').then(({ data }) => setStats(data)).catch(() => {});
     api.get('/app/quality-options').then(({ data }) => setQualityOptions(data)).catch(() => {});
-    if (isAdmin) api.get('/admin/users').then(({ data }) => setUsers(data.map((u: { id: number; displayName: string; email: string }) => ({ id: u.id, displayName: u.displayName || u.email })))).catch(() => {});
+    if (hasPermission('admin.*')) api.get('/admin/users').then(({ data }) => setUsers(data.map((u: { id: number; displayName: string; email: string }) => ({ id: u.id, displayName: u.displayName || u.email })))).catch(() => {});
   }, []);
 
   const fetchRequests = useCallback(async (pageNum: number, append = false) => {
@@ -174,7 +174,7 @@ export default function RequestsPage() {
       <div className="mb-8">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl font-bold text-ndp-text">{t('requests.title')}</h1>
-          {isAdmin && stats && (stats.available > 0 || stats.approved > 0 || stats.declined > 0) && (
+          {hasPermission('admin.danger') && stats && (stats.available > 0 || stats.approved > 0 || stats.declined > 0) && (
             <button
               onClick={() => { setShowCleanup(true); setCleanupActions({}); setCleanupResult(null); }}
               className="text-xs text-ndp-text-dim hover:text-ndp-text flex items-center gap-1.5 hover:bg-white/5 px-3 py-1.5 rounded-lg transition-colors"
@@ -215,8 +215,8 @@ export default function RequestsPage() {
             })}
           </div>
 
-          {/* Advanced filters (admin only) */}
-          {isAdmin && (
+          {/* Advanced filters */}
+          {hasPermission('requests.approve') && (
             <RequestFilters
               filterUser={filterUser} setFilterUser={setFilterUser}
               filterMediaType={filterMediaType} setFilterMediaType={setFilterMediaType}
@@ -258,7 +258,7 @@ export default function RequestsPage() {
                       </h2>
                       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
                         {pendingRequests.map((req, index) => (
-                          <RequestCard key={req.id} request={req} isAdmin={isAdmin} actionLoading={actionLoading} onAction={handleAction} onDelete={handleDelete} qualityOptions={qualityOptions} index={index} />
+                          <RequestCard key={req.id} request={req} canApprove={hasPermission('requests.approve')} canDecline={hasPermission('requests.decline')} actionLoading={actionLoading} onAction={handleAction} onDelete={handleDelete} qualityOptions={qualityOptions} index={index} />
                         ))}
                       </div>
                     </div>
@@ -273,7 +273,7 @@ export default function RequestsPage() {
                       )}
                       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
                         {otherRequests.map((req, index) => (
-                          <RequestCard key={req.id} request={req} isAdmin={isAdmin} actionLoading={actionLoading} onAction={handleAction} onDelete={handleDelete} qualityOptions={qualityOptions} index={index} />
+                          <RequestCard key={req.id} request={req} canApprove={hasPermission('requests.approve')} canDecline={hasPermission('requests.decline')} actionLoading={actionLoading} onAction={handleAction} onDelete={handleDelete} qualityOptions={qualityOptions} index={index} />
                         ))}
                       </div>
                     </div>
@@ -391,7 +391,8 @@ export default function RequestsPage() {
 
 function RequestCard({
   request: req,
-  isAdmin,
+  canApprove,
+  canDecline,
   actionLoading,
   onAction,
   onDelete,
@@ -399,7 +400,8 @@ function RequestCard({
   index,
 }: {
   request: MediaRequest;
-  isAdmin: boolean;
+  canApprove: boolean;
+  canDecline?: boolean;
   actionLoading: number | null;
   onAction: (id: number, action: 'approve' | 'decline', qualityOptionId?: number) => void;
   onDelete: (id: number) => void;
@@ -523,7 +525,7 @@ function RequestCard({
       {/* Bottom action bar */}
       {isPending && (
         <div className="absolute bottom-2 left-2 right-[108px] z-10 flex items-center bg-white/[0.03] backdrop-blur-2xl border border-white/[0.07] rounded-xl" onClick={(e) => e.preventDefault()}>
-          {isAdmin ? (
+          {canApprove ? (
             <>
               <button
                 onClick={(e) => { e.preventDefault(); onAction(req.id, 'approve', selectedQuality); }}
@@ -533,15 +535,19 @@ function RequestCard({
                 {actionLoading === req.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <CheckCircle className="w-3.5 h-3.5" />}
                 {t('requests.approve')}
               </button>
-              <div className="w-px h-5 bg-white/10" />
-              <button
-                onClick={(e) => { e.preventDefault(); onAction(req.id, 'decline'); }}
-                disabled={actionLoading === req.id}
-                className="flex-1 flex items-center justify-center gap-1.5 py-2 text-ndp-danger hover:bg-ndp-danger/10 transition-colors text-xs font-medium"
-              >
-                <XCircle className="w-3.5 h-3.5" />
-                {t('requests.decline')}
-              </button>
+              {canDecline && (
+                <>
+                  <div className="w-px h-5 bg-white/10" />
+                  <button
+                    onClick={(e) => { e.preventDefault(); onAction(req.id, 'decline'); }}
+                    disabled={actionLoading === req.id}
+                    className="flex-1 flex items-center justify-center gap-1.5 py-2 text-ndp-danger hover:bg-ndp-danger/10 transition-colors text-xs font-medium"
+                  >
+                    <XCircle className="w-3.5 h-3.5" />
+                    {t('requests.decline')}
+                  </button>
+                </>
+              )}
               <div className="w-px h-5 bg-white/10" />
               <button
                 onClick={(e) => {

--- a/packages/frontend/src/pages/RequestsPage.tsx
+++ b/packages/frontend/src/pages/RequestsPage.tsx
@@ -80,11 +80,13 @@ export default function RequestsPage() {
   const [cleanupLoading, setCleanupLoading] = useState(false);
   const [cleanupResult, setCleanupResult] = useState<{ oscarr: number; service: number } | null>(null);
 
+  const canAccessAdmin = hasPermission('admin.*');
+
   useEffect(() => {
     api.get('/requests/stats').then(({ data }) => setStats(data)).catch(() => {});
     api.get('/app/quality-options').then(({ data }) => setQualityOptions(data)).catch(() => {});
-    if (hasPermission('admin.*')) api.get('/admin/users').then(({ data }) => setUsers(data.map((u: { id: number; displayName: string; email: string }) => ({ id: u.id, displayName: u.displayName || u.email })))).catch(() => {});
-  }, []);
+    if (canAccessAdmin) api.get('/admin/users').then(({ data }) => setUsers(data.map((u: { id: number; displayName: string; email: string }) => ({ id: u.id, displayName: u.displayName || u.email })))).catch(() => {});
+  }, [canAccessAdmin]);
 
   const fetchRequests = useCallback(async (pageNum: number, append = false) => {
     if (!append) setFiltering(true);


### PR DESCRIPTION
## Summary

Replaces ALL `isAdmin` boolean checks in the frontend with granular `hasPermission()` calls backed by the backend RBAC system. Custom roles (Moderator, Curator, Support Manager) now work properly in the UI.

### Backend
- `GET /auth/me` now returns `permissions: string[]` resolved from the user's role
- New export `getPermissionsForRole()` in RBAC middleware

### Frontend — AuthContext
- `permissions: string[]` stored in context from `/auth/me` response
- `hasPermission(permission)` — supports exact match, `*` wildcard, prefix wildcards (`admin.*`)
- `isAdmin` kept for backward compat but now derived purely from `hasPermission('admin.*')`
- `login()` fetches permissions immediately after auth (no stale empty state)

### Frontend — Permission mapping

| Before | After | Component |
|---|---|---|
| `isAdmin` (approve/decline) | `hasPermission('requests.approve')` / `hasPermission('requests.decline')` | RequestsPage |
| `isAdmin` (cleanup) | `hasPermission('admin.danger')` | RequestsPage |
| `isAdmin` (filters) | `hasPermission('requests.approve')` | RequestsPage |
| `isAdmin` (admin guard) | `hasPermission('admin.*')` | AdminPage |
| `isAdmin` (admin nav) | `hasPermission('admin.*')` | Layout |
| `isAdmin` (changelog) | `hasPermission('admin.*')` | Layout |
| `isAdmin` (view-as-role) | `hasPermission('admin.roles')` | Layout |
| `isAdmin` (ticket mgmt) | `hasPermission('support.manage')` | MessagesPage |

### Code review fixes included
- `login()` now fetches `/auth/me` to populate permissions immediately
- `isAdmin` no longer falls back to `user.role === 'admin'`
- Stable boolean deps in useEffects (no function reference churn)
- `header.actions` plugin slot receives permission context
- AdminPage guard handles loading state

## Stats
- 9 files changed, +119 / -71 lines
- Zero `isAdmin` remaining in frontend

## Test plan
- [ ] Admin user sees all admin features after login (no hard reload needed)
- [ ] Moderator role with `requests.approve` sees approve button but NOT admin panel
- [ ] Support manager with `support.manage` sees ticket requester names + close button
- [ ] User with no special permissions sees only their own requests + delete button
- [ ] Plugin hook contexts receive `hasPermission` and `isAdmin`
- [ ] Role change mid-session reflects after re-login

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)