### PR TITLE
refactor(backend): split index.ts into bootstrap modules

### DIFF
--- a/packages/backend/src/bootstrap/docs.ts
+++ b/packages/backend/src/bootstrap/docs.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from 'fastify';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+import { getAccessTag } from '../middleware/rbac.js';
+
+/**
+ * OpenAPI / Swagger UI at /api/docs, dev-only. The auto-tagging hook attaches each route to
+ * its category (derived from the prefix) and its access tier (derived from RBAC).
+ * Must be registered BEFORE routes so the onRoute hook catches every addition.
+ */
+export async function registerDocs(app: FastifyInstance) {
+  if (process.env.NODE_ENV === 'production') return;
+
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: 'Oscarr API',
+        description: 'API documentation for Oscarr — media request management',
+        version: '0.1.0-alpha',
+      },
+      components: {
+        securitySchemes: {
+          cookieAuth: { type: 'apiKey', in: 'cookie', name: 'token' },
+        },
+      },
+      security: [{ cookieAuth: [] }],
+      tags: [
+        { name: 'Public', description: 'No authentication required — open to anyone' },
+        { name: 'Auth Required', description: 'Requires a valid JWT session (logged-in user)' },
+        { name: 'Admin Only', description: 'Requires admin role — sensitive operations' },
+      ],
+    },
+  });
+
+  await app.register(swaggerUi, {
+    routePrefix: '/api/docs',
+    uiConfig: { docExpansion: 'list', deepLinking: true },
+    uiHooks: {
+      preHandler: async (request, reply) => {
+        try { await request.jwtVerify(); } catch { return reply.status(401).send({ error: 'Unauthorized' }); }
+        const user = request.user as { id: number; role: string };
+        if (user.role !== 'admin') return reply.status(403).send({ error: 'Admin only' });
+      },
+    },
+  });
+
+  app.addHook('onRoute', (routeOptions) => {
+    if (routeOptions.url.startsWith('/api/docs')) return;
+    if (!routeOptions.url.startsWith('/api/')) return;
+
+    const segment = (routeOptions.prefix || '').split('/').filter(Boolean).pop() || 'other';
+    const categoryTag = segment.charAt(0).toUpperCase() + segment.slice(1);
+
+    const methods = Array.isArray(routeOptions.method) ? routeOptions.method : [routeOptions.method];
+    const accessTag = getAccessTag(methods[0], routeOptions.url);
+
+    routeOptions.schema = { ...routeOptions.schema, tags: [categoryTag, accessTag] };
+  });
+}

--- a/packages/backend/src/bootstrap/jobs.ts
+++ b/packages/backend/src/bootstrap/jobs.ts
@@ -1,0 +1,15 @@
+import { initScheduler } from '../services/scheduler.js';
+import { initNotifications as initNotificationsInternal } from '../notifications/index.js';
+import { pluginEngine } from '../plugins/engine.js';
+
+/** Initialize core notification providers before plugins load so plugin providers can extend
+ *  the registry rather than race it. */
+export function initNotifications() {
+  initNotificationsInternal();
+}
+
+/** Start CRON scheduler after the HTTP server is listening so a misbehaving job can't block
+ *  the listen call. Passes the plugin engine so plugin-contributed jobs get scheduled too. */
+export async function startScheduler() {
+  await initScheduler(pluginEngine);
+}

--- a/packages/backend/src/bootstrap/plugins.ts
+++ b/packages/backend/src/bootstrap/plugins.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from 'fastify';
+import { pluginEngine } from '../plugins/engine.js';
+import { pluginRoutes } from '../plugins/routes.js';
+
+/**
+ * Load every installed plugin, register the routes they contribute, then mount the core
+ * `/api/plugins` management endpoints. Run AFTER notifications init so plugin providers can
+ * extend the notification system.
+ */
+export async function registerPlugins(app: FastifyInstance) {
+  await pluginEngine.loadAll();
+  await pluginEngine.registerWithFastify(app);
+  await app.register(pluginRoutes, { prefix: '/api/plugins' });
+}

--- a/packages/backend/src/bootstrap/routes.ts
+++ b/packages/backend/src/bootstrap/routes.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from 'fastify';
+import { authRoutes } from '../routes/auth.js';
+import { tmdbRoutes } from '../routes/tmdb.js';
+import { requestRoutes } from '../routes/requests.js';
+import { mediaRoutes } from '../routes/media.js';
+import { radarrSonarrRoutes } from '../routes/radarr-sonarr.js';
+import { adminRoutes } from '../routes/admin/index.js';
+import { setupRoutes } from '../routes/setup.js';
+import { appRoutes } from '../routes/app.js';
+import { supportRoutes } from '../routes/support.js';
+import { notificationRoutes } from '../routes/notifications.js';
+import { pushRoutes } from '../routes/push.js';
+
+/**
+ * Mount every HTTP route group under its /api/<prefix>. The TMDB language cache is warmed here
+ * so the first request doesn't pay the hydration cost.
+ *
+ * Webhooks are lazy-imported because they pull in a handful of provider-specific modules that
+ * we don't need evaluated unless the server actually starts handling requests.
+ */
+export async function registerRoutes(app: FastifyInstance) {
+  const { getInstanceLanguages } = await import('../services/tmdb.js');
+  await getInstanceLanguages();
+
+  await app.register(authRoutes, { prefix: '/api/auth' });
+  await app.register(tmdbRoutes, { prefix: '/api/tmdb' });
+  await app.register(requestRoutes, { prefix: '/api/requests' });
+  await app.register(mediaRoutes, { prefix: '/api/media' });
+  await app.register(radarrSonarrRoutes, { prefix: '/api/services' });
+  await app.register(adminRoutes, { prefix: '/api/admin' });
+  await app.register(setupRoutes, { prefix: '/api/setup' });
+  await app.register(appRoutes, { prefix: '/api/app' });
+  await app.register(supportRoutes, { prefix: '/api/support' });
+  await app.register(notificationRoutes, { prefix: '/api/notifications' });
+  await app.register(pushRoutes, { prefix: '/api/push' });
+  await app.register((await import('../routes/webhooks.js')).webhookRoutes, { prefix: '/api/webhooks' });
+}

--- a/packages/backend/src/bootstrap/security.ts
+++ b/packages/backend/src/bootstrap/security.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import jwt from '@fastify/jwt';
+import cookie from '@fastify/cookie';
+import rateLimit from '@fastify/rate-limit';
+import { rbacPlugin } from '../middleware/rbac.js';
+
+/**
+ * Security layer: CORS, cookies, JWT session, rate-limit, RBAC.
+ * Must run before any route is registered so permission checks + auth decorators are available.
+ */
+export async function registerSecurity(app: FastifyInstance) {
+  await app.register(cors, {
+    origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+    credentials: true,
+  });
+
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) throw new Error('JWT_SECRET environment variable is required');
+
+  await app.register(cookie);
+  await app.register(jwt, {
+    secret: jwtSecret,
+    cookie: { cookieName: 'token', signed: false },
+  });
+  await app.register(rateLimit, { global: false });
+
+  rbacPlugin(app);
+}

--- a/packages/backend/src/bootstrap/static.ts
+++ b/packages/backend/src/bootstrap/static.ts
@@ -1,0 +1,30 @@
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { existsSync } from 'fs';
+import type { FastifyInstance } from 'fastify';
+import fastifyStatic from '@fastify/static';
+
+/**
+ * Production-only: serve the built frontend and fall back to `index.html` for unknown non-API
+ * routes so the React Router SPA can handle them. No-op in dev — Vite owns the frontend there.
+ */
+export async function registerStatic(app: FastifyInstance) {
+  if (process.env.NODE_ENV !== 'production') return;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const frontendDir = resolve(__dirname, '../../../frontend/dist');
+  if (!existsSync(frontendDir)) return;
+
+  await app.register(fastifyStatic, {
+    root: frontendDir,
+    prefix: '/',
+    wildcard: false,
+  });
+
+  app.setNotFoundHandler((request, reply) => {
+    if (request.url.startsWith('/api/')) {
+      return reply.status(404).send({ error: 'Not found' });
+    }
+    return reply.sendFile('index.html');
+  });
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,34 +1,12 @@
 import './env.js';
-import { resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { existsSync } from 'fs';
 import Fastify from 'fastify';
-import cors from '@fastify/cors';
-import jwt from '@fastify/jwt';
-import cookie from '@fastify/cookie';
-import rateLimit from '@fastify/rate-limit';
-import fastifyStatic from '@fastify/static';
-import swagger from '@fastify/swagger';
-import swaggerUi from '@fastify/swagger-ui';
-import { authRoutes } from './routes/auth.js';
-import { tmdbRoutes } from './routes/tmdb.js';
-import { requestRoutes } from './routes/requests.js';
-import { mediaRoutes } from './routes/media.js';
-import { radarrSonarrRoutes } from './routes/radarr-sonarr.js';
-import { adminRoutes } from './routes/admin/index.js';
-import { setupRoutes } from './routes/setup.js';
-import { appRoutes } from './routes/app.js';
-import { supportRoutes } from './routes/support.js';
-import { notificationRoutes } from './routes/notifications.js';
-import { pushRoutes } from './routes/push.js';
-import { rbacPlugin, getAccessTag } from './middleware/rbac.js';
-import { initScheduler } from './services/scheduler.js';
-import { initNotifications } from './notifications/index.js';
-import { pluginEngine } from './plugins/engine.js';
-import { pluginRoutes } from './plugins/routes.js';
 import { loadInstallState } from './utils/install.js';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { registerSecurity } from './bootstrap/security.js';
+import { registerDocs } from './bootstrap/docs.js';
+import { registerRoutes } from './bootstrap/routes.js';
+import { registerPlugins } from './bootstrap/plugins.js';
+import { registerStatic } from './bootstrap/static.js';
+import { initNotifications, startScheduler } from './bootstrap/jobs.js';
 
 // Trust X-Forwarded-* headers (client IP, scheme) when running behind a reverse proxy — the
 // default because Docker / Traefik / nginx / Caddy are the overwhelming deploy path. Set
@@ -39,136 +17,19 @@ const app = Fastify({ logger: true, trustProxy });
 
 async function start() {
   loadInstallState();
-  await app.register(cors, {
-    origin: process.env.FRONTEND_URL || 'http://localhost:5173',
-    credentials: true,
-  });
-
-  const jwtSecret = process.env.JWT_SECRET;
-  if (!jwtSecret) {
-    throw new Error('JWT_SECRET environment variable is required');
-  }
-
-  await app.register(cookie);
-
-  await app.register(jwt, {
-    secret: jwtSecret,
-    cookie: { cookieName: 'token', signed: false },
-  });
-  await app.register(rateLimit, { global: false });
-
-  // Hydrate instance language cache before any route handles requests
-  const { getInstanceLanguages } = await import('./services/tmdb.js');
-  await getInstanceLanguages();
-
-  // Register RBAC middleware (central access control for all routes)
-  rbacPlugin(app);
-
-  // OpenAPI / Swagger (disabled in production — no /api/docs route exposed)
-  if (process.env.NODE_ENV !== 'production') {
-    await app.register(swagger, {
-      openapi: {
-        info: {
-          title: 'Oscarr API',
-          description: 'API documentation for Oscarr — media request management',
-          version: '0.1.0-alpha',
-        },
-        components: {
-          securitySchemes: {
-            cookieAuth: {
-              type: 'apiKey',
-              in: 'cookie',
-              name: 'token',
-            },
-          },
-        },
-        security: [{ cookieAuth: [] }],
-        tags: [
-          { name: 'Public', description: 'No authentication required — open to anyone' },
-          { name: 'Auth Required', description: 'Requires a valid JWT session (logged-in user)' },
-          { name: 'Admin Only', description: 'Requires admin role — sensitive operations' },
-        ],
-      },
-    });
-
-    await app.register(swaggerUi, {
-      routePrefix: '/api/docs',
-      uiConfig: {
-        docExpansion: 'list',
-        deepLinking: true,
-      },
-      uiHooks: {
-        preHandler: async (request, reply) => {
-          try { await request.jwtVerify(); } catch { return reply.status(401).send({ error: 'Unauthorized' }); }
-          const user = request.user as { id: number; role: string };
-          if (user.role !== 'admin') return reply.status(403).send({ error: 'Admin only' });
-        },
-      },
-    });
-  }
-
-  // Auto-tag every route for Swagger using the RBAC permission map
-  app.addHook('onRoute', (routeOptions) => {
-    if (routeOptions.url.startsWith('/api/docs')) return;
-    if (!routeOptions.url.startsWith('/api/')) return;
-
-    const segment = (routeOptions.prefix || '').split('/').filter(Boolean).pop() || 'other';
-    const categoryTag = segment.charAt(0).toUpperCase() + segment.slice(1);
-
-    const methods = Array.isArray(routeOptions.method) ? routeOptions.method : [routeOptions.method];
-    const accessTag = getAccessTag(methods[0], routeOptions.url);
-
-    routeOptions.schema = { ...routeOptions.schema, tags: [categoryTag, accessTag] };
-  });
-
-  await app.register(authRoutes, { prefix: '/api/auth' });
-  await app.register(tmdbRoutes, { prefix: '/api/tmdb' });
-  await app.register(requestRoutes, { prefix: '/api/requests' });
-  await app.register(mediaRoutes, { prefix: '/api/media' });
-  await app.register(radarrSonarrRoutes, { prefix: '/api/services' });
-  await app.register(adminRoutes, { prefix: '/api/admin' });
-  await app.register(setupRoutes, { prefix: '/api/setup' });
-  await app.register(appRoutes, { prefix: '/api/app' });
-  await app.register(supportRoutes, { prefix: '/api/support' });
-  await app.register(notificationRoutes, { prefix: '/api/notifications' });
-  await app.register(pushRoutes, { prefix: '/api/push' });
-  await app.register((await import('./routes/webhooks.js')).webhookRoutes, { prefix: '/api/webhooks' });
-
-  // Initialize notification system (before plugins, so they can extend it)
-  initNotifications();
-
-  // Load plugins and register their routes
-  await pluginEngine.loadAll();
-  await pluginEngine.registerWithFastify(app);
-  await app.register(pluginRoutes, { prefix: '/api/plugins' });
-
-  // In production, serve the frontend SPA
-  const frontendDir = resolve(__dirname, '../../frontend/dist');
-  if (process.env.NODE_ENV === 'production' && existsSync(frontendDir)) {
-    await app.register(fastifyStatic, {
-      root: frontendDir,
-      prefix: '/',
-      wildcard: false,
-    });
-
-    // SPA fallback: serve index.html for non-API routes
-    app.setNotFoundHandler((request, reply) => {
-      if (request.url.startsWith('/api/')) {
-        return reply.status(404).send({ error: 'Not found' });
-      }
-      return reply.sendFile('index.html');
-    });
-  }
+  await registerSecurity(app);
+  await registerDocs(app); // before routes so the onRoute hook tags everything
+  await registerRoutes(app);
+  initNotifications();     // before plugins so providers can extend the registry
+  await registerPlugins(app);
+  await registerStatic(app);
 
   const port = parseInt(process.env.PORT || '3001', 10);
-  if (Number.isNaN(port)) {
-    throw new Error('PORT environment variable must be a valid number');
-  }
+  if (Number.isNaN(port)) throw new Error('PORT environment variable must be a valid number');
   await app.listen({ port, host: '0.0.0.0' });
   console.log(`Oscarr API running on port ${port}`);
 
-  // Start CRON scheduler (with plugin jobs)
-  await initScheduler(pluginEngine);
+  await startScheduler();
 }
 
 start().catch((err) => {


### PR DESCRIPTION
Closes #140.

## Summary

`packages/backend/src/index.ts` went from **179 lines** of intertwined setup to **40 lines** of orchestration. Each concern now lives in a single-purpose module under `src/bootstrap/`:

| Module | Responsibility |
|--------|----------------|
| `security.ts` | CORS, cookies, JWT, rate-limit, RBAC |
| `docs.ts` | Swagger + UI + `onRoute` auto-tagging (dev-only) |
| `routes.ts` | 12 route groups + TMDB language cache warm |
| `plugins.ts` | `loadAll` + `registerWithFastify` + `/api/plugins` |
| `static.ts` | Production SPA fallback (no-op in dev) |
| `jobs.ts` | `initNotifications` + `startScheduler` |

## Registration order

Preserved and now explicit in `index.ts`:

```
security → docs (before routes so the onRoute hook tags everything)
        → routes
        → initNotifications (before plugins so providers can extend)
        → plugins
        → static
        → listen
        → scheduler (after listen so a misbehaving job can't block it)
```

## No behavior change

- Same `trustProxy` env gate, same port parsing, same fatal-on-start error path.
- Same dev-only Swagger gate.
- Same production-only static serve + SPA fallback.
- Same `__dirname` resolution (path adjusted for the deeper location).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Dev server boots cleanly
- [ ] Production build serves the frontend from `/` and falls back to `index.html` for unknown non-API routes
- [ ] `/api/docs` still gated behind admin in dev
- [ ] CRON jobs still fire after restart
- [ ] Plugins still load and their routes mount under `/api/plugins/...`

Parent: #145