### PR TITLE
fix: set media status to searching immediately after request

### DIFF
--- a/packages/backend/src/routes/requests.ts
+++ b/packages/backend/src/routes/requests.ts
@@ -181,7 +181,16 @@ export async function requestRoutes(app: FastifyInstance) {
     if (shouldAutoApprove) {
       const tagName = await getUserTagName(user.id);
       const sent = await sendToService(media, mediaType, tagName, user.id, validSeasons, body.qualityOptionId);
-      if (!sent) {
+      if (sent) {
+        // Update media status immediately so the UI shows "Searching" instead of "Already requested"
+        // Don't override 'available' (quality request) or 'processing' (TV partial — keep showing "request rest")
+        if (media.status !== 'available' && media.status !== 'processing') {
+          await prisma.media.update({
+            where: { id: media.id },
+            data: { status: 'searching' },
+          }).catch(() => {}); // best-effort
+        }
+      } else {
         await prisma.mediaRequest.update({ where: { id: mediaRequest.id }, data: { status: 'failed' } });
         sendFailed = true;
       }
@@ -292,6 +301,15 @@ export async function requestRoutes(app: FastifyInstance) {
     const seasons = mediaRequest.seasons ? JSON.parse(mediaRequest.seasons) : undefined;
     const tagName = mediaRequest.user.displayName || mediaRequest.user.email || `user-${mediaRequest.user.id}`;
     const sent = await sendToService(mediaRequest.media, mediaRequest.mediaType, tagName, mediaRequest.userId, seasons, effectiveQuality, mediaRequest.rootFolder);
+
+    // Update media status immediately so the UI reflects the search
+    // Don't override 'available' or 'processing' (TV partial availability)
+    if (sent && mediaRequest.media.status !== 'available' && mediaRequest.media.status !== 'processing') {
+      await prisma.media.update({
+        where: { id: mediaRequest.media.id },
+        data: { status: 'searching' },
+      }).catch(() => {});
+    }
 
     const updated = await prisma.mediaRequest.update({
       where: { id: requestId },


### PR DESCRIPTION
## Problem

After requesting a movie, the detail page shows "Already requested" instead of "Searching..." because:
1. `findOrCreateMedia` creates the media with `status: 'unknown'` (Prisma default)
2. `sendToService` sends to Radarr but never updates `media.status`
3. The status only gets corrected at the next sync cycle (every 15 min)
4. Meanwhile, the frontend sees `userHasRequest = true` + `isSearching = false` → "Already requested"

## Fix

After a successful `sendToService`, immediately update `media.status` to `'searching'`.

Applied in both code paths:
- `POST /requests` (auto-approve flow, line 184)
- `POST /requests/:id/approve` (admin approve flow, line 297)

### Protected statuses

| Current status | After sendToService | Reason |
|---|---|---|
| `unknown` | → `searching` | New request, film being searched |
| `pending` | → `searching` | Was pending, now actively searching |
| `searching` | → `searching` | No-op, already correct |
| `available` | **kept** | Quality request — film already available |
| `processing` | **kept** | TV partial — keep "Request rest" button |

## Test plan
- [ ] Request a new movie → button shows "Searching..." immediately (not "Already requested")
- [ ] Request a different quality on an available movie → button stays "Available"
- [ ] Request missing episodes on a TV show → button stays "Request rest"
- [ ] Admin approves a pending request → button shows "Searching..."
- [ ] Failed sendToService → request marked as failed, media status unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)