### PR TITLE
feat(plugins): Tailwind CSS bundles per plugin (#148)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -603,7 +603,49 @@ export default function MyPluginPage() {
 }
 ```
 
-The frontend component is lazy-loaded via ESM by Oscarr's router. It has access to all Tailwind CSS classes and Oscarr's design system (e.g. `text-ndp-text`, `card`, `btn-primary`).
+The frontend component is lazy-loaded via ESM by Oscarr's router. See [Styling](#styling) for how to use Tailwind classes and Oscarr's design tokens in your plugin.
+
+## Styling
+
+Plugins can style their UI with the same Tailwind + design tokens as the core. Two things to know:
+
+**Component classes (`card`, `btn-primary`, `btn-secondary`, `input`, …) come free.** They're defined in the core CSS bundle that Oscarr loads on every page, so just writing `<div className="card">` in your plugin works out of the box.
+
+**Tailwind utility classes (`bg-sky-500`, `border-l-amber-400`, `p-4`, `flex`…) need the plugin to ship its own CSS bundle.** Tailwind's JIT purges classes the core doesn't use itself, so a plugin that wants colors or spacings not present in core would otherwise render unstyled. To fix this, plugins compile a small CSS bundle alongside their JS, which Oscarr's loader injects when the plugin mounts.
+
+### One-time setup (per plugin)
+
+Run the scaffolder from the Oscarr repo:
+
+```bash
+npm run plugin:add-tailwind -- ~/Oscarr/plugins/my-plugin
+```
+
+The script is idempotent — safe to re-run. It drops in:
+
+- `tailwind.preset.js` — Oscarr's design tokens (`ndp-*` colors, animations, keyframes), copied inline so your plugin stays self-contained. **Oscarr-owned**: re-running the scaffolder re-syncs it. If you want to extend the tokens (extra colors, brand fonts), use `theme.extend` in your plugin's `tailwind.config.js` rather than editing the preset in-place.
+- `tailwind.config.js` — wires the preset, scans `frontend/**/*.{ts,tsx}`, and disables preflight (core's reset already applies).
+- `frontend/index.css` — entry file that just emits `@tailwind utilities;`. Base + components are served by the core bundle already loaded in the page.
+- `package.json` — pins `tailwindcss` to the same version the core uses.
+- `build.js` — patched to run `npx tailwindcss` after esbuild, emitting `dist/frontend/index.css`.
+
+After the script runs:
+
+```bash
+cd ~/Oscarr/plugins/my-plugin
+npm install
+npm run build     # emits dist/frontend/{index.js,index.css}
+```
+
+The plugin loader injects `<link rel="stylesheet" href="/api/plugins/<id>/frontend/index.css">` the first time any component from the plugin mounts, and removes it when the plugin is disabled or uninstalled. No explicit import needed on your side.
+
+### Scoping runtime-injected custom CSS
+
+If your plugin injects raw CSS at runtime (e.g. `.plugin-communication`'s markdown typography), prefix selectors with `.oscarr-<plugin-id>-*` to avoid colliding with core or other plugins. Tailwind utilities don't need scoping — same class name = same rule everywhere.
+
+### Tailwind version alignment
+
+The scaffolder pins `tailwindcss` to the core's exact version. Major version drift (e.g. core v3 → v4) changes syntax for some utilities (opacity, arbitrary values) and will eventually require running the scaffolder again to re-pin. Keep your plugin's `tailwindcss` in lockstep with the Oscarr you're targeting.
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:generate": "npm run db:generate --workspace=packages/backend",
     "db:studio": "npm run db:studio --workspace=packages/backend",
     "db:seed": "npm run db:seed --workspace=packages/backend",
-    "db:fresh": "rm -f packages/backend/data/oscarr.db packages/backend/data/install.json && npm run db:migrate && npm run db:generate"
+    "db:fresh": "rm -f packages/backend/data/oscarr.db packages/backend/data/install.json && npm run db:migrate && npm run db:generate",
+    "plugin:add-tailwind": "node packages/frontend/scripts/add-tailwind-to-plugin.mjs"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/packages/frontend/scripts/add-tailwind-to-plugin.mjs
+++ b/packages/frontend/scripts/add-tailwind-to-plugin.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * One-shot scaffolder to add Tailwind CSS support to an Oscarr plugin.
+ *
+ * Drops in a Tailwind config (with the Oscarr design tokens inlined so the plugin stays
+ * portable), a CSS entry that only pulls utilities (components come from the core bundle
+ * already loaded in the page), patches build.js to run the Tailwind CLI after esbuild, and
+ * adds tailwindcss to the plugin's devDependencies at the same version the core uses.
+ *
+ * Usage:
+ *   node packages/frontend/scripts/add-tailwind-to-plugin.mjs <plugin-dir>
+ *
+ * The script is idempotent: re-running on a plugin that's already wired is a no-op per step.
+ */
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORE_FRONTEND = resolve(__dirname, '..');
+const PRESET_SRC = resolve(CORE_FRONTEND, 'tailwind.preset.js');
+// Sentinel comment we emit when patching build.js so a re-run reliably detects our own patch
+// instead of false-positiving on any unrelated mention of "tailwindcss" in the file.
+const BUILD_JS_MARKER = '// ── Tailwind CSS step (added by add-tailwind-to-plugin.mjs)';
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    exit(`Malformed JSON in ${label} (${path}): ${e.message}`);
+  }
+}
+
+function readCorePackage() {
+  const pkg = readJson(resolve(CORE_FRONTEND, 'package.json'), 'core package.json');
+  const ver = pkg.dependencies?.tailwindcss || pkg.devDependencies?.tailwindcss;
+  if (!ver) exit('Cannot find tailwindcss version in core package.json');
+  return ver;
+}
+
+function assertPluginDir(dir) {
+  if (!existsSync(dir)) exit(`Plugin directory does not exist: ${dir}`);
+  for (const f of ['package.json', 'build.js', 'manifest.json']) {
+    if (!existsSync(join(dir, f))) exit(`Not a plugin directory (missing ${f}): ${dir}`);
+  }
+  if (!existsSync(join(dir, 'frontend'))) {
+    exit(`Plugin has no frontend/ folder — nothing to style: ${dir}`);
+  }
+}
+
+function exit(msg) {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+function log(msg) {
+  console.log(`  ${msg}`);
+}
+
+function addDevDep(pkgPath, name, version) {
+  const pkg = readJson(pkgPath, 'plugin package.json');
+  pkg.devDependencies = pkg.devDependencies || {};
+  if (pkg.devDependencies[name] === version) {
+    log(`devDep ${name}@${version} already present`);
+    return false;
+  }
+  pkg.devDependencies[name] = version;
+  // Preserve key ordering where possible: alphabetise devDeps for a clean diff.
+  const sorted = Object.keys(pkg.devDependencies).sort().reduce((acc, k) => {
+    acc[k] = pkg.devDependencies[k];
+    return acc;
+  }, {});
+  pkg.devDependencies = sorted;
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  log(`added devDep ${name}@${version}`);
+  return true;
+}
+
+function writeIfMissing(path, content, label) {
+  if (existsSync(path)) {
+    log(`${label} already exists at ${path}`);
+    return false;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  log(`created ${label}`);
+  return true;
+}
+
+function patchBuildJs(buildJsPath) {
+  const src = readFileSync(buildJsPath, 'utf8');
+  if (src.includes(BUILD_JS_MARKER)) {
+    log('build.js already patched — skipping (marker found)');
+    return false;
+  }
+  if (src.includes('tailwindcss')) {
+    // File mentions tailwindcss but not our sentinel — likely a hand-rolled setup we'd stomp
+    // on if we appended blindly. Bail out loudly rather than skip silently.
+    exit(`build.js at ${buildJsPath} references tailwindcss but lacks our marker. Patch it manually or remove the existing integration, then re-run this script.`);
+  }
+
+  // Append a post-build Tailwind step. Runs the CLI with the plugin's local config, reads the
+  // CSS entry we dropped at frontend/index.css, emits to dist/frontend/index.css. Works with
+  // both one-shot `npm run build` and watch mode — the CLI supports `--watch` itself.
+  const patch = `
+${BUILD_JS_MARKER} ─────────────────
+import { spawn, spawnSync } from 'child_process';
+
+const tailwindArgs = [
+  '-c', resolve(__dirname, 'tailwind.config.js'),
+  '-i', resolve(__dirname, 'frontend/index.css'),
+  '-o', resolve(__dirname, 'dist/frontend/index.css'),
+  ...(watch ? ['--watch'] : ['--minify']),
+];
+
+if (watch) {
+  // Fire-and-forget in watch mode; the CLI's own watcher owns the lifecycle.
+  const child = spawn('npx', ['tailwindcss', ...tailwindArgs], { stdio: 'inherit', cwd: __dirname });
+  child.on('exit', (code) => { if (code !== null && code !== 0) process.exit(code); });
+} else {
+  const result = spawnSync('npx', ['tailwindcss', ...tailwindArgs], { stdio: 'inherit', cwd: __dirname });
+  if (result.status !== 0) process.exit(result.status || 1);
+  console.log('Frontend (CSS) built → dist/frontend/index.css');
+}
+`;
+
+  writeFileSync(buildJsPath, src.trimEnd() + '\n' + patch);
+  log('patched build.js with Tailwind step');
+  return true;
+}
+
+function main() {
+  const [, , rawDir] = process.argv;
+  if (!rawDir) exit('Usage: add-tailwind-to-plugin.mjs <plugin-dir>');
+  const pluginDir = resolve(process.cwd(), rawDir);
+
+  assertPluginDir(pluginDir);
+  if (!existsSync(PRESET_SRC)) exit(`Missing core preset at ${PRESET_SRC}`);
+
+  console.log(`→ Adding Tailwind to plugin at ${pluginDir}`);
+
+  // 1. Copy the core preset inline — plugins are ~/Oscarr/plugins/* (outside the monorepo),
+  //    so we can't require from the core. A copy stays self-contained and travels with the
+  //    plugin repo. The preset is Oscarr-owned: re-running this script re-syncs it, which
+  //    means a plugin that edits its copy in-place loses those changes. Extend Oscarr's tokens
+  //    via the plugin's tailwind.config.js `theme.extend` instead of editing the preset.
+  const presetDst = join(pluginDir, 'tailwind.preset.js');
+  const presetSrcContent = readFileSync(PRESET_SRC, 'utf8');
+  if (existsSync(presetDst) && readFileSync(presetDst, 'utf8') === presetSrcContent) {
+    log('tailwind.preset.js already up to date');
+  } else {
+    if (existsSync(presetDst)) {
+      log('tailwind.preset.js differs from core — overwriting (extend via tailwind.config.js, not in-place)');
+    } else {
+      log('copied tailwind.preset.js into plugin');
+    }
+    copyFileSync(PRESET_SRC, presetDst);
+  }
+
+  // 2. Plugin-local tailwind.config.js that wires the preset and scans the plugin's frontend.
+  writeIfMissing(
+    join(pluginDir, 'tailwind.config.js'),
+    `import preset from './tailwind.preset.js';
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  presets: [preset],
+  content: ['./frontend/**/*.{ts,tsx,js,jsx}'],
+  // Base + components already ship in the core CSS bundle that Oscarr loads globally — we only
+  // need utilities here. Keep this config lean to avoid bloating the plugin's CSS bundle.
+  corePlugins: { preflight: false },
+  plugins: [],
+};
+`,
+    'tailwind.config.js',
+  );
+
+  // 3. CSS entry — utilities only. Components (card, btn-primary, input, …) and the base reset
+  //    come from the core bundle; adding them here would duplicate ~15KB per plugin for no gain.
+  writeIfMissing(
+    join(pluginDir, 'frontend/index.css'),
+    `/* Tailwind utilities compiled into the plugin's own CSS bundle. Core ships base + components. */
+@tailwind utilities;
+`,
+    'frontend/index.css',
+  );
+
+  // 4. Pin tailwindcss to the core's version so utility syntax matches exactly.
+  const coreTailwindVersion = readCorePackage();
+  addDevDep(join(pluginDir, 'package.json'), 'tailwindcss', coreTailwindVersion);
+
+  // 5. Extend the plugin's build.js to invoke the Tailwind CLI alongside esbuild.
+  patchBuildJs(join(pluginDir, 'build.js'));
+
+  console.log('');
+  console.log('✓ Done. Next steps:');
+  console.log(`  cd ${pluginDir}`);
+  console.log('  npm install       # pulls tailwindcss');
+  console.log('  npm run build     # emits dist/frontend/{index.js,index.css}');
+  console.log('');
+  console.log('  Oscarr\'s plugin loader injects the <link> automatically when your plugin mounts.');
+}
+
+main();

--- a/packages/frontend/scripts/add-tailwind-to-plugin.mjs
+++ b/packages/frontend/scripts/add-tailwind-to-plugin.mjs
@@ -77,14 +77,20 @@ function addDevDep(pkgPath, name, version) {
 }
 
 function writeIfMissing(path, content, label) {
-  if (existsSync(path)) {
-    log(`${label} already exists at ${path}`);
-    return false;
-  }
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, content);
-  log(`created ${label}`);
-  return true;
+  try {
+    // `wx` = atomic "create only if missing". Avoids the existsSync + writeFileSync TOCTOU
+    // window and makes the intent ("don't clobber") explicit in the syscall itself.
+    writeFileSync(path, content, { flag: 'wx' });
+    log(`created ${label}`);
+    return true;
+  } catch (err) {
+    if ((err)?.code === 'EEXIST') {
+      log(`${label} already exists at ${path}`);
+      return false;
+    }
+    throw err;
+  }
 }
 
 function patchBuildJs(buildJsPath) {

--- a/packages/frontend/src/plugins/pluginModuleCache.ts
+++ b/packages/frontend/src/plugins/pluginModuleCache.ts
@@ -7,7 +7,58 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
-/** Load a plugin ESM module from a URL. Returns the default export as a React component. */
+/** Plugin id → injected `<link>` node. Stored by reference so removal never has to re-query
+ *  the DOM with a user-controlled selector (escape safety) and stays consistent with the DOM
+ *  across Vite HMR cycles where module state resets but document.head doesn't. */
+const cssLinks = new Map<string, HTMLLinkElement>();
+
+/** Extract the plugin id from a plugin asset URL. Both entry-point and hook-point URLs follow
+ *  `/api/plugins/<pluginId>/frontend/...`, so the third path segment is the id. */
+function pluginIdFromUrl(url: string): string | null {
+  const match = url.match(/^\/api\/plugins\/([^/]+)\/frontend\//);
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Inject a `<link rel="stylesheet">` for the plugin's compiled CSS bundle, once per plugin.
+ * Called only after the plugin's JS loads successfully so a broken import doesn't leave an
+ * orphan stylesheet in the page. If the CSS file 404s (plugin not rebuilt with the Tailwind
+ * scaffolder), we surface a dev-mode warning rather than debug-archaeology the network panel.
+ */
+function ensurePluginCss(pluginId: string): void {
+  if (cssLinks.has(pluginId)) return;
+  // HMR safety: if a previous module instance already appended the link, re-use it.
+  const existing = Array.from(document.head.querySelectorAll<HTMLLinkElement>('link[data-plugin-id]'))
+    .find((el) => el.dataset.pluginId === pluginId);
+  if (existing) {
+    cssLinks.set(pluginId, existing);
+    return;
+  }
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = `/api/plugins/${pluginId}/frontend/index.css`;
+  link.dataset.pluginId = pluginId;
+  if (import.meta.env.DEV) {
+    link.onerror = () => console.warn(
+      `Plugin "${pluginId}" did not ship a CSS bundle. Run \`npm run plugin:add-tailwind -- <plugin-dir>\` to enable Tailwind in the plugin.`,
+    );
+  }
+  document.head.appendChild(link);
+  cssLinks.set(pluginId, link);
+}
+
+/** Remove a previously-injected plugin CSS link — used when the plugin is disabled /
+ *  uninstalled so stale utilities don't keep styling the page after the JS is gone. */
+function removePluginCss(pluginId: string): void {
+  const link = cssLinks.get(pluginId);
+  if (!link) return;
+  link.remove();
+  cssLinks.delete(pluginId);
+}
+
+/** Load a plugin ESM module from a URL. Returns the default export as a React component.
+ *  Also injects the plugin's compiled CSS bundle on first successful load — the core bundle
+ *  no longer purges classes it doesn't use itself, so plugins ship their own utilities. */
 export async function loadPluginModule(url: string): Promise<ComponentType<any> | null> {
   const cached = cache.get(url);
   if (cached) return cached.component;
@@ -15,10 +66,14 @@ export async function loadPluginModule(url: string): Promise<ComponentType<any> 
   try {
     const mod = await import(/* @vite-ignore */ url);
     const component = mod.default || null;
+    const pluginId = pluginIdFromUrl(url);
+    if (pluginId) ensurePluginCss(pluginId);
     cache.set(url, { component, loadedAt: Date.now() });
     return component;
-  } catch {
-    // Don't cache failures — allow retry on next call
+  } catch (err) {
+    // Don't cache failures — allow retry on next call. Log in dev so a bundle eval crash /
+    // CSP block / syntax error doesn't silently render the plugin as missing.
+    if (import.meta.env.DEV) console.error(`Failed to load plugin module at ${url}`, err);
     return null;
   }
 }
@@ -33,16 +88,19 @@ export function getCached(url: string): ComponentType<any> | null {
   return cache.get(url)?.component ?? null;
 }
 
-/** Invalidate cache for a specific plugin (by pluginId prefix) or all entries. */
+/** Invalidate cache for a specific plugin (by pluginId prefix) or all entries. Also tears down
+ *  the plugin's injected CSS so a disabled plugin can't keep styling the app. */
 export function invalidate(pluginId?: string): void {
   if (!pluginId) {
     cache.clear();
+    for (const id of Array.from(cssLinks.keys())) removePluginCss(id);
     return;
   }
   const prefix = `/api/plugins/${pluginId}/`;
   for (const key of cache.keys()) {
     if (key.startsWith(prefix)) cache.delete(key);
   }
+  removePluginCss(pluginId);
 }
 
 /** Build the standard URL for a plugin's main frontend module. */

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -1,61 +1,8 @@
+import preset from './tailwind.preset.js';
+
 /** @type {import('tailwindcss').Config} */
 export default {
+  presets: [preset],
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  theme: {
-    extend: {
-      colors: {
-        ndp: {
-          bg: '#0a0e17',
-          surface: '#111827',
-          'surface-light': '#1f2937',
-          'surface-hover': '#283548',
-          accent: '#6366f1',
-          'accent-hover': '#818cf8',
-          'accent-dark': '#4f46e5',
-          gold: '#f59e0b',
-          success: '#10b981',
-          danger: '#ef4444',
-          warning: '#f59e0b',
-          text: '#f3f4f6',
-          'text-muted': '#9ca3af',
-          'text-dim': '#6b7280',
-          border: '#1f2937',
-        },
-      },
-      fontFamily: {
-        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
-      },
-      animation: {
-        'fade-in': 'fadeIn 0.3s ease-in-out',
-        'slide-up': 'slideUp 0.3s ease-out',
-        'slide-in-right': 'slideInRight 0.3s ease-out',
-        shimmer: 'shimmer 2s infinite',
-        shake: 'shake 0.4s ease-in-out',
-      },
-      keyframes: {
-        fadeIn: {
-          '0%': { opacity: '0' },
-          '100%': { opacity: '1' },
-        },
-        slideUp: {
-          '0%': { opacity: '0', transform: 'translateY(20px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
-        },
-        slideInRight: {
-          '0%': { opacity: '0', transform: 'translateX(20px)' },
-          '100%': { opacity: '1', transform: 'translateX(0)' },
-        },
-        shimmer: {
-          '0%': { backgroundPosition: '-200% 0' },
-          '100%': { backgroundPosition: '200% 0' },
-        },
-        shake: {
-          '0%, 100%': { transform: 'translateX(0)' },
-          '15%, 45%, 75%': { transform: 'translateX(-6px)' },
-          '30%, 60%, 90%': { transform: 'translateX(6px)' },
-        },
-      },
-    },
-  },
   plugins: [],
 };

--- a/packages/frontend/tailwind.preset.js
+++ b/packages/frontend/tailwind.preset.js
@@ -1,0 +1,71 @@
+/**
+ * Shared Tailwind preset for Oscarr — colors, fonts, animations.
+ *
+ * Used by the core frontend (packages/frontend/tailwind.config.js) and intended to be copied
+ * verbatim into any plugin that wants to use Oscarr's design language while self-compiling its
+ * own CSS bundle. Plugins ship with this file inline so they stay portable (no require to the
+ * core repo from ~/Oscarr/plugins/).
+ *
+ * Keep this in sync with the Oscarr major version: a color rename here = a plugin visual regression
+ * after the next core upgrade. Version the preset with the core if you rename anything.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+export default {
+  theme: {
+    extend: {
+      colors: {
+        ndp: {
+          bg: '#0a0e17',
+          surface: '#111827',
+          'surface-light': '#1f2937',
+          'surface-hover': '#283548',
+          accent: '#6366f1',
+          'accent-hover': '#818cf8',
+          'accent-dark': '#4f46e5',
+          gold: '#f59e0b',
+          success: '#10b981',
+          danger: '#ef4444',
+          warning: '#f59e0b',
+          text: '#f3f4f6',
+          'text-muted': '#9ca3af',
+          'text-dim': '#6b7280',
+          border: '#1f2937',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.3s ease-in-out',
+        'slide-up': 'slideUp 0.3s ease-out',
+        'slide-in-right': 'slideInRight 0.3s ease-out',
+        shimmer: 'shimmer 2s infinite',
+        shake: 'shake 0.4s ease-in-out',
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        slideUp: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        slideInRight: {
+          '0%': { opacity: '0', transform: 'translateX(20px)' },
+          '100%': { opacity: '1', transform: 'translateX(0)' },
+        },
+        shimmer: {
+          '0%': { backgroundPosition: '-200% 0' },
+          '100%': { backgroundPosition: '200% 0' },
+        },
+        shake: {
+          '0%, 100%': { transform: 'translateX(0)' },
+          '15%, 45%, 75%': { transform: 'translateX(-6px)' },
+          '30%, 60%, 90%': { transform: 'translateX(6px)' },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Closes #148.

## Problem

Tailwind's JIT purges classes the core doesn't use itself from the compiled bundle. Plugin components using \`bg-sky-500\`, \`border-l-amber-400\`, or any color/state combo absent from core rendered unstyled — admins had to fall back to inline styles or runtime-injected CSS blocks, losing Tailwind dev ergonomics.

## Approach

Each plugin compiles its **own** CSS bundle alongside its JS, and Oscarr's loader injects a \`<link>\` to it automatically when the plugin mounts. Component classes (\`card\`, \`btn-primary\`, …) keep coming from the core CSS bundle that every page already loads, so plugins don't re-compile them.

| Component | Change |
|-----------|--------|
| \`tailwind.preset.js\` (new) | Extracted \`ndp-*\` tokens + animations. One source of truth for core + plugins. |
| \`tailwind.config.js\` | Now just wires the preset + content globs. |
| \`pluginModuleCache.ts\` | After a successful JS import, inject a \`<link rel="stylesheet">\` to \`/api/plugins/<id>/frontend/index.css\`. Dedup by plugin id, reference-stored for removal, HMR-safe, dev-only onerror hint. |
| \`add-tailwind-to-plugin.mjs\` (new) | One-shot scaffolder. Copies the preset inline (plugin stays self-contained), drops a \`tailwind.config.js\` and \`frontend/index.css\` (utilities only — core owns base + components), pins tailwindcss to the core's version, and patches \`build.js\` to run \`npx tailwindcss\` after esbuild. Idempotent + sentinel-marker patching. |
| \`package.json\` (root) | \`npm run plugin:add-tailwind -- <plugin-dir>\` wrapper. |
| \`docs/plugins.md\` | New **Styling** section: component vs utility classes, one-time setup, \`.oscarr-<id>-*\` scoping convention, Tailwind version alignment. |

## Plugin author flow

One-time per plugin:
\`\`\`bash
npm run plugin:add-tailwind -- ~/Oscarr/plugins/my-plugin
cd ~/Oscarr/plugins/my-plugin
npm install
npm run build
\`\`\`

Ongoing: write \`className="bg-sky-500 card text-ndp-text"\` — \`npm run build\` rebuilds JS + CSS, Oscarr injects the \`<link>\` when the plugin loads. No manual registration.

## Verification

End-to-end run on \`plugin-communication\`:
- Scaffolder ran, then re-ran (idempotence OK — all steps reported "already present / up to date")
- \`npm install\` pulled tailwindcss 3.4.17
- \`npm run build\` emitted \`dist/frontend/index.css\` at **12KB**, containing all the previously-purged utilities (sky/amber/rose color variants, border-l-*, bg-*/15 opacity shades)
- Typechecks pass front + back

## Reviewer findings applied before commit

- CSS injection moved **after** successful JS import so a broken bundle doesn't leave an orphan stylesheet
- Link removal now stores the \`HTMLLinkElement\` reference instead of doing \`querySelector\` with an unescaped pluginId (avoids selector injection + HMR state drift)
- Dev-mode \`link.onerror\` warning so plugin authors who forget the scaffolder get a hint in the console
- Scaffolder \`patchBuildJs\` now uses a sentinel marker and aborts loudly on unknown tailwindcss mentions rather than skipping silently
- Friendly JSON-parse errors in the scaffolder
- Docs + script output both note the preset is Oscarr-owned (extend via \`theme.extend\`, not in-place edits)

## Test plan

- [ ] Fresh plugin without CSS (pre-scaffolder state): loader logs a dev-only warning via \`link.onerror\`, plugin JS still renders (just without plugin-specific utilities)
- [ ] Run scaffolder on a pristine plugin: creates preset + config + CSS entry + devDep + patched build.js
- [ ] Re-run scaffolder: all steps skip cleanly, no file mutation
- [ ] \`npm run build\` in a scaffolded plugin emits \`dist/frontend/index.css\`
- [ ] Admin loads the plugin tab: \`<link data-plugin-id="…">\` present in \`<head>\`, utilities applied
- [ ] Disable plugin: link removed from \`<head>\`, utilities gone
- [ ] Re-enable: link back, utilities back
- [ ] Plugin CSS 404s (dev): one \`console.warn\` in DevTools, plugin JS still mounts

## Follow-up (separate PRs)

- Migrate the other 3 plugins (\`plugin-subscription\`, \`plugin-radarr\`, \`plugin-tautulli-insights\`) — just \`npm run plugin:add-tailwind -- <path>\` + \`npm run build\` each.

Parent: #145