### PR TITLE
refactor: replace detail page action button ternary chain with state machine (#107)

### DIFF
--- a/packages/frontend/src/components/ActionButton.tsx
+++ b/packages/frontend/src/components/ActionButton.tsx
@@ -10,7 +10,7 @@ interface ActionButtonProps {
   blacklistReason?: string;
   onRequest: () => void;
   onSearchMissing: () => void;
-  t: (key: string) => string;
+  t: (key: string, options?: Record<string, unknown>) => string;
 }
 
 export default function ActionButton({
@@ -102,7 +102,7 @@ export default function ActionButton({
     case 'partially_error':
       return (
         <button disabled className="btn-danger flex items-center gap-2 cursor-default text-sm">
-          {searchMissingError}
+          {searchMissingError || t('common.error')}
         </button>
       );
 

--- a/packages/frontend/src/components/ActionButton.tsx
+++ b/packages/frontend/src/components/ActionButton.tsx
@@ -1,0 +1,141 @@
+import { Check, Plus, Loader2, Clock, ShieldAlert } from 'lucide-react';
+import type { ButtonState } from '@/utils/resolveButtonState';
+
+interface ActionButtonProps {
+  state: ButtonState;
+  requesting: boolean;
+  justRequested: boolean;
+  download?: { progress: number; timeLeft?: string } | null;
+  searchMissingError?: string;
+  blacklistReason?: string;
+  onRequest: () => void;
+  onSearchMissing: () => void;
+  t: (key: string) => string;
+}
+
+export default function ActionButton({
+  state,
+  requesting,
+  justRequested,
+  download,
+  searchMissingError,
+  blacklistReason,
+  onRequest,
+  onSearchMissing,
+  t,
+}: ActionButtonProps) {
+  switch (state) {
+    case 'available':
+      return (
+        <button disabled className="btn-success flex items-center gap-2 cursor-default">
+          <Check className="w-4 h-4" />
+          {t('status.available')}
+        </button>
+      );
+
+    case 'can_request_quality':
+      return (
+        <button
+          onClick={onRequest}
+          disabled={requesting}
+          className="btn-primary flex items-center gap-2"
+        >
+          {requesting ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Plus className="w-4 h-4" />
+          )}
+          {t('media.request')}
+        </button>
+      );
+
+    case 'downloading':
+      return (
+        <button disabled className="relative overflow-hidden rounded-xl px-5 py-2.5 text-sm font-medium text-white cursor-default min-w-[180px]">
+          <div
+            className="absolute inset-0 bg-ndp-accent/80 transition-all duration-1000 ease-out"
+            style={{ width: `${download?.progress ?? 0}%` }}
+          />
+          <div className="absolute inset-0 bg-white/5" />
+          <div className="relative flex items-center justify-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>{Math.round(download?.progress ?? 0)}%</span>
+            {download?.timeLeft && download.timeLeft !== '00:00:00' && (
+              <span className="text-xs opacity-70">— {download.timeLeft.replace(/^0+:?/, '')}</span>
+            )}
+          </div>
+        </button>
+      );
+
+    case 'upcoming':
+      return (
+        <button disabled className="btn-secondary flex items-center gap-2 cursor-default opacity-60">
+          <Clock className="w-4 h-4" />
+          {t('status.upcoming')}
+        </button>
+      );
+
+    case 'searching':
+      return (
+        <button disabled className="btn-secondary flex items-center gap-2 cursor-default opacity-60">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          {t('status.searching_long')}
+        </button>
+      );
+
+    case 'already_requested':
+      return (
+        <button disabled className="btn-success flex items-center gap-2 cursor-default">
+          <Check className="w-4 h-4" />
+          {justRequested ? t('status.request_sent') : t('status.already_requested')}
+        </button>
+      );
+
+    case 'partially_searching':
+      return (
+        <button disabled className="btn-success flex items-center gap-2 cursor-default">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          {t('media.search_missing_in_progress')}
+        </button>
+      );
+
+    case 'partially_error':
+      return (
+        <button disabled className="btn-danger flex items-center gap-2 cursor-default text-sm">
+          {searchMissingError}
+        </button>
+      );
+
+    case 'partially_available':
+      return (
+        <button
+          onClick={onSearchMissing}
+          disabled={requesting}
+          className="btn-primary flex items-center gap-2"
+        >
+          {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+          {t('media.request_rest')}
+        </button>
+      );
+
+    case 'blocked':
+      return (
+        <button disabled className="btn-secondary flex items-center gap-2 cursor-not-allowed opacity-60" title={blacklistReason || undefined}>
+          <ShieldAlert className="w-4 h-4 text-ndp-danger" />
+          {t('media.blocked')}
+        </button>
+      );
+
+    case 'can_request':
+      return (
+        <button
+          onClick={onRequest}
+          disabled={requesting}
+          className="btn-primary flex items-center gap-2"
+        >
+          {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+          {t('media.request')}
+        </button>
+      );
+  }
+}

--- a/packages/frontend/src/pages/MediaDetailPage.tsx
+++ b/packages/frontend/src/pages/MediaDetailPage.tsx
@@ -5,7 +5,6 @@ import {
   Star,
   Calendar,
   Clock,
-  Plus,
   Check,
   Loader2,
   ArrowLeft,
@@ -33,6 +32,8 @@ import { useMediaRequestActions } from '@/hooks/useMediaRequestActions';
 import { useEpisodeModal } from '@/hooks/useEpisodeModal';
 import type { TmdbMedia, Media, TmdbCast, TmdbCrew } from '@/types';
 import { ACTIVE_REQUEST_STATUSES } from '@/utils/requestStatus';
+import { resolveButtonState } from '@/utils/resolveButtonState';
+import ActionButton from '@/components/ActionButton';
 
 interface Props {
   type: 'movie' | 'tv';
@@ -102,6 +103,18 @@ export default function MediaDetailPage({ type }: Props) {
   ]);
   const userHasRequest = activeRequests.some(r => r.user?.id === user?.id);
   const canRequestNewQuality = selectedQuality != null && !takenQualityIds.has(selectedQuality);
+
+  const buttonState = resolveButtonState({
+    isAvailable,
+    isPartiallyAvailable,
+    isDownloading,
+    isUpcoming,
+    isSearching,
+    userHasRequest,
+    canRequestNewQuality,
+    blacklisted: blacklisted?.blocked ?? false,
+    searchMissingState,
+  });
 
   if (loading) {
     return (
@@ -256,98 +269,17 @@ export default function MediaDetailPage({ type }: Props) {
                 </a>
               )}
 
-              {isAvailable && !canRequestNewQuality ? (
-                <button disabled className="btn-success flex items-center gap-2 cursor-default">
-                  <Check className="w-4 h-4" />
-                  {t('status.available')}
-                </button>
-              ) : isAvailable && canRequestNewQuality ? (
-                <button
-                  onClick={handleRequest}
-                  disabled={requesting}
-                  className="btn-primary flex items-center gap-2"
-                >
-                  {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-                  {t('media.request')}
-                </button>
-              ) : isDownloading ? (
-                <button disabled className="relative overflow-hidden rounded-xl px-5 py-2.5 text-sm font-medium text-white cursor-default min-w-[180px]">
-                  <div
-                    className="absolute inset-0 bg-ndp-accent/80 transition-all duration-1000 ease-out"
-                    style={{ width: `${download.progress}%` }}
-                  />
-                  <div className="absolute inset-0 bg-white/5" />
-                  <div className="relative flex items-center justify-center gap-2">
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>{Math.round(download.progress)}%</span>
-                    {download.timeLeft && download.timeLeft !== '00:00:00' && (
-                      <span className="text-xs opacity-70">— {download.timeLeft.replace(/^0+:?/, '')}</span>
-                    )}
-                  </div>
-                </button>
-              ) : isUpcoming ? (
-                <button disabled className="btn-secondary flex items-center gap-2 cursor-default opacity-60">
-                  <Clock className="w-4 h-4" />
-                  {t('status.upcoming')}
-                </button>
-              ) : isSearching ? (
-                <button disabled className="btn-secondary flex items-center gap-2 cursor-default opacity-60">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  {t('status.searching_long')}
-                </button>
-              ) : canRequestNewQuality ? (
-                <button
-                  onClick={handleRequest}
-                  disabled={requesting}
-                  className="btn-primary flex items-center gap-2"
-                >
-                  {requesting ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  ) : (
-                    <Plus className="w-4 h-4" />
-                  )}
-                  {t('media.request')}
-                </button>
-              ) : userHasRequest && !canRequestNewQuality && !isPartiallyAvailable ? (
-                <button disabled className="btn-success flex items-center gap-2 cursor-default">
-                  <Check className="w-4 h-4" />
-                  {justRequested ? t('status.request_sent') : t('status.already_requested')}
-                </button>
-              ) : isPartiallyAvailable ? (
-                searchMissingState === 'searching' ? (
-                  <button disabled className="btn-success flex items-center gap-2 cursor-default">
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    {t('media.search_missing_in_progress')}
-                  </button>
-                ) : searchMissingState === 'error' ? (
-                  <button disabled className="btn-danger flex items-center gap-2 cursor-default text-sm">
-                    {searchMissingError}
-                  </button>
-                ) : (
-                  <button
-                    onClick={handleSearchMissing}
-                    disabled={requesting}
-                    className="btn-primary flex items-center gap-2"
-                  >
-                    {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-                    {t('media.request_rest')}
-                  </button>
-                )
-              ) : blacklisted.blocked ? (
-                <button disabled className="btn-secondary flex items-center gap-2 cursor-not-allowed opacity-60" title={blacklisted.reason || undefined}>
-                  <ShieldAlert className="w-4 h-4 text-ndp-danger" />
-                  {t('media.blocked')}
-                </button>
-              ) : (
-                <button
-                  onClick={handleRequest}
-                  disabled={requesting}
-                  className="btn-primary flex items-center gap-2"
-                >
-                  {requesting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-                  {t('media.request')}
-                </button>
-              )}
+              <ActionButton
+                state={buttonState}
+                requesting={requesting}
+                justRequested={justRequested}
+                download={download ? { progress: download.progress, timeLeft: download.timeLeft } : null}
+                searchMissingError={searchMissingError}
+                blacklistReason={blacklisted?.reason ?? undefined}
+                onRequest={handleRequest}
+                onSearchMissing={handleSearchMissing}
+                t={t}
+              />
 
               {/* Request error message */}
               {requestError && (

--- a/packages/frontend/src/utils/resolveButtonState.ts
+++ b/packages/frontend/src/utils/resolveButtonState.ts
@@ -33,11 +33,14 @@ export function resolveButtonState(inputs: ButtonStateInputs): ButtonState {
   // Priority order matches the original ternary chain exactly
   if (isAvailable && !canRequestNewQuality) return 'available';
   if (isAvailable && canRequestNewQuality) return 'can_request_quality';
+  // Note: canRequestNewQuality is intentionally checked AFTER isDownloading/isUpcoming/isSearching
+  // to match the original behavior. A future improvement could allow quality requests during these states.
   if (isDownloading) return 'downloading';
   if (isUpcoming) return 'upcoming';
   if (isSearching) return 'searching';
   if (canRequestNewQuality) return 'can_request_quality';
-  if (userHasRequest && !canRequestNewQuality && !isPartiallyAvailable) return 'already_requested';
+  // canRequestNewQuality is always false here (already returned above if true)
+  if (userHasRequest && !isPartiallyAvailable) return 'already_requested';
   if (isPartiallyAvailable) {
     if (searchMissingState === 'searching') return 'partially_searching';
     if (searchMissingState === 'error') return 'partially_error';

--- a/packages/frontend/src/utils/resolveButtonState.ts
+++ b/packages/frontend/src/utils/resolveButtonState.ts
@@ -1,0 +1,48 @@
+export type ButtonState =
+  | 'available'
+  | 'can_request_quality'
+  | 'downloading'
+  | 'upcoming'
+  | 'searching'
+  | 'already_requested'
+  | 'partially_available'
+  | 'partially_searching'
+  | 'partially_error'
+  | 'blocked'
+  | 'can_request';
+
+export interface ButtonStateInputs {
+  isAvailable: boolean;
+  isPartiallyAvailable: boolean;
+  isDownloading: boolean;
+  isUpcoming: boolean;
+  isSearching: boolean;
+  userHasRequest: boolean;
+  canRequestNewQuality: boolean;
+  blacklisted: boolean;
+  searchMissingState: 'idle' | 'searching' | 'error';
+}
+
+export function resolveButtonState(inputs: ButtonStateInputs): ButtonState {
+  const {
+    isAvailable, isPartiallyAvailable, isDownloading, isUpcoming,
+    isSearching, userHasRequest, canRequestNewQuality, blacklisted,
+    searchMissingState,
+  } = inputs;
+
+  // Priority order matches the original ternary chain exactly
+  if (isAvailable && !canRequestNewQuality) return 'available';
+  if (isAvailable && canRequestNewQuality) return 'can_request_quality';
+  if (isDownloading) return 'downloading';
+  if (isUpcoming) return 'upcoming';
+  if (isSearching) return 'searching';
+  if (canRequestNewQuality) return 'can_request_quality';
+  if (userHasRequest && !canRequestNewQuality && !isPartiallyAvailable) return 'already_requested';
+  if (isPartiallyAvailable) {
+    if (searchMissingState === 'searching') return 'partially_searching';
+    if (searchMissingState === 'error') return 'partially_error';
+    return 'partially_available';
+  }
+  if (blacklisted) return 'blocked';
+  return 'can_request';
+}


### PR DESCRIPTION
## Summary

Replaces the 90-line nested ternary chain for the media detail page action button with an explicit state machine — a pure function + a dedicated component.

### New files
- **`resolveButtonState.ts`** — pure function, no React. Maps 9 boolean inputs to 1 of 11 `ButtonState` values. Testable, documented, no side effects.
- **`ActionButton.tsx`** — renders each `ButtonState` with its exact styling, icon, label, and behavior. Switch statement, one case per state.

### What changed in MediaDetailPage
- **Removed:** 90 lines of nested ternary conditions (lines 259-350)
- **Added:** 2 lines — `resolveButtonState(inputs)` + `<ActionButton state={buttonState} />`
- Net: **+214 / -93 lines** (new files + simplified page)

### Button states (11)

| State | Trigger | Button |
|---|---|---|
| `available` | Media fully available | Green "Available" (disabled) |
| `can_request_quality` | Available but user selected new quality | "Request" (actionable) |
| `downloading` | In download queue | Progress bar with % + ETA |
| `upcoming` | Not released yet | "Upcoming" (disabled) |
| `searching` | Searching indexers | "Searching..." (disabled) |
| `already_requested` | User has active request | "Already requested" (disabled) |
| `partially_available` | TV: some episodes available | "Request rest" (actionable) |
| `partially_searching` | Searching for missing episodes | Spinner (disabled) |
| `partially_error` | Search failed | Error message (disabled) |
| `blocked` | Blacklisted | "Blocked" (disabled) |
| `can_request` | Default — no request yet | "Request" (actionable) |

### Review fixes included
- Fallback text on `partially_error` when error message is undefined
- `t` prop typed with interpolation support
- Dead code guard removed with comment
- Priority order documented (matches original ternary exactly)

## Test plan
- [ ] Available media shows green "Available" button
- [ ] Downloading media shows progress bar
- [ ] Upcoming media shows "Upcoming" disabled
- [ ] Searching media shows spinner
- [ ] Already requested shows "Already requested"
- [ ] TV partially available shows "Request rest"
- [ ] Blacklisted shows "Blocked"
- [ ] Default shows "Request" button
- [ ] Quality selection enables request even when available
- [ ] Button states match exactly what was shown before the refactor

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)