### PR TITLE
refactor(admin): split PluginsTab + ServicesTab (#138)

### DIFF
--- a/packages/frontend/src/pages/admin/PluginsTab.tsx
+++ b/packages/frontend/src/pages/admin/PluginsTab.tsx
@@ -1,102 +1,47 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
 import { clsx } from 'clsx';
-import { Plug, ExternalLink, Star, Loader2, Download, Package, Terminal, BookOpen, Copy, Check, RefreshCw, AlertTriangle, Trash2, X } from 'lucide-react';
-import api from '@/lib/api';
-import { toastApiError } from '@/utils/toast';
-import { invalidatePluginUICache } from '@/plugins/usePlugins';
+import { BookOpen, Download, Loader2, Package, RefreshCw } from 'lucide-react';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import { PluginConsentModal } from './PluginConsentModal';
-import type { PluginInfo } from '@/plugins/types';
+import { usePluginsTab } from './plugins/usePluginsTab';
+import { InstalledList } from './plugins/InstalledList';
+import { DiscoverList } from './plugins/DiscoverList';
+import { ManualInstallModal } from './plugins/ManualInstallModal';
+import { PluginDocsModal } from './plugins/PluginDocsModal';
+import type { RegistryPlugin, SubTab } from './plugins/constants';
 
-// `plugin.updateAvailable` + `plugin.latestVersion` come straight from the backend, which
-// runs a proper semver comparison against the registry cache. No hand-rolled version logic here.
-
-interface RegistryPlugin {
-  id: string;
-  name: string;
-  version: string;
-  apiVersion: string;
-  description: string;
-  author: string;
-  repository: string;
-  category: string;
-  tags?: string[];
-  url: string;
-  stars: number;
-  updatedAt: string | null;
-  services?: string[];
-  capabilities?: string[];
-  capabilityReasons?: Record<string, string>;
-}
-
-type SubTab = 'installed' | 'discover';
-
-const CATEGORY_CONFIG: Record<string, { label: string; color: string }> = {
-  bots: { label: 'Bot', color: 'bg-indigo-500/15 text-indigo-400' },
-  notifications: { label: 'Notifications', color: 'bg-amber-500/15 text-amber-400' },
-  automation: { label: 'Automation', color: 'bg-cyan-500/15 text-cyan-400' },
-  'requests-workflow': { label: 'Requests', color: 'bg-pink-500/15 text-pink-400' },
-  subscriptions: { label: 'Subscriptions', color: 'bg-fuchsia-500/15 text-fuchsia-400' },
-  'ui-themes': { label: 'Themes', color: 'bg-purple-500/15 text-purple-400' },
-  analytics: { label: 'Analytics', color: 'bg-emerald-500/15 text-emerald-400' },
-  utilities: { label: 'Utilities', color: 'bg-slate-500/15 text-slate-400' },
-};
-
-const TAG_CONFIG: Record<string, { label: string; color: string }> = {
-  plex: { label: 'Plex', color: 'bg-[#e5a00d]/15 text-[#e5a00d]' },
-  jellyfin: { label: 'Jellyfin', color: 'bg-violet-500/15 text-violet-400' },
-  emby: { label: 'Emby', color: 'bg-green-500/15 text-green-400' },
-  discord: { label: 'Discord', color: 'bg-indigo-500/15 text-indigo-400' },
-  telegram: { label: 'Telegram', color: 'bg-sky-500/15 text-sky-400' },
-  matrix: { label: 'Matrix', color: 'bg-teal-500/15 text-teal-400' },
-  slack: { label: 'Slack', color: 'bg-rose-500/15 text-rose-400' },
-  radarr: { label: 'Radarr', color: 'bg-yellow-500/15 text-yellow-400' },
-  sonarr: { label: 'Sonarr', color: 'bg-blue-500/15 text-blue-400' },
-};
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      onClick={() => { navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
-      className="text-ndp-text-dim hover:text-ndp-text transition-colors"
-      title="Copy"
-    >
-      {copied ? <Check className="w-3.5 h-3.5 text-ndp-success" /> : <Copy className="w-3.5 h-3.5" />}
-    </button>
-  );
-}
-
-function PluginInitial({ name }: { name: string }) {
-  const letter = name.charAt(0).toUpperCase();
-  return (
-    <div className="w-12 h-12 rounded-xl bg-ndp-accent/15 flex items-center justify-center text-ndp-accent font-bold text-lg flex-shrink-0">
-      {letter}
-    </div>
-  );
-}
-
+/**
+ * Admin → Plugins. Two sub-tabs: Installed (local runtime list) and Discover (remote registry).
+ * Install is a two-step flow: click → consent modal (shows the plugin's declared services and
+ * capabilities) → confirm → actual tarball download.
+ *
+ * Data + mutations all live in `usePluginsTab`; lists and modals are their own components.
+ */
 export function PluginsTab() {
-  const { t } = useTranslation();
-  const [subTab, setSubTab] = useState<SubTab>('installed');
-  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
-  const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [registryLoading, setRegistryLoading] = useState(false);
-  const [registryError, setRegistryError] = useState<string | null>(null);
-  const [toggling, setToggling] = useState<string | null>(null);
-  const [expandedInstall, setExpandedInstall] = useState<string | null>(null);
-  const [showHowTo, setShowHowTo] = useState(false);
-  const [restarting, setRestarting] = useState(false);
-  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
-  const [installing, setInstalling] = useState<string | null>(null);
-  const [installMessage, setInstallMessage] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  const {
+    plugins, registry, loading, registryLoading, registryError,
+    toggling, installing, uninstalling, restarting, installMessage,
+    fetchRegistry, checkForUpdates, toggle, install, uninstall, restart,
+    setInstallMessage,
+  } = usePluginsTab();
 
-  // Consent-first install: click Install → modal shows the manifest's services + capabilities →
-  // admin confirms → Oscarr actually downloads the tarball and stores the plugin (disabled by default).
+  const [subTab, setSubTab] = useState<SubTab>('installed');
+  const [showHowTo, setShowHowTo] = useState(false);
+  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
+  const [expandedInstall, setExpandedInstall] = useState<string | null>(null);
+
+  /** Consent-first install: click Install → modal shows services + capabilities →
+   *  admin confirms → Oscarr actually downloads the tarball (disabled by default). */
   const [installConsent, setInstallConsent] = useState<RegistryPlugin | null>(null);
+
+  useEffect(() => {
+    if (subTab === 'discover' && registry.length === 0 && !registryLoading) {
+      fetchRegistry();
+    }
+  }, [subTab, registry.length, registryLoading, fetchRegistry]);
+
+  useEffect(() => { checkForUpdates(subTab); }, [subTab, checkForUpdates]);
 
   const handleInstall = (entry: RegistryPlugin) => {
     setInstallMessage(null);
@@ -104,122 +49,24 @@ export function PluginsTab() {
   };
 
   const doInstall = async (entry: RegistryPlugin) => {
-    setInstalling(entry.id);
-    const url = `https://api.github.com/repos/${entry.repository}/tarball/HEAD`;
-    try {
-      const { data } = await api.post('/plugins/install', { url });
-      setInstallMessage({ kind: 'success', text: `Installed ${data.plugin.name} v${data.plugin.version} — toggle it on in Installed whenever you're ready` });
+    // On failure, keep the consent modal open so the admin sees the error banner still inside
+    // the Discover context. Only a successful install closes the modal and flips the sub-tab.
+    const ok = await install(entry);
+    if (ok) {
       setInstallConsent(null);
-      await fetchPlugins();
       setSubTab('installed');
-    } catch (err) {
-      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? String((err as Error).message);
-      setInstallMessage({ kind: 'error', text: msg });
-    } finally {
-      setInstalling(null);
-      setTimeout(() => setInstallMessage(null), 6000);
     }
   };
 
   const handleRestart = async () => {
     setShowRestartConfirm(false);
-    setRestarting(true);
-    try {
-      await api.post('/admin/restart');
-    } catch { /* server is shutting down, expected */ }
-
-    // Poll until server is back
-    const poll = async () => {
-      for (let i = 0; i < 30; i++) {
-        await new Promise(r => setTimeout(r, 1000));
-        try {
-          await api.get('/app/features');
-          window.location.reload();
-          return;
-        } catch { /* still down */ }
-      }
-      // Give up after 30s
-      setRestarting(false);
-      alert('Server did not come back after 30 seconds. Check the logs.');
-    };
-    poll();
+    await restart();
   };
-
-  const fetchPlugins = useCallback(() => {
-    api.get('/plugins')
-      .then(({ data }) => setPlugins(data))
-      .catch((err) => toastApiError(err, t('admin.plugins.load_failed')))
-      .finally(() => setLoading(false));
-  }, [t]);
-
-  const fetchRegistry = useCallback(() => {
-    setRegistryLoading(true);
-    setRegistryError(null);
-    api.get('/plugins/registry')
-      .then(({ data }) => setRegistry(data))
-      .catch(() => setRegistryError('Failed to load plugin registry'))
-      .finally(() => setRegistryLoading(false));
-  }, []);
-
-  useEffect(() => { fetchPlugins(); }, [fetchPlugins]);
-  useEffect(() => {
-    if (subTab === 'discover' && registry.length === 0 && !registryLoading) {
-      fetchRegistry();
-    }
-  }, [subTab, registry.length, registryLoading, fetchRegistry]);
-
-  // Kick an update-check once on first mount of the Installed tab so the
-  // latestVersion badges can populate without user action. Backend has its
-  // own 1h cache, so this is a no-op on subsequent mounts.
-  const updateCheckedRef = useRef(false);
-  useEffect(() => {
-    if (subTab !== 'installed' || updateCheckedRef.current) return;
-    updateCheckedRef.current = true;
-    api.get('/plugins/updates').then(() => fetchPlugins()).catch(() => { /* best-effort */ });
-  }, [subTab, fetchPlugins]);
-
-  // Toggle is now friction-free — consent lives at install time (handleInstall), so flipping a
-  // plugin on/off post-install is just a DB flag change.
-  const handleToggle = async (plugin: PluginInfo) => {
-    setToggling(plugin.id);
-    try {
-      await api.put(`/plugins/${plugin.id}/toggle`, { enabled: !plugin.enabled });
-      setPlugins(prev => prev.map(p => p.id === plugin.id ? { ...p, enabled: !plugin.enabled } : p));
-      invalidatePluginUICache();
-    } catch (err) { toastApiError(err, t('admin.plugins.toggle_failed', { name: plugin.name })); }
-    setToggling(null);
-  };
-
-  const [uninstalling, setUninstalling] = useState<string | null>(null);
-  const [uninstallConfirm, setUninstallConfirm] = useState<string | null>(null);
-
-  const handleUninstall = async (id: string) => {
-    setUninstalling(id);
-    setUninstallConfirm(null);
-    try {
-      await api.post(`/plugins/${id}/uninstall`);
-      await fetchPlugins();
-      invalidatePluginUICache();
-    } catch (err) {
-      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? String((err as Error).message);
-      setInstallMessage({ kind: 'error', text: `Uninstall failed: ${msg}` });
-      setTimeout(() => setInstallMessage(null), 6000);
-    }
-    setUninstalling(null);
-  };
-
-  const installedIds = new Set(plugins.map(p => p.id));
-
-  // Registry metadata (repo URL etc.) — used only for the "View update" link, not for version detection.
-  const registryRepos = new Map<string, { url: string; repository: string }>();
-  for (const rp of registry) {
-    registryRepos.set(rp.id, { url: rp.url, repository: rp.repository });
-  }
-
-  // Update detection is authoritative from the backend (plugin.updateAvailable / plugin.latestVersion).
-  const updatesAvailable = plugins.filter((p) => p.updateAvailable).length;
 
   if (loading) return <Spinner />;
+
+  const updatesAvailable = plugins.filter((p) => p.updateAvailable).length;
+  const installedIds = new Set(plugins.map((p) => p.id));
 
   const headerActions = (
     <>
@@ -242,26 +89,24 @@ export function PluginsTab() {
     </>
   );
 
+  const expandedPlugin = expandedInstall ? registry.find((p) => p.id === expandedInstall) ?? null : null;
+
   return (
     <AdminTabLayout actions={headerActions}>
-      {/* Sub-tabs — underline style to stay consistent with MediaConfigTab. */}
       <div className="flex gap-2 mb-6 border-b border-white/5 pb-3">
         <button
           onClick={() => setSubTab('installed')}
           className={clsx(
             'flex items-center gap-2 px-4 py-1.5 rounded-lg text-sm font-medium transition-colors',
-            subTab === 'installed'
-              ? 'bg-ndp-accent/10 text-ndp-accent'
-              : 'text-ndp-text-muted hover:text-ndp-text hover:bg-white/5'
+            subTab === 'installed' ? 'bg-ndp-accent/10 text-ndp-accent' : 'text-ndp-text-muted hover:text-ndp-text hover:bg-white/5',
           )}
         >
           <Package className="w-4 h-4" />
           Installed
           {plugins.length > 0 && (
-            <span className={clsx(
-              'text-xs px-1.5 py-0.5 rounded-full',
-              subTab === 'installed' ? 'bg-ndp-accent/15' : 'bg-white/10'
-            )}>{plugins.length}</span>
+            <span className={clsx('text-xs px-1.5 py-0.5 rounded-full', subTab === 'installed' ? 'bg-ndp-accent/15' : 'bg-white/10')}>
+              {plugins.length}
+            </span>
           )}
           {updatesAvailable > 0 && (
             <span className="text-xs px-1.5 py-0.5 rounded-full bg-ndp-accent/80 text-white">
@@ -273,9 +118,7 @@ export function PluginsTab() {
           onClick={() => setSubTab('discover')}
           className={clsx(
             'flex items-center gap-2 px-4 py-1.5 rounded-lg text-sm font-medium transition-colors',
-            subTab === 'discover'
-              ? 'bg-ndp-accent/10 text-ndp-accent'
-              : 'text-ndp-text-muted hover:text-ndp-text hover:bg-white/5'
+            subTab === 'discover' ? 'bg-ndp-accent/10 text-ndp-accent' : 'text-ndp-text-muted hover:text-ndp-text hover:bg-white/5',
           )}
         >
           <Download className="w-4 h-4" />
@@ -283,10 +126,9 @@ export function PluginsTab() {
         </button>
       </div>
 
-      {/* Restart confirmation modal */}
       {showRestartConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowRestartConfirm(false)}>
-          <div className="card p-6 max-w-md mx-4" onClick={e => e.stopPropagation()}>
+          <div className="card p-6 max-w-md mx-4" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-ndp-text font-semibold mb-2">Reload plugins</h3>
             <p className="text-sm text-ndp-text-muted mb-4">
               Restarts Oscarr to discover plugins you added to <code className="text-ndp-text bg-black/30 px-1 py-0.5 rounded text-xs">packages/plugins</code> by hand.
@@ -304,7 +146,6 @@ export function PluginsTab() {
         </div>
       )}
 
-      {/* Restarting overlay */}
       {restarting && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
           <div className="flex flex-col items-center gap-4">
@@ -315,317 +156,33 @@ export function PluginsTab() {
         </div>
       )}
 
-      {/* ═══ Installed tab ═══ */}
       {subTab === 'installed' && (
-        <>
-          {plugins.length === 0 ? (
-            <div className="card p-10 text-center">
-              <Plug className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
-              <p className="text-ndp-text font-medium">{t('admin.plugins.no_plugins')}</p>
-              <p className="text-sm text-ndp-text-dim mt-1.5 max-w-md mx-auto">{t('admin.plugins.no_plugins_help')}</p>
-              <button
-                onClick={() => setSubTab('discover')}
-                className="mt-5 px-5 py-2.5 bg-ndp-accent text-white rounded-xl text-sm font-medium hover:bg-ndp-accent/90 transition-colors inline-flex items-center gap-2"
-              >
-                <Download className="w-4 h-4" />
-                Browse plugins
-              </button>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-              {plugins.map((plugin) => {
-                const rv = registryRepos.get(plugin.id);
-                const hasUpdate = !!plugin.updateAvailable;
-                const hasError = !!plugin.error;
-                const isConfirming = uninstallConfirm === plugin.id;
-                return (
-                  <div
-                    key={plugin.id}
-                    className={clsx(
-                      'card p-5 flex flex-col gap-4 transition-colors',
-                      hasError && 'border-ndp-danger/30'
-                    )}
-                  >
-                    {/* Header: avatar + name + version */}
-                    <div className="flex items-start gap-3">
-                      <PluginInitial name={plugin.name} />
-                      <div className="min-w-0 flex-1">
-                        <h3 className="text-sm font-semibold text-ndp-text truncate">{plugin.name}</h3>
-                        <p className="text-xs text-ndp-text-dim mt-0.5">
-                          v{plugin.version}
-                          {plugin.author && <> · {plugin.author}</>}
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Status badges */}
-                    {(hasUpdate || plugin.compat?.status === 'untested' || plugin.compat?.status === 'incompatible' || hasError) && (
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        {hasUpdate && plugin.latestVersion && (
-                          <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-accent/15 text-ndp-accent font-medium">
-                            v{plugin.latestVersion} available
-                          </span>
-                        )}
-                        {plugin.compat?.status === 'untested' && (
-                          <span className="text-xs px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-300 font-medium" title={plugin.compat.reason}>
-                            Untested
-                          </span>
-                        )}
-                        {plugin.compat?.status === 'incompatible' && (
-                          <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-danger/15 text-ndp-danger font-medium" title={plugin.compat.reason}>
-                            Incompatible
-                          </span>
-                        )}
-                        {hasError && (
-                          <span className="text-xs bg-ndp-danger/10 text-ndp-danger px-2 py-0.5 rounded-full">
-                            {t('common.error')}
-                          </span>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Description or error detail — fills to push footer down */}
-                    <div className="flex-1 min-h-[2.5rem]">
-                      {hasError ? (
-                        <p className="text-xs text-ndp-danger line-clamp-3">{plugin.error}</p>
-                      ) : plugin.description ? (
-                        <p className="text-sm text-ndp-text-muted line-clamp-2">{plugin.description}</p>
-                      ) : null}
-                      {hasUpdate && rv?.url && !hasError && (
-                        <a
-                          href={rv.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-xs text-ndp-accent hover:underline inline-flex items-center gap-1 mt-1.5"
-                        >
-                          View update <ExternalLink className="w-3 h-3" />
-                        </a>
-                      )}
-                    </div>
-
-                    {/* Footer: toggle + uninstall */}
-                    <div className="flex items-center justify-between pt-3 border-t border-white/5">
-                      <button
-                        onClick={() => handleToggle(plugin)}
-                        disabled={toggling === plugin.id}
-                        className="flex items-center gap-2.5 text-xs font-medium text-ndp-text-dim hover:text-ndp-text transition-colors"
-                        title={plugin.enabled ? 'Disable' : 'Enable'}
-                      >
-                        <span
-                          className={clsx(
-                            'relative w-9 h-5 rounded-full transition-colors',
-                            plugin.enabled ? 'bg-ndp-accent' : 'bg-white/10'
-                          )}
-                        >
-                          <span
-                            className={clsx(
-                              'absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform',
-                              plugin.enabled && 'translate-x-4'
-                            )}
-                          />
-                        </span>
-                        {plugin.enabled ? 'Enabled' : 'Disabled'}
-                      </button>
-                      {isConfirming ? (
-                        <div className="flex items-center gap-1.5">
-                          <button
-                            onClick={() => handleUninstall(plugin.id)}
-                            disabled={uninstalling === plugin.id}
-                            className="px-2.5 py-1 bg-ndp-danger hover:bg-ndp-danger/80 text-white rounded-md text-xs font-medium transition-colors disabled:opacity-50"
-                          >
-                            {uninstalling === plugin.id ? 'Uninstalling…' : 'Confirm'}
-                          </button>
-                          <button
-                            onClick={() => setUninstallConfirm(null)}
-                            className="px-2.5 py-1 text-ndp-text-dim hover:text-ndp-text rounded-md text-xs font-medium transition-colors"
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          onClick={() => setUninstallConfirm(plugin.id)}
-                          className="p-1.5 rounded-lg text-ndp-text-dim hover:text-ndp-danger hover:bg-ndp-danger/10 transition-colors"
-                          title="Uninstall"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </>
+        <InstalledList
+          plugins={plugins}
+          registry={registry}
+          toggling={toggling}
+          uninstalling={uninstalling}
+          onToggle={toggle}
+          onUninstall={uninstall}
+          onBrowse={() => setSubTab('discover')}
+        />
       )}
 
-      {/* ═══ Discover tab ═══ */}
       {subTab === 'discover' && (
-        <div className="space-y-5">
-          {installMessage && (
-            <div
-              className={clsx(
-                'card px-4 py-3 text-sm flex items-center gap-3',
-                installMessage.kind === 'success' && 'border-ndp-success/30 text-ndp-success',
-                installMessage.kind === 'error' && 'border-ndp-error/30 text-ndp-error'
-              )}
-            >
-              {installMessage.kind === 'success' ? <Check className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
-              <span>{installMessage.text}</span>
-            </div>
-          )}
-
-          {registryLoading && (
-            <div className="flex justify-center py-12">
-              <Loader2 className="w-6 h-6 animate-spin text-ndp-accent" />
-            </div>
-          )}
-
-          {registryError && (
-            <div className="card p-6 text-center">
-              <p className="text-ndp-error text-sm">{registryError}</p>
-              <button
-                onClick={fetchRegistry}
-                className="mt-3 px-4 py-2 bg-ndp-accent text-white rounded-lg text-sm font-medium hover:bg-ndp-accent/90 transition-colors"
-              >
-                Retry
-              </button>
-            </div>
-          )}
-
-          {!registryLoading && !registryError && registry.length === 0 && (
-            <div className="card p-10 text-center">
-              <Download className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
-              <p className="text-ndp-text font-medium">No plugins available yet</p>
-              <p className="text-sm text-ndp-text-dim mt-1.5">Community plugins will appear here once published.</p>
-            </div>
-          )}
-
-          {!registryLoading && registry.length > 0 && (
-            <>
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-ndp-text-dim">
-                  {registry.length} plugin{registry.length !== 1 ? 's' : ''} available
-                </p>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-                {registry.map((plugin) => {
-                  const isInstalled = installedIds.has(plugin.id);
-                  const cat = CATEGORY_CONFIG[plugin.category] || { label: plugin.category, color: 'bg-white/5 text-ndp-text-dim' };
-
-                  return (
-                    <div key={plugin.id} className="card p-5 flex flex-col gap-4">
-                      {/* Header: avatar + name + version */}
-                      <div className="flex items-start gap-3">
-                        <PluginInitial name={plugin.name} />
-                        <div className="min-w-0 flex-1">
-                          <h3 className="text-sm font-semibold text-ndp-text truncate">{plugin.name}</h3>
-                          <p className="text-xs text-ndp-text-dim mt-0.5">
-                            v{plugin.version}
-                            {plugin.author && <> · {plugin.author}</>}
-                          </p>
-                        </div>
-                        <a
-                          href={plugin.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="p-1.5 -m-1.5 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
-                          title="View on GitHub"
-                        >
-                          <ExternalLink className="w-4 h-4" />
-                        </a>
-                      </div>
-
-                      {/* Category + tags */}
-                      <div className="flex items-center gap-1.5 flex-wrap">
-                        <span className={clsx('text-xs px-2 py-0.5 rounded-full font-medium', cat.color)}>
-                          {cat.label}
-                        </span>
-                        {plugin.tags?.map((tag) => {
-                          const tagCfg = TAG_CONFIG[tag] || { label: tag, color: 'bg-white/5 text-ndp-text-dim' };
-                          return (
-                            <span key={tag} className={clsx('text-xs px-2 py-0.5 rounded-full font-medium', tagCfg.color)}>
-                              {tagCfg.label}
-                            </span>
-                          );
-                        })}
-                        {isInstalled && (
-                          <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-success/15 text-ndp-success font-medium">
-                            Installed
-                          </span>
-                        )}
-                      </div>
-
-                      {/* Description — fills to push footer down so actions align across the row */}
-                      <div className="flex-1 min-h-[2.5rem]">
-                        {plugin.description && (
-                          <p className="text-sm text-ndp-text-muted line-clamp-3">{plugin.description}</p>
-                        )}
-                      </div>
-
-                      {/* Meta */}
-                      <div className="flex items-center gap-3 text-xs text-ndp-text-dim">
-                        {plugin.stars > 0 && (
-                          <span className="flex items-center gap-1">
-                            <Star className="w-3 h-3" />
-                            {plugin.stars}
-                          </span>
-                        )}
-                        {plugin.updatedAt && (
-                          <span>Updated {new Date(plugin.updatedAt).toLocaleDateString()}</span>
-                        )}
-                      </div>
-
-                      {/* Footer: Install + advanced terminal */}
-                      <div className="flex items-center gap-2 pt-3 border-t border-white/5">
-                        {isInstalled ? (
-                          <button
-                            onClick={() => setSubTab('installed')}
-                            className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-ndp-text-muted transition-colors"
-                          >
-                            <Package className="w-4 h-4" />
-                            Manage
-                          </button>
-                        ) : (
-                          <>
-                            <button
-                              onClick={() => handleInstall(plugin)}
-                              disabled={installing === plugin.id}
-                              className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-ndp-accent hover:bg-ndp-accent/90 disabled:opacity-50 rounded-lg text-sm text-white font-medium transition-colors"
-                            >
-                              {installing === plugin.id ? (
-                                <>
-                                  <Loader2 className="w-4 h-4 animate-spin" />
-                                  Installing…
-                                </>
-                              ) : (
-                                <>
-                                  <Download className="w-4 h-4" />
-                                  Install
-                                </>
-                              )}
-                            </button>
-                            <button
-                              onClick={() => setExpandedInstall(plugin.id)}
-                              className="p-2 bg-white/5 hover:bg-white/10 rounded-lg text-ndp-text-dim hover:text-ndp-text transition-colors"
-                              title="Manual install (advanced)"
-                            >
-                              <Terminal className="w-4 h-4" />
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-        </div>
+        <DiscoverList
+          registry={registry}
+          registryLoading={registryLoading}
+          registryError={registryError}
+          installedIds={installedIds}
+          installing={installing}
+          installMessage={installMessage}
+          onRetry={fetchRegistry}
+          onInstall={handleInstall}
+          onExpandManual={setExpandedInstall}
+          onManage={() => setSubTab('installed')}
+        />
       )}
+
       <PluginConsentModal
         plugin={installConsent}
         open={!!installConsent}
@@ -635,134 +192,11 @@ export function PluginsTab() {
         onConfirm={() => installConsent && doInstall(installConsent)}
       />
 
-      {/* Manual install modal — replaces the inline expand so the discover grid stays intact. */}
-      {expandedInstall && (() => {
-        const plugin = registry.find((p) => p.id === expandedInstall);
-        if (!plugin) return null;
-        const installCmd = `cd packages/plugins && git clone ${plugin.url}.git ${plugin.id}`;
-        const npmCmd = `cd packages/plugins/${plugin.id} && npm install --production`;
-        return (
-          <div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-            onClick={(e) => { if (e.target === e.currentTarget) setExpandedInstall(null); }}
-          >
-            <div className="card w-full max-w-lg shadow-2xl shadow-black/50">
-              <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4">
-                <div className="min-w-0">
-                  <h2 className="text-base font-semibold text-ndp-text">Manual install</h2>
-                  <p className="text-xs text-ndp-text-dim mt-0.5">{plugin.name} · v{plugin.version}</p>
-                </div>
-                <button
-                  onClick={() => setExpandedInstall(null)}
-                  className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors"
-                  aria-label="Close"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-              <div className="px-6 pb-6 space-y-2">
-                <p className="text-xs text-ndp-text-dim">
-                  Run these commands from your Oscarr checkout, then restart the server to discover and enable the plugin.
-                </p>
-                <div className="flex items-center gap-2 pt-2">
-                  <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">1</span>
-                  <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
-                    {installCmd}
-                  </code>
-                  <CopyButton text={installCmd} />
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">2</span>
-                  <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
-                    {npmCmd}
-                  </code>
-                  <CopyButton text={npmCmd} />
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">3</span>
-                  <span className="flex-1 text-xs text-ndp-text-dim px-3 py-2">
-                    Click <span className="text-ndp-text">Reload plugins</span> to pick it up without a full restart.
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      })()}
-
-      {/* Plugin development docs — triggered from the Docs button in the header row. */}
-      {showHowTo && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-          onClick={(e) => { if (e.target === e.currentTarget) setShowHowTo(false); }}
-        >
-          <div className="card w-full max-w-xl shadow-2xl shadow-black/50 max-h-[85vh] flex flex-col">
-            <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4 flex-shrink-0">
-              <div className="min-w-0">
-                <h2 className="text-base font-semibold text-ndp-text">Build a plugin</h2>
-                <p className="text-xs text-ndp-text-dim mt-0.5">Quick reference to get a plugin skeleton running.</p>
-              </div>
-              <button
-                onClick={() => setShowHowTo(false)}
-                className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
-                aria-label="Close"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-            <div className="px-6 pb-6 space-y-4 text-sm text-ndp-text-muted overflow-y-auto">
-              <p>
-                Oscarr plugins are Node.js modules that extend the backend and/or frontend.
-                Each one lives in its own folder under <code className="text-ndp-text bg-black/30 px-1.5 py-0.5 rounded text-xs">packages/plugins/</code>.
-              </p>
-              <div>
-                <p className="text-ndp-text font-medium mb-2 text-xs uppercase tracking-wider">Minimal structure</p>
-                <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
-{`my-plugin/
-├── manifest.json    # Plugin metadata
-├── package.json     # Dependencies
-├── index.js         # Entry point (register function)
-└── src/             # Your code`}
-                </pre>
-              </div>
-              <div>
-                <p className="text-ndp-text font-medium mb-2 text-xs uppercase tracking-wider">manifest.json</p>
-                <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
-{`{
-  "id": "my-plugin",
-  "name": "My Plugin",
-  "version": "1.0.0",
-  "apiVersion": "v1",
-  "entry": "index.js",
-  "description": "What it does",
-  "author": "Your name"
-}`}
-                </pre>
-              </div>
-              <div className="flex items-center gap-2 pt-1 flex-wrap">
-                <a
-                  href="https://github.com/arediss/Oscarr/blob/main/docs/plugins.md"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-xs text-ndp-text transition-colors"
-                >
-                  <BookOpen className="w-3.5 h-3.5" />
-                  Full documentation
-                </a>
-                <a
-                  href="https://github.com/arediss/Oscarr-Plugin-Registry"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-xs text-ndp-text transition-colors"
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                  Submit your plugin
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
+      {expandedPlugin && (
+        <ManualInstallModal plugin={expandedPlugin} onClose={() => setExpandedInstall(null)} />
       )}
+
+      {showHowTo && <PluginDocsModal onClose={() => setShowHowTo(false)} />}
     </AdminTabLayout>
   );
 }

--- a/packages/frontend/src/pages/admin/ServicesTab.tsx
+++ b/packages/frontend/src/pages/admin/ServicesTab.tsx
@@ -1,89 +1,35 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { clsx } from 'clsx';
-import { Loader2, RefreshCw, Plus, Trash2, Pencil, Power, Save, Server, Star, Plug, Eye, EyeOff } from 'lucide-react';
-import api from '@/lib/api';
-import { toastApiError } from '@/utils/toast';
+import { Loader2, Plus, Server, Trash2 } from 'lucide-react';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import { useServiceSchemas, type ServiceData } from '@/hooks/useServiceSchemas';
+import { useServicesTab } from './services/useServicesTab';
+import { ServiceRow } from './services/ServiceRow';
+import { ServiceModal } from './services/ServiceModal';
 
+/**
+ * Admin → Services. Lists every configured *arr / media server / downloader, with per-row test
+ * badges, quick toggles, and a modal for create/edit. Data + mutations live in `useServicesTab`;
+ * the row and the form are their own components. This file just composes the layout.
+ */
 export function ServicesTab() {
   const { schemas: SERVICE_SCHEMAS } = useServiceSchemas();
   const { t } = useTranslation();
-  const [services, setServices] = useState<ServiceData[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    services, loading, testing, testResults, deleting,
+    fetchServices, deleteService, toggleService, setDefaultService, testService,
+  } = useServicesTab();
+
   const [showModal, setShowModal] = useState(false);
   const [editingService, setEditingService] = useState<ServiceData | null>(null);
-  const [testing, setTesting] = useState<number | null>(null);
-  const [testResults, setTestResults] = useState<Record<number, { ok: boolean; version?: string }>>({});
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
-  const [deleting, setDeleting] = useState(false);
 
-  const fetchServices = useCallback(async () => {
-    try {
-      const { data } = await api.get('/admin/services');
-      setServices(data);
-      return data as ServiceData[];
-    } catch (err) {
-      toastApiError(err, t('admin.services.load_failed'));
-      return [];
-    } finally { setLoading(false); }
-  }, [t]);
-
-  const testAllServices = useCallback((serviceList: ServiceData[]) => {
-    // Bulk probe on mount: one red badge per failing service in the grid is enough UX signal,
-    // no per-service toast. But log so a timeout / 401 / DNS issue leaves a trail in devtools.
-    serviceList.forEach(async (svc) => {
-      if (!svc.enabled) return;
-      try {
-        const { data } = await api.post(`/admin/services/${svc.id}/test`);
-        setTestResults(prev => ({ ...prev, [svc.id]: { ok: true, version: data.version } }));
-      } catch (err) {
-        console.error(`Service test failed for #${svc.id} (${svc.type})`, err);
-        setTestResults(prev => ({ ...prev, [svc.id]: { ok: false } }));
-      }
-    });
-  }, []);
-
-  useEffect(() => {
-    fetchServices().then((svcs) => { if (svcs.length) testAllServices(svcs); });
-  }, [fetchServices, testAllServices]);
-
-  const handleDelete = async (id: number) => {
-    setDeleting(true);
-    try {
-      await api.delete(`/admin/services/${id}`);
-      fetchServices();
-    } catch (err) { toastApiError(err, t('admin.services.delete_failed')); }
-    finally { setDeleting(false); setConfirmDelete(null); }
-  };
-
-  const handleToggle = async (service: ServiceData) => {
-    try {
-      await api.put(`/admin/services/${service.id}`, { enabled: !service.enabled });
-      fetchServices();
-    } catch (err) { toastApiError(err, t('admin.services.toggle_failed')); }
-  };
-
-  const handleSetDefault = async (service: ServiceData) => {
-    try {
-      await api.put(`/admin/services/${service.id}`, { isDefault: true });
-      fetchServices();
-    } catch (err) { toastApiError(err, t('admin.services.set_default_failed')); }
-  };
-
-  const handleTest = async (service: ServiceData) => {
-    setTesting(service.id);
-    try {
-      const { data } = await api.post(`/admin/services/${service.id}/test`);
-      setTestResults(prev => ({ ...prev, [service.id]: { ok: true, version: data.version } }));
-    } catch (err) {
-      // Explicit click — surface the backend error so the admin knows if it's a 401, timeout, etc.
-      toastApiError(err, t('admin.services.test_failed', { name: service.name }));
-      setTestResults(prev => ({ ...prev, [service.id]: { ok: false } }));
-    } finally { setTesting(null); }
+  const handleDeleteConfirmed = async (id: number) => {
+    // Only close the confirm modal on success — on error the toast explains what happened and
+    // the admin can retry with the same selection still in view.
+    if (await deleteService(id)) setConfirmDelete(null);
   };
 
   if (loading) return <Spinner />;
@@ -98,7 +44,6 @@ export function ServicesTab() {
         </button>
       }
     >
-
       {services.length === 0 ? (
         <div className="card p-12 text-center">
           <Server className="w-12 h-12 text-ndp-text-dim mx-auto mb-4" />
@@ -107,79 +52,36 @@ export function ServicesTab() {
         </div>
       ) : (
         <div className="space-y-3">
-          {services.map((service) => {
-            const schema = SERVICE_SCHEMAS[service.type];
-            const result = testResults[service.id] || null;
-            return (
-              <div key={service.id} className={clsx('card', !service.enabled && 'opacity-50')}>
-                <div className="flex items-center gap-4 p-4">
-                  {/* Status dot */}
-                  <span className={clsx('w-2.5 h-2.5 rounded-full flex-shrink-0', service.enabled ? 'bg-ndp-success' : 'bg-ndp-text-dim')} />
-
-                  {/* Icon + info */}
-                  <img src={schema?.icon || '/favicon.svg'} alt={schema?.label || service.type} className="w-8 h-8 rounded-lg object-contain flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-semibold text-ndp-text truncate">{service.name}</span>
-                      {service.isDefault && (
-                        <span className="px-1.5 py-0.5 bg-ndp-accent/10 text-ndp-accent text-[10px] font-semibold rounded-full flex-shrink-0">{t('common.default_badge')}</span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-3 mt-0.5">
-                      <span className="text-xs text-ndp-text-dim">{schema?.label || service.type}</span>
-                      {service.config.url && <span className="text-xs text-ndp-text-dim truncate">{service.config.url}</span>}
-                    </div>
-                  </div>
-
-                  {/* Test result */}
-                  {result && (
-                    <span className={clsx('text-xs px-2 py-1 rounded-lg flex-shrink-0', result.ok ? 'bg-ndp-success/10 text-ndp-success' : 'bg-ndp-danger/10 text-ndp-danger')}>
-                      {result.ok ? (result.version ? `v${result.version}` : t('status.connected')) : t('status.connection_failed')}
-                    </span>
-                  )}
-
-                  {/* Actions */}
-                  <div className="flex items-center gap-0.5 flex-shrink-0">
-                    <button onClick={() => handleTest(service)} disabled={testing === service.id} className="p-2 text-ndp-text-dim hover:text-ndp-accent hover:bg-white/5 rounded-lg transition-colors" title={t('common.test')}>
-                      {testing === service.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plug className="w-4 h-4" />}
-                    </button>
-                    <button onClick={() => { setEditingService(service); setShowModal(true); }} className="p-2 text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 rounded-lg transition-colors" title={t('common.edit')}>
-                      <Pencil className="w-4 h-4" />
-                    </button>
-                    <button onClick={() => handleToggle(service)} className="p-2 text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 rounded-lg transition-colors" title={service.enabled ? t('common.disable') : t('common.enable')}>
-                      <Power className={clsx('w-4 h-4', service.enabled && 'text-ndp-success')} />
-                    </button>
-                    {!service.isDefault && (
-                      <button onClick={() => handleSetDefault(service)} className="p-2 text-ndp-text-dim hover:text-ndp-warning hover:bg-white/5 rounded-lg transition-colors" title={t('admin.services.set_default')}>
-                        <Star className="w-4 h-4" />
-                      </button>
-                    )}
-                    <div className="w-px h-5 bg-white/10 mx-1" />
-                    <button onClick={() => setConfirmDelete(service.id)} className="p-2 text-ndp-text-dim hover:text-ndp-danger hover:bg-white/5 rounded-lg transition-colors" title={t('common.delete')}>
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+          {services.map((service) => (
+            <ServiceRow
+              key={service.id}
+              service={service}
+              schema={SERVICE_SCHEMAS[service.type]}
+              testing={testing === service.id}
+              result={testResults[service.id] || null}
+              onTest={testService}
+              onEdit={(s) => { setEditingService(s); setShowModal(true); }}
+              onToggle={toggleService}
+              onSetDefault={setDefaultService}
+              onDelete={setConfirmDelete}
+            />
+          ))}
         </div>
       )}
 
-      {/* Delete confirmation modal */}
-      {confirmDelete && createPortal(
+      {confirmDelete !== null && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in">
           <div className="card p-6 max-w-sm w-full mx-4 shadow-2xl">
             <h3 className="text-lg font-bold text-ndp-text mb-2">{t('admin.danger.confirm_title')}</h3>
             <p className="text-sm text-ndp-text-muted mb-6">
-              {t('admin.services.confirm_delete', { name: services.find(s => s.id === confirmDelete)?.name })}
+              {t('admin.services.confirm_delete', { name: services.find((s) => s.id === confirmDelete)?.name })}
             </p>
             <div className="flex gap-3">
               <button onClick={() => setConfirmDelete(null)} className="btn-secondary text-sm flex-1">
                 {t('common.cancel')}
               </button>
               <button
-                onClick={() => handleDelete(confirmDelete)}
+                onClick={() => handleDeleteConfirmed(confirmDelete)}
                 disabled={deleting}
                 className="btn-danger text-sm flex-1 flex items-center justify-center gap-2"
               >
@@ -189,7 +91,7 @@ export function ServicesTab() {
             </div>
           </div>
         </div>,
-        document.body
+        document.body,
       )}
 
       {showModal && (
@@ -200,158 +102,5 @@ export function ServicesTab() {
         />
       )}
     </AdminTabLayout>
-  );
-}
-
-function ServiceModal({ service, onClose, onSaved }: { service: ServiceData | null; onClose: () => void; onSaved: () => void }) {
-  const { t } = useTranslation();
-  const { schemas: SERVICE_SCHEMAS } = useServiceSchemas();
-  const isEdit = !!service;
-  const [type, setType] = useState(service?.type || 'radarr');
-  const [name, setName] = useState(service?.name || '');
-  const [config, setConfig] = useState<Record<string, string>>(service?.config || {});
-  const [isDefault, setIsDefault] = useState(service?.isDefault || false);
-  const [saving, setSaving] = useState(false);
-  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
-  const [fetchingPlexToken, setFetchingPlexToken] = useState(false);
-  const [detectingMachineId, setDetectingMachineId] = useState(false);
-  const [modalError, setModalError] = useState('');
-
-  const schema = SERVICE_SCHEMAS[type];
-
-  const handleConfigChange = (key: string, value: string) => {
-    setConfig((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const fetchPlexToken = async () => {
-    setFetchingPlexToken(true);
-    try {
-      const { data } = await api.get('/admin/plex-token');
-      if (data.token) handleConfigChange('token', data.token);
-    } catch {
-      setModalError(t('admin.services.plex_token_error'));
-      setTimeout(() => setModalError(''), 5000);
-    } finally { setFetchingPlexToken(false); }
-  };
-
-  const detectMachineId = async () => {
-    const url = config.url;
-    const token = config.token;
-    if (!url || !token) return;
-    setDetectingMachineId(true);
-    try {
-      const res = await fetch(`${url}/identity`, {
-        headers: { 'X-Plex-Token': token, Accept: 'application/json' },
-      });
-      const json = await res.json();
-      const machineId = json.MediaContainer?.machineIdentifier;
-      if (machineId) handleConfigChange('machineId', machineId);
-    } catch (err) { toastApiError(err, t('admin.services.detect_machine_id_failed')); }
-    finally { setDetectingMachineId(false); }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    try {
-      if (isEdit) {
-        await api.put(`/admin/services/${service!.id}`, { name, config, isDefault });
-      } else {
-        await api.post('/admin/services', { name, type, config, isDefault });
-      }
-      onSaved();
-    } catch (err) { toastApiError(err, t(isEdit ? 'admin.services.save_failed' : 'admin.services.create_failed')); }
-    finally { setSaving(false); }
-  };
-
-  return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onMouseDown={onClose}>
-      <div className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in" onMouseDown={(e) => e.stopPropagation()}>
-        <h2 className="text-lg font-bold text-ndp-text mb-5">{isEdit ? t('admin.services.edit_title') : t('admin.services.add_title')}</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {!isEdit && (
-            <div>
-              <label className="text-sm text-ndp-text mb-1.5 block">{t('admin.services.service_type')}</label>
-              <select value={type} onChange={(e) => { setType(e.target.value); setConfig({}); }} className="input w-full">
-                {Object.entries(SERVICE_SCHEMAS).map(([key, s]) => (
-                  <option key={key} value={key}>{s.label}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <div>
-            <label className="text-sm text-ndp-text mb-1.5 block">{t('common.name')}</label>
-            <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder={`${schema?.label || type} Principal`} className="input w-full" required />
-          </div>
-
-          {schema?.fields.map((field) => (
-            <div key={field.key}>
-              <label className="text-sm text-ndp-text mb-1.5 block">{t(field.labelKey)}</label>
-              <div className="relative">
-                <input
-                  type={field.type === 'password' && !showSecrets[field.key] ? 'password' : 'text'}
-                  value={config[field.key] || ''}
-                  onChange={(e) => handleConfigChange(field.key, e.target.value)}
-                  placeholder={field.placeholder}
-                  className="input w-full pr-10"
-                />
-                {field.type === 'password' && (
-                  <button
-                    type="button"
-                    onClick={() => setShowSecrets((prev) => ({ ...prev, [field.key]: !prev[field.key] }))}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ndp-text-dim hover:text-ndp-text"
-                  >
-                    {showSecrets[field.key] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                  </button>
-                )}
-              </div>
-              {/* Plex helpers */}
-              {type === 'plex' && field.key === 'token' && (
-                <>
-                  <button
-                    type="button"
-                    onClick={fetchPlexToken}
-                    disabled={fetchingPlexToken}
-                    className="mt-1.5 text-xs text-ndp-accent hover:text-ndp-accent-hover flex items-center gap-1 transition-colors"
-                  >
-                    {fetchingPlexToken ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plug className="w-3 h-3" />}
-                    {t('admin.services.use_plex_token')}
-                  </button>
-                  {modalError && <p className="text-xs text-ndp-danger mt-1">{modalError}</p>}
-                </>
-              )}
-              {type === 'plex' && field.key === 'machineId' && (
-                <button
-                  type="button"
-                  onClick={detectMachineId}
-                  disabled={detectingMachineId || !config.url || !config.token}
-                  className="mt-1.5 text-xs text-ndp-accent hover:text-ndp-accent-hover flex items-center gap-1 transition-colors disabled:opacity-40"
-                >
-                  {detectingMachineId ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
-                  {t('admin.services.auto_detect')}
-                </button>
-              )}
-            </div>
-          ))}
-
-          <label className="flex items-center gap-2 text-sm text-ndp-text-muted cursor-pointer">
-            <input type="checkbox" checked={isDefault} onChange={(e) => setIsDefault(e.target.checked)} className="rounded" />
-            {t('admin.services.set_default')}
-          </label>
-
-          <div className="flex gap-3 pt-2">
-            <button type="button" onClick={onClose} className="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium bg-ndp-surface text-ndp-text-muted hover:bg-ndp-surface-light transition-colors">
-              {t('common.cancel')}
-            </button>
-            <button type="submit" disabled={saving} className="flex-1 btn-primary flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium">
-              {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
-              {isEdit ? t('common.save') : t('common.add')}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>,
-    document.body
   );
 }

--- a/packages/frontend/src/pages/admin/plugins/DiscoverList.tsx
+++ b/packages/frontend/src/pages/admin/plugins/DiscoverList.tsx
@@ -1,0 +1,183 @@
+import { clsx } from 'clsx';
+import { AlertTriangle, Check, Download, ExternalLink, Loader2, Package, Star, Terminal } from 'lucide-react';
+import { PluginInitial } from './PluginCardChrome';
+import { CATEGORY_CONFIG, TAG_CONFIG, type RegistryPlugin } from './constants';
+import type { InstallMessage } from './usePluginsTab';
+
+interface DiscoverListProps {
+  registry: RegistryPlugin[];
+  registryLoading: boolean;
+  registryError: string | null;
+  installedIds: Set<string>;
+  installing: string | null;
+  installMessage: InstallMessage | null;
+  onRetry: () => void;
+  onInstall: (entry: RegistryPlugin) => void;
+  onExpandManual: (id: string) => void;
+  onManage: () => void;
+}
+
+/** Discover grid — browse the GitHub plugin registry, install with a click (consent happens in
+ *  the parent through PluginConsentModal), or expand the Terminal icon for manual git-clone
+ *  instructions (admin escape hatch when the automatic install can't reach the registry). */
+export function DiscoverList({
+  registry, registryLoading, registryError, installedIds,
+  installing, installMessage, onRetry, onInstall, onExpandManual, onManage,
+}: DiscoverListProps) {
+  return (
+    <div className="space-y-5">
+      {installMessage && (
+        <div
+          className={clsx(
+            'card px-4 py-3 text-sm flex items-center gap-3',
+            installMessage.kind === 'success' && 'border-ndp-success/30 text-ndp-success',
+            installMessage.kind === 'error' && 'border-ndp-error/30 text-ndp-error',
+          )}
+        >
+          {installMessage.kind === 'success' ? <Check className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          <span>{installMessage.text}</span>
+        </div>
+      )}
+
+      {registryLoading && (
+        <div className="flex justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-ndp-accent" />
+        </div>
+      )}
+
+      {registryError && (
+        <div className="card p-6 text-center">
+          <p className="text-ndp-error text-sm">{registryError}</p>
+          <button onClick={onRetry} className="mt-3 px-4 py-2 bg-ndp-accent text-white rounded-lg text-sm font-medium hover:bg-ndp-accent/90 transition-colors">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!registryLoading && !registryError && registry.length === 0 && (
+        <div className="card p-10 text-center">
+          <Download className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
+          <p className="text-ndp-text font-medium">No plugins available yet</p>
+          <p className="text-sm text-ndp-text-dim mt-1.5">Community plugins will appear here once published.</p>
+        </div>
+      )}
+
+      {!registryLoading && registry.length > 0 && (
+        <>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-ndp-text-dim">
+              {registry.length} plugin{registry.length !== 1 ? 's' : ''} available
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {registry.map((plugin) => {
+              const isInstalled = installedIds.has(plugin.id);
+              const cat = CATEGORY_CONFIG[plugin.category] || { label: plugin.category, color: 'bg-white/5 text-ndp-text-dim' };
+
+              return (
+                <div key={plugin.id} className="card p-5 flex flex-col gap-4">
+                  <div className="flex items-start gap-3">
+                    <PluginInitial name={plugin.name} />
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-sm font-semibold text-ndp-text truncate">{plugin.name}</h3>
+                      <p className="text-xs text-ndp-text-dim mt-0.5">
+                        v{plugin.version}
+                        {plugin.author && <> · {plugin.author}</>}
+                      </p>
+                    </div>
+                    <a
+                      href={plugin.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="p-1.5 -m-1.5 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
+                      title="View on GitHub"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                    </a>
+                  </div>
+
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span className={clsx('text-xs px-2 py-0.5 rounded-full font-medium', cat.color)}>
+                      {cat.label}
+                    </span>
+                    {plugin.tags?.map((tag) => {
+                      const tagCfg = TAG_CONFIG[tag] || { label: tag, color: 'bg-white/5 text-ndp-text-dim' };
+                      return (
+                        <span key={tag} className={clsx('text-xs px-2 py-0.5 rounded-full font-medium', tagCfg.color)}>
+                          {tagCfg.label}
+                        </span>
+                      );
+                    })}
+                    {isInstalled && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-success/15 text-ndp-success font-medium">
+                        Installed
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-h-[2.5rem]">
+                    {plugin.description && (
+                      <p className="text-sm text-ndp-text-muted line-clamp-3">{plugin.description}</p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-3 text-xs text-ndp-text-dim">
+                    {plugin.stars > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Star className="w-3 h-3" />
+                        {plugin.stars}
+                      </span>
+                    )}
+                    {plugin.updatedAt && (
+                      <span>Updated {new Date(plugin.updatedAt).toLocaleDateString()}</span>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-2 pt-3 border-t border-white/5">
+                    {isInstalled ? (
+                      <button
+                        onClick={onManage}
+                        className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-ndp-text-muted transition-colors"
+                      >
+                        <Package className="w-4 h-4" />
+                        Manage
+                      </button>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => onInstall(plugin)}
+                          disabled={installing === plugin.id}
+                          className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-ndp-accent hover:bg-ndp-accent/90 disabled:opacity-50 rounded-lg text-sm text-white font-medium transition-colors"
+                        >
+                          {installing === plugin.id ? (
+                            <>
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                              Installing…
+                            </>
+                          ) : (
+                            <>
+                              <Download className="w-4 h-4" />
+                              Install
+                            </>
+                          )}
+                        </button>
+                        <button
+                          onClick={() => onExpandManual(plugin.id)}
+                          className="p-2 bg-white/5 hover:bg-white/10 rounded-lg text-ndp-text-dim hover:text-ndp-text transition-colors"
+                          title="Manual install (advanced)"
+                        >
+                          <Terminal className="w-4 h-4" />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/plugins/InstalledList.tsx
+++ b/packages/frontend/src/pages/admin/plugins/InstalledList.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { clsx } from 'clsx';
+import { Download, ExternalLink, Plug, Trash2 } from 'lucide-react';
+import type { PluginInfo } from '@/plugins/types';
+import { PluginInitial } from './PluginCardChrome';
+import type { RegistryPlugin } from './constants';
+
+interface InstalledListProps {
+  plugins: PluginInfo[];
+  registry: RegistryPlugin[];
+  toggling: string | null;
+  uninstalling: string | null;
+  onToggle: (plugin: PluginInfo) => void;
+  onUninstall: (id: string) => void;
+  onBrowse: () => void;
+}
+
+/** Grid of installed plugins — version / author / status badges / update link / enable toggle /
+ *  uninstall-with-inline-confirm. Renders the empty state with a "Browse plugins" CTA when the
+ *  list is empty. */
+export function InstalledList({
+  plugins, registry, toggling, uninstalling, onToggle, onUninstall, onBrowse,
+}: InstalledListProps) {
+  const { t } = useTranslation();
+  const [uninstallConfirm, setUninstallConfirm] = useState<string | null>(null);
+
+  // Registry lookup for the "View update" link — we don't care about the version here (the
+  // backend decides updateAvailable), only the GitHub URL where the changelog lives.
+  const registryRepos = new Map(registry.map((rp) => [rp.id, { url: rp.url, repository: rp.repository }]));
+
+  if (plugins.length === 0) {
+    return (
+      <div className="card p-10 text-center">
+        <Plug className="w-12 h-12 text-ndp-text-dim mx-auto mb-4 opacity-50" />
+        <p className="text-ndp-text font-medium">{t('admin.plugins.no_plugins')}</p>
+        <p className="text-sm text-ndp-text-dim mt-1.5 max-w-md mx-auto">{t('admin.plugins.no_plugins_help')}</p>
+        <button
+          onClick={onBrowse}
+          className="mt-5 px-5 py-2.5 bg-ndp-accent text-white rounded-xl text-sm font-medium hover:bg-ndp-accent/90 transition-colors inline-flex items-center gap-2"
+        >
+          <Download className="w-4 h-4" />
+          Browse plugins
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {plugins.map((plugin) => {
+        const rv = registryRepos.get(plugin.id);
+        const hasUpdate = !!plugin.updateAvailable;
+        const hasError = !!plugin.error;
+        const isConfirming = uninstallConfirm === plugin.id;
+        return (
+          <div key={plugin.id} className={clsx('card p-5 flex flex-col gap-4 transition-colors', hasError && 'border-ndp-danger/30')}>
+            <div className="flex items-start gap-3">
+              <PluginInitial name={plugin.name} />
+              <div className="min-w-0 flex-1">
+                <h3 className="text-sm font-semibold text-ndp-text truncate">{plugin.name}</h3>
+                <p className="text-xs text-ndp-text-dim mt-0.5">
+                  v{plugin.version}
+                  {plugin.author && <> · {plugin.author}</>}
+                </p>
+              </div>
+            </div>
+
+            {(hasUpdate || plugin.compat?.status === 'untested' || plugin.compat?.status === 'incompatible' || hasError) && (
+              <div className="flex items-center gap-1.5 flex-wrap">
+                {hasUpdate && plugin.latestVersion && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-accent/15 text-ndp-accent font-medium">
+                    v{plugin.latestVersion} available
+                  </span>
+                )}
+                {plugin.compat?.status === 'untested' && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-300 font-medium" title={plugin.compat.reason}>
+                    Untested
+                  </span>
+                )}
+                {plugin.compat?.status === 'incompatible' && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-ndp-danger/15 text-ndp-danger font-medium" title={plugin.compat.reason}>
+                    Incompatible
+                  </span>
+                )}
+                {hasError && (
+                  <span className="text-xs bg-ndp-danger/10 text-ndp-danger px-2 py-0.5 rounded-full">
+                    {t('common.error')}
+                  </span>
+                )}
+              </div>
+            )}
+
+            <div className="flex-1 min-h-[2.5rem]">
+              {hasError ? (
+                <p className="text-xs text-ndp-danger line-clamp-3">{plugin.error}</p>
+              ) : plugin.description ? (
+                <p className="text-sm text-ndp-text-muted line-clamp-2">{plugin.description}</p>
+              ) : null}
+              {hasUpdate && rv?.url && !hasError && (
+                <a href={rv.url} target="_blank" rel="noopener noreferrer" className="text-xs text-ndp-accent hover:underline inline-flex items-center gap-1 mt-1.5">
+                  View update <ExternalLink className="w-3 h-3" />
+                </a>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between pt-3 border-t border-white/5">
+              <button
+                onClick={() => onToggle(plugin)}
+                disabled={toggling === plugin.id}
+                className="flex items-center gap-2.5 text-xs font-medium text-ndp-text-dim hover:text-ndp-text transition-colors"
+                title={plugin.enabled ? 'Disable' : 'Enable'}
+              >
+                <span className={clsx('relative w-9 h-5 rounded-full transition-colors', plugin.enabled ? 'bg-ndp-accent' : 'bg-white/10')}>
+                  <span className={clsx('absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform', plugin.enabled && 'translate-x-4')} />
+                </span>
+                {plugin.enabled ? 'Enabled' : 'Disabled'}
+              </button>
+              {isConfirming ? (
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={() => { setUninstallConfirm(null); onUninstall(plugin.id); }}
+                    disabled={uninstalling === plugin.id}
+                    className="px-2.5 py-1 bg-ndp-danger hover:bg-ndp-danger/80 text-white rounded-md text-xs font-medium transition-colors disabled:opacity-50"
+                  >
+                    {uninstalling === plugin.id ? 'Uninstalling…' : 'Confirm'}
+                  </button>
+                  <button
+                    onClick={() => setUninstallConfirm(null)}
+                    className="px-2.5 py-1 text-ndp-text-dim hover:text-ndp-text rounded-md text-xs font-medium transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setUninstallConfirm(plugin.id)}
+                  className="p-1.5 rounded-lg text-ndp-text-dim hover:text-ndp-danger hover:bg-ndp-danger/10 transition-colors"
+                  title="Uninstall"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/plugins/ManualInstallModal.tsx
+++ b/packages/frontend/src/pages/admin/plugins/ManualInstallModal.tsx
@@ -1,0 +1,63 @@
+import { X } from 'lucide-react';
+import { CopyButton } from './PluginCardChrome';
+import type { RegistryPlugin } from './constants';
+
+interface ManualInstallModalProps {
+  plugin: RegistryPlugin;
+  onClose: () => void;
+}
+
+/** Shell commands an admin would run to clone + install a plugin by hand — escape hatch for
+ *  when the Install button can't reach the GitHub tarball (air-gapped env, rate-limit, etc.). */
+export function ManualInstallModal({ plugin, onClose }: ManualInstallModalProps) {
+  const installCmd = `cd packages/plugins && git clone ${plugin.url}.git ${plugin.id}`;
+  const npmCmd = `cd packages/plugins/${plugin.id} && npm install --production`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="card w-full max-w-lg shadow-2xl shadow-black/50">
+        <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4">
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-ndp-text">Manual install</h2>
+            <p className="text-xs text-ndp-text-dim mt-0.5">{plugin.name} · v{plugin.version}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="px-6 pb-6 space-y-2">
+          <p className="text-xs text-ndp-text-dim">
+            Run these commands from your Oscarr checkout, then restart the server to discover and enable the plugin.
+          </p>
+          <div className="flex items-center gap-2 pt-2">
+            <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">1</span>
+            <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
+              {installCmd}
+            </code>
+            <CopyButton text={installCmd} />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">2</span>
+            <code className="flex-1 text-xs bg-black/30 rounded-lg px-3 py-2 text-ndp-text font-mono overflow-x-auto">
+              {npmCmd}
+            </code>
+            <CopyButton text={npmCmd} />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-ndp-text-dim w-4 text-center font-mono">3</span>
+            <span className="flex-1 text-xs text-ndp-text-dim px-3 py-2">
+              Click <span className="text-ndp-text">Reload plugins</span> to pick it up without a full restart.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/plugins/PluginCardChrome.tsx
+++ b/packages/frontend/src/pages/admin/plugins/PluginCardChrome.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+/** Inline "copy to clipboard" button with a 2s success state. Used in the manual-install modal
+ *  next to each shell command so the admin can paste without selecting. */
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => { navigator.clipboard.writeText(text); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
+      className="text-ndp-text-dim hover:text-ndp-text transition-colors"
+      title="Copy"
+    >
+      {copied ? <Check className="w-3.5 h-3.5 text-ndp-success" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  );
+}
+
+/** Monogram tile for a plugin — first letter of the name inside a colored square. Used in both
+ *  the Installed and Discover grids as a placeholder until plugins ship their own icon. */
+export function PluginInitial({ name }: { name: string }) {
+  const letter = name.charAt(0).toUpperCase();
+  return (
+    <div className="w-12 h-12 rounded-xl bg-ndp-accent/15 flex items-center justify-center text-ndp-accent font-bold text-lg flex-shrink-0">
+      {letter}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/plugins/PluginDocsModal.tsx
+++ b/packages/frontend/src/pages/admin/plugins/PluginDocsModal.tsx
@@ -1,0 +1,82 @@
+import { BookOpen, ExternalLink, X } from 'lucide-react';
+
+interface PluginDocsModalProps {
+  onClose: () => void;
+}
+
+/** Quick-reference modal for building a plugin — minimal structure + manifest example + links
+ *  out to the full docs and the registry. Triggered from the "Docs" button in the tab header. */
+export function PluginDocsModal({ onClose }: PluginDocsModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="card w-full max-w-xl shadow-2xl shadow-black/50 max-h-[85vh] flex flex-col">
+        <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4 flex-shrink-0">
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-ndp-text">Build a plugin</h2>
+            <p className="text-xs text-ndp-text-dim mt-0.5">Quick reference to get a plugin skeleton running.</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="px-6 pb-6 space-y-4 text-sm text-ndp-text-muted overflow-y-auto">
+          <p>
+            Oscarr plugins are Node.js modules that extend the backend and/or frontend.
+            Each one lives in its own folder under <code className="text-ndp-text bg-black/30 px-1.5 py-0.5 rounded text-xs">packages/plugins/</code>.
+          </p>
+          <div>
+            <p className="text-ndp-text font-medium mb-2 text-xs uppercase tracking-wider">Minimal structure</p>
+            <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
+{`my-plugin/
+├── manifest.json    # Plugin metadata
+├── package.json     # Dependencies
+├── index.js         # Entry point (register function)
+└── src/             # Your code`}
+            </pre>
+          </div>
+          <div>
+            <p className="text-ndp-text font-medium mb-2 text-xs uppercase tracking-wider">manifest.json</p>
+            <pre className="text-xs bg-black/30 rounded-lg px-4 py-3 text-ndp-text-dim overflow-x-auto">
+{`{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "entry": "index.js",
+  "description": "What it does",
+  "author": "Your name"
+}`}
+            </pre>
+          </div>
+          <div className="flex items-center gap-2 pt-1 flex-wrap">
+            <a
+              href="https://github.com/arediss/Oscarr/blob/main/docs/plugins.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-xs text-ndp-text transition-colors"
+            >
+              <BookOpen className="w-3.5 h-3.5" />
+              Full documentation
+            </a>
+            <a
+              href="https://github.com/arediss/Oscarr-Plugin-Registry"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-3 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-xs text-ndp-text transition-colors"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              Submit your plugin
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/plugins/constants.ts
+++ b/packages/frontend/src/pages/admin/plugins/constants.ts
@@ -1,0 +1,49 @@
+/** Registry entry shape returned by GET /plugins/registry — intentionally looser than the
+ *  installed PluginInfo shape (no runtime state like `enabled` / `error` / `updateAvailable`,
+ *  more marketing metadata like `stars` / `tags` / `category`). */
+export interface RegistryPlugin {
+  id: string;
+  name: string;
+  version: string;
+  apiVersion: string;
+  description: string;
+  author: string;
+  repository: string;
+  category: string;
+  tags?: string[];
+  url: string;
+  stars: number;
+  updatedAt: string | null;
+  services?: string[];
+  capabilities?: string[];
+  capabilityReasons?: Record<string, string>;
+}
+
+/** Label + pill color for each registry category. Keys must match the `category` field the
+ *  registry JSON ships; unknown categories fall back to the raw string + a neutral color. */
+export const CATEGORY_CONFIG: Record<string, { label: string; color: string }> = {
+  bots: { label: 'Bot', color: 'bg-indigo-500/15 text-indigo-400' },
+  notifications: { label: 'Notifications', color: 'bg-amber-500/15 text-amber-400' },
+  automation: { label: 'Automation', color: 'bg-cyan-500/15 text-cyan-400' },
+  'requests-workflow': { label: 'Requests', color: 'bg-pink-500/15 text-pink-400' },
+  subscriptions: { label: 'Subscriptions', color: 'bg-fuchsia-500/15 text-fuchsia-400' },
+  'ui-themes': { label: 'Themes', color: 'bg-purple-500/15 text-purple-400' },
+  analytics: { label: 'Analytics', color: 'bg-emerald-500/15 text-emerald-400' },
+  utilities: { label: 'Utilities', color: 'bg-slate-500/15 text-slate-400' },
+};
+
+/** Label + color for well-known tags so Plex / Jellyfin / Discord / etc. render with their
+ *  brand hue. Unknown tags fall back to a neutral pill. */
+export const TAG_CONFIG: Record<string, { label: string; color: string }> = {
+  plex: { label: 'Plex', color: 'bg-[#e5a00d]/15 text-[#e5a00d]' },
+  jellyfin: { label: 'Jellyfin', color: 'bg-violet-500/15 text-violet-400' },
+  emby: { label: 'Emby', color: 'bg-green-500/15 text-green-400' },
+  discord: { label: 'Discord', color: 'bg-indigo-500/15 text-indigo-400' },
+  telegram: { label: 'Telegram', color: 'bg-sky-500/15 text-sky-400' },
+  matrix: { label: 'Matrix', color: 'bg-teal-500/15 text-teal-400' },
+  slack: { label: 'Slack', color: 'bg-rose-500/15 text-rose-400' },
+  radarr: { label: 'Radarr', color: 'bg-yellow-500/15 text-yellow-400' },
+  sonarr: { label: 'Sonarr', color: 'bg-blue-500/15 text-blue-400' },
+};
+
+export type SubTab = 'installed' | 'discover';

--- a/packages/frontend/src/pages/admin/plugins/usePluginsTab.ts
+++ b/packages/frontend/src/pages/admin/plugins/usePluginsTab.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import api from '@/lib/api';
+import { toastApiError } from '@/utils/toast';
+import { invalidatePluginUICache } from '@/plugins/usePlugins';
+import type { PluginInfo } from '@/plugins/types';
+import type { RegistryPlugin, SubTab } from './constants';
+
+export interface InstallMessage {
+  kind: 'success' | 'error';
+  text: string;
+}
+
+/**
+ * Owns all plugin-page data + mutations: installed list, remote registry, toggle/install/
+ * uninstall flows, one-shot update-check probe on the Installed tab, and the Reload-Oscarr
+ * restart poller. UI consumes the returned state + handlers and stays presentational.
+ */
+export function usePluginsTab() {
+  const { t } = useTranslation();
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+  const [registry, setRegistry] = useState<RegistryPlugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [registryLoading, setRegistryLoading] = useState(false);
+  const [registryError, setRegistryError] = useState<string | null>(null);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [installing, setInstalling] = useState<string | null>(null);
+  const [uninstalling, setUninstalling] = useState<string | null>(null);
+  const [restarting, setRestarting] = useState(false);
+  const [installMessage, setInstallMessage] = useState<InstallMessage | null>(null);
+
+  const fetchPlugins = useCallback(() => {
+    return api.get('/plugins')
+      .then(({ data }) => setPlugins(data))
+      .catch((err) => toastApiError(err, t('admin.plugins.load_failed')))
+      .finally(() => setLoading(false));
+  }, [t]);
+
+  const fetchRegistry = useCallback(() => {
+    setRegistryLoading(true);
+    setRegistryError(null);
+    return api.get('/plugins/registry')
+      .then(({ data }) => setRegistry(data))
+      .catch(() => setRegistryError('Failed to load plugin registry'))
+      .finally(() => setRegistryLoading(false));
+  }, []);
+
+  useEffect(() => { fetchPlugins(); }, [fetchPlugins]);
+
+  /** Kick an update-check once when the Installed tab first becomes visible so the
+   *  `latestVersion` badges can populate without user action. Backend has a 1h cache, so this
+   *  is a cheap no-op on subsequent mounts. */
+  const updateCheckedRef = useRef(false);
+  const checkForUpdates = useCallback((subTab: SubTab) => {
+    if (subTab !== 'installed' || updateCheckedRef.current) return;
+    updateCheckedRef.current = true;
+    api.get('/plugins/updates').then(() => fetchPlugins()).catch(() => { /* best-effort */ });
+  }, [fetchPlugins]);
+
+  const toggle = useCallback(async (plugin: PluginInfo) => {
+    setToggling(plugin.id);
+    try {
+      await api.put(`/plugins/${plugin.id}/toggle`, { enabled: !plugin.enabled });
+      setPlugins((prev) => prev.map((p) => (p.id === plugin.id ? { ...p, enabled: !plugin.enabled } : p)));
+      invalidatePluginUICache();
+    } catch (err) {
+      toastApiError(err, t('admin.plugins.toggle_failed', { name: plugin.name }));
+    } finally {
+      setToggling(null);
+    }
+  }, [t]);
+
+  const install = useCallback(async (entry: RegistryPlugin): Promise<boolean> => {
+    setInstalling(entry.id);
+    const url = `https://api.github.com/repos/${entry.repository}/tarball/HEAD`;
+    try {
+      const { data } = await api.post('/plugins/install', { url });
+      setInstallMessage({ kind: 'success', text: `Installed ${data.plugin.name} v${data.plugin.version} — toggle it on in Installed whenever you're ready` });
+      // Fire-and-forget so the caller can unmount the consent modal immediately; the refetch
+      // populates the Installed tab in the background before the admin flips to it.
+      fetchPlugins();
+      return true;
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? String((err as Error).message);
+      setInstallMessage({ kind: 'error', text: msg });
+      return false;
+    } finally {
+      setInstalling(null);
+      setTimeout(() => setInstallMessage(null), 6000);
+    }
+  }, [fetchPlugins]);
+
+  const uninstall = useCallback(async (id: string) => {
+    setUninstalling(id);
+    try {
+      await api.post(`/plugins/${id}/uninstall`);
+      await fetchPlugins();
+      invalidatePluginUICache();
+    } catch (err) {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? String((err as Error).message);
+      setInstallMessage({ kind: 'error', text: `Uninstall failed: ${msg}` });
+      setTimeout(() => setInstallMessage(null), 6000);
+    } finally {
+      setUninstalling(null);
+    }
+  }, [fetchPlugins]);
+
+  const restart = useCallback(async () => {
+    setRestarting(true);
+    try {
+      await api.post('/admin/restart');
+    } catch { /* server is shutting down, expected */ }
+
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      try {
+        await api.get('/app/features');
+        window.location.reload();
+        return;
+      } catch { /* still down */ }
+    }
+    setRestarting(false);
+    alert('Server did not come back after 30 seconds. Check the logs.');
+  }, []);
+
+  return {
+    plugins, registry, loading, registryLoading, registryError,
+    toggling, installing, uninstalling, restarting, installMessage,
+    fetchPlugins, fetchRegistry, checkForUpdates,
+    toggle, install, uninstall, restart,
+    setInstallMessage,
+  };
+}

--- a/packages/frontend/src/pages/admin/services/ServiceModal.tsx
+++ b/packages/frontend/src/pages/admin/services/ServiceModal.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Eye, EyeOff, Loader2, Plug, RefreshCw, Save } from 'lucide-react';
+import api from '@/lib/api';
+import { toastApiError } from '@/utils/toast';
+import { useServiceSchemas, type ServiceData } from '@/hooks/useServiceSchemas';
+
+interface ServiceModalProps {
+  service: ServiceData | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+/** Create / edit form for a service. Dynamic fields driven by the service schema, with two
+ *  Plex-specific helpers (fetch saved token from the admin's linked account, auto-detect the
+ *  server's machineIdentifier via /identity). */
+export function ServiceModal({ service, onClose, onSaved }: ServiceModalProps) {
+  const { t } = useTranslation();
+  const { schemas: SERVICE_SCHEMAS } = useServiceSchemas();
+  const isEdit = !!service;
+  const [type, setType] = useState(service?.type || 'radarr');
+  const [name, setName] = useState(service?.name || '');
+  const [config, setConfig] = useState<Record<string, string>>(service?.config || {});
+  const [isDefault, setIsDefault] = useState(service?.isDefault || false);
+  const [saving, setSaving] = useState(false);
+  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
+  const [fetchingPlexToken, setFetchingPlexToken] = useState(false);
+  const [detectingMachineId, setDetectingMachineId] = useState(false);
+  const [modalError, setModalError] = useState('');
+
+  const schema = SERVICE_SCHEMAS[type];
+
+  const handleConfigChange = (key: string, value: string) => {
+    setConfig((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const fetchPlexToken = async () => {
+    setFetchingPlexToken(true);
+    try {
+      const { data } = await api.get('/admin/plex-token');
+      if (data.token) handleConfigChange('token', data.token);
+    } catch {
+      setModalError(t('admin.services.plex_token_error'));
+      setTimeout(() => setModalError(''), 5000);
+    } finally { setFetchingPlexToken(false); }
+  };
+
+  const detectMachineId = async () => {
+    const url = config.url;
+    const token = config.token;
+    if (!url || !token) return;
+    setDetectingMachineId(true);
+    try {
+      const res = await fetch(`${url}/identity`, {
+        headers: { 'X-Plex-Token': token, Accept: 'application/json' },
+      });
+      const json = await res.json();
+      const machineId = json.MediaContainer?.machineIdentifier;
+      if (machineId) handleConfigChange('machineId', machineId);
+    } catch (err) { toastApiError(err, t('admin.services.detect_machine_id_failed')); }
+    finally { setDetectingMachineId(false); }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      if (isEdit) {
+        await api.put(`/admin/services/${service!.id}`, { name, config, isDefault });
+      } else {
+        await api.post('/admin/services', { name, type, config, isDefault });
+      }
+      onSaved();
+    } catch (err) { toastApiError(err, t(isEdit ? 'admin.services.save_failed' : 'admin.services.create_failed')); }
+    finally { setSaving(false); }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onMouseDown={onClose}>
+      <div className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in" onMouseDown={(e) => e.stopPropagation()}>
+        <h2 className="text-lg font-bold text-ndp-text mb-5">{isEdit ? t('admin.services.edit_title') : t('admin.services.add_title')}</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {!isEdit && (
+            <div>
+              <label className="text-sm text-ndp-text mb-1.5 block">{t('admin.services.service_type')}</label>
+              <select value={type} onChange={(e) => { setType(e.target.value); setConfig({}); }} className="input w-full">
+                {Object.entries(SERVICE_SCHEMAS).map(([key, s]) => (
+                  <option key={key} value={key}>{s.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label className="text-sm text-ndp-text mb-1.5 block">{t('common.name')}</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder={`${schema?.label || type} Principal`} className="input w-full" required />
+          </div>
+
+          {schema?.fields.map((field) => (
+            <div key={field.key}>
+              <label className="text-sm text-ndp-text mb-1.5 block">{t(field.labelKey)}</label>
+              <div className="relative">
+                <input
+                  type={field.type === 'password' && !showSecrets[field.key] ? 'password' : 'text'}
+                  value={config[field.key] || ''}
+                  onChange={(e) => handleConfigChange(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  className="input w-full pr-10"
+                />
+                {field.type === 'password' && (
+                  <button
+                    type="button"
+                    onClick={() => setShowSecrets((prev) => ({ ...prev, [field.key]: !prev[field.key] }))}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-ndp-text-dim hover:text-ndp-text"
+                  >
+                    {showSecrets[field.key] ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                )}
+              </div>
+              {type === 'plex' && field.key === 'token' && (
+                <>
+                  <button
+                    type="button"
+                    onClick={fetchPlexToken}
+                    disabled={fetchingPlexToken}
+                    className="mt-1.5 text-xs text-ndp-accent hover:text-ndp-accent-hover flex items-center gap-1 transition-colors"
+                  >
+                    {fetchingPlexToken ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plug className="w-3 h-3" />}
+                    {t('admin.services.use_plex_token')}
+                  </button>
+                  {modalError && <p className="text-xs text-ndp-danger mt-1">{modalError}</p>}
+                </>
+              )}
+              {type === 'plex' && field.key === 'machineId' && (
+                <button
+                  type="button"
+                  onClick={detectMachineId}
+                  disabled={detectingMachineId || !config.url || !config.token}
+                  className="mt-1.5 text-xs text-ndp-accent hover:text-ndp-accent-hover flex items-center gap-1 transition-colors disabled:opacity-40"
+                >
+                  {detectingMachineId ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+                  {t('admin.services.auto_detect')}
+                </button>
+              )}
+            </div>
+          ))}
+
+          <label className="flex items-center gap-2 text-sm text-ndp-text-muted cursor-pointer">
+            <input type="checkbox" checked={isDefault} onChange={(e) => setIsDefault(e.target.checked)} className="rounded" />
+            {t('admin.services.set_default')}
+          </label>
+
+          <div className="flex gap-3 pt-2">
+            <button type="button" onClick={onClose} className="flex-1 px-4 py-2.5 rounded-xl text-sm font-medium bg-ndp-surface text-ndp-text-muted hover:bg-ndp-surface-light transition-colors">
+              {t('common.cancel')}
+            </button>
+            <button type="submit" disabled={saving} className="flex-1 btn-primary flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium">
+              {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+              {isEdit ? t('common.save') : t('common.add')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/frontend/src/pages/admin/services/ServiceRow.tsx
+++ b/packages/frontend/src/pages/admin/services/ServiceRow.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next';
+import { clsx } from 'clsx';
+import { Loader2, Pencil, Plug, Power, Star, Trash2 } from 'lucide-react';
+import type { ServiceData, ServiceSchema } from '@/hooks/useServiceSchemas';
+import type { ServiceTestResult } from './useServicesTab';
+
+interface ServiceRowProps {
+  service: ServiceData;
+  schema: ServiceSchema | undefined;
+  testing: boolean;
+  result: ServiceTestResult | null;
+  onTest: (service: ServiceData) => void;
+  onEdit: (service: ServiceData) => void;
+  onToggle: (service: ServiceData) => void;
+  onSetDefault: (service: ServiceData) => void;
+  onDelete: (id: number) => void;
+}
+
+/** One row in the services list — status dot, icon, name + URL, test badge, action buttons. */
+export function ServiceRow({
+  service, schema, testing, result, onTest, onEdit, onToggle, onSetDefault, onDelete,
+}: ServiceRowProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={clsx('card', !service.enabled && 'opacity-50')}>
+      <div className="flex items-center gap-4 p-4">
+        <span className={clsx('w-2.5 h-2.5 rounded-full flex-shrink-0', service.enabled ? 'bg-ndp-success' : 'bg-ndp-text-dim')} />
+
+        <img src={schema?.icon || '/favicon.svg'} alt={schema?.label || service.type} className="w-8 h-8 rounded-lg object-contain flex-shrink-0" />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-ndp-text truncate">{service.name}</span>
+            {service.isDefault && (
+              <span className="px-1.5 py-0.5 bg-ndp-accent/10 text-ndp-accent text-[10px] font-semibold rounded-full flex-shrink-0">{t('common.default_badge')}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-3 mt-0.5">
+            <span className="text-xs text-ndp-text-dim">{schema?.label || service.type}</span>
+            {service.config.url && <span className="text-xs text-ndp-text-dim truncate">{service.config.url}</span>}
+          </div>
+        </div>
+
+        {result && (
+          <span className={clsx('text-xs px-2 py-1 rounded-lg flex-shrink-0', result.ok ? 'bg-ndp-success/10 text-ndp-success' : 'bg-ndp-danger/10 text-ndp-danger')}>
+            {result.ok ? (result.version ? `v${result.version}` : t('status.connected')) : t('status.connection_failed')}
+          </span>
+        )}
+
+        <div className="flex items-center gap-0.5 flex-shrink-0">
+          <button onClick={() => onTest(service)} disabled={testing} className="p-2 text-ndp-text-dim hover:text-ndp-accent hover:bg-white/5 rounded-lg transition-colors" title={t('common.test')}>
+            {testing ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plug className="w-4 h-4" />}
+          </button>
+          <button onClick={() => onEdit(service)} className="p-2 text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 rounded-lg transition-colors" title={t('common.edit')}>
+            <Pencil className="w-4 h-4" />
+          </button>
+          <button onClick={() => onToggle(service)} className="p-2 text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 rounded-lg transition-colors" title={service.enabled ? t('common.disable') : t('common.enable')}>
+            <Power className={clsx('w-4 h-4', service.enabled && 'text-ndp-success')} />
+          </button>
+          {!service.isDefault && (
+            <button onClick={() => onSetDefault(service)} className="p-2 text-ndp-text-dim hover:text-ndp-warning hover:bg-white/5 rounded-lg transition-colors" title={t('admin.services.set_default')}>
+              <Star className="w-4 h-4" />
+            </button>
+          )}
+          <div className="w-px h-5 bg-white/10 mx-1" />
+          <button onClick={() => onDelete(service.id)} className="p-2 text-ndp-text-dim hover:text-ndp-danger hover:bg-white/5 rounded-lg transition-colors" title={t('common.delete')}>
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/services/useServicesTab.ts
+++ b/packages/frontend/src/pages/admin/services/useServicesTab.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import api from '@/lib/api';
+import { toastApiError } from '@/utils/toast';
+import type { ServiceData } from '@/hooks/useServiceSchemas';
+
+export interface ServiceTestResult {
+  ok: boolean;
+  version?: string;
+}
+
+/**
+ * Owns the ServicesTab data layer: list fetch + per-service probe + mutations (toggle, set
+ * default, delete, explicit test). The UI consumes the returned state + handlers; nothing in
+ * here touches React JSX so it's easy to test in isolation.
+ */
+export function useServicesTab() {
+  const { t } = useTranslation();
+  const [services, setServices] = useState<ServiceData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [testing, setTesting] = useState<number | null>(null);
+  const [testResults, setTestResults] = useState<Record<number, ServiceTestResult>>({});
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchServices = useCallback(async () => {
+    try {
+      const { data } = await api.get('/admin/services');
+      setServices(data);
+      return data as ServiceData[];
+    } catch (err) {
+      toastApiError(err, t('admin.services.load_failed'));
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  const testAllServices = useCallback((serviceList: ServiceData[]) => {
+    // Bulk probe on mount — one red badge per failing row is enough UX signal, no per-service
+    // toast. But log so a timeout / 401 / DNS issue leaves a trail in devtools.
+    serviceList.forEach(async (svc) => {
+      if (!svc.enabled) return;
+      try {
+        const { data } = await api.post(`/admin/services/${svc.id}/test`);
+        setTestResults((prev) => ({ ...prev, [svc.id]: { ok: true, version: data.version } }));
+      } catch (err) {
+        console.error(`Service test failed for #${svc.id} (${svc.type})`, err);
+        setTestResults((prev) => ({ ...prev, [svc.id]: { ok: false } }));
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchServices().then((svcs) => {
+      if (svcs.length) testAllServices(svcs);
+    });
+  }, [fetchServices, testAllServices]);
+
+  const deleteService = useCallback(async (id: number): Promise<boolean> => {
+    setDeleting(true);
+    try {
+      await api.delete(`/admin/services/${id}`);
+      await fetchServices();
+      return true;
+    } catch (err) {
+      toastApiError(err, t('admin.services.delete_failed'));
+      return false;
+    } finally {
+      setDeleting(false);
+    }
+  }, [fetchServices, t]);
+
+  const toggleService = useCallback(async (service: ServiceData) => {
+    try {
+      await api.put(`/admin/services/${service.id}`, { enabled: !service.enabled });
+      await fetchServices();
+    } catch (err) {
+      toastApiError(err, t('admin.services.toggle_failed'));
+    }
+  }, [fetchServices, t]);
+
+  const setDefaultService = useCallback(async (service: ServiceData) => {
+    try {
+      await api.put(`/admin/services/${service.id}`, { isDefault: true });
+      await fetchServices();
+    } catch (err) {
+      toastApiError(err, t('admin.services.set_default_failed'));
+    }
+  }, [fetchServices, t]);
+
+  const testService = useCallback(async (service: ServiceData) => {
+    setTesting(service.id);
+    try {
+      const { data } = await api.post(`/admin/services/${service.id}/test`);
+      setTestResults((prev) => ({ ...prev, [service.id]: { ok: true, version: data.version } }));
+    } catch (err) {
+      // Explicit user click — surface the backend error so the admin knows 401 / timeout / etc.
+      toastApiError(err, t('admin.services.test_failed', { name: service.name }));
+      setTestResults((prev) => ({ ...prev, [service.id]: { ok: false } }));
+    } finally {
+      setTesting(null);
+    }
+  }, [t]);
+
+  return {
+    services,
+    loading,
+    testing,
+    testResults,
+    deleting,
+    fetchServices,
+    deleteService,
+    toggleService,
+    setDefaultService,
+    testService,
+  };
+}


### PR DESCRIPTION
Closes #138.

## Summary

Two admin tabs decomposed into data-layer hooks + presentational components + thin shells. Zero UX regression — same JSX, same backend calls, same modals.

## Changes

### ServicesTab: 357 → 105 lines

\`packages/frontend/src/pages/admin/services/\`
| File | Role |
|------|------|
| \`useServicesTab.ts\` | fetch / test / toggle / setDefault / delete |
| \`ServiceRow.tsx\` | row card with action cluster |
| \`ServiceModal.tsx\` | create/edit form with Plex helpers |

### PluginsTab: 768 → 198 lines

\`packages/frontend/src/pages/admin/plugins/\`
| File | Role |
|------|------|
| \`constants.ts\` | \`RegistryPlugin\` type, \`CATEGORY_CONFIG\`, \`TAG_CONFIG\` |
| \`usePluginsTab.ts\` | list + registry + mutations + restart poller |
| \`PluginCardChrome.tsx\` | \`CopyButton\` + \`PluginInitial\` helpers |
| \`InstalledList.tsx\` | installed grid + empty state |
| \`DiscoverList.tsx\` | discover grid + loading/error/empty states |
| \`ManualInstallModal.tsx\` | advanced git-clone escape hatch |
| \`PluginDocsModal.tsx\` | plugin-dev quickref modal |

## Reviewer findings applied before commit

The reviewer caught three real regressions in the first draft — all fixed:

1. **Install error closed the consent modal + flipped sub-tab.** The old code kept the modal open on error so the admin could see the toast. \`install()\` now returns a boolean; consumer only closes/flips on success.
2. **Delete-confirm modal always closed, even on error.** Matched old behavior but made the UX worse (admin re-opens the modal from scratch). \`deleteService()\` now returns a boolean too; modal stays open on error for retry.
3. **Consent modal stayed visible during post-install refetch.** The \`fetchPlugins()\` call after a successful install is now fire-and-forget so the modal unmounts immediately; the Installed tab populates in the background.

## Test plan

No behavior should change — pixel-identical UI, same network calls.

- [ ] **Services** — load, test (click + bulk on mount), toggle, set default, create, edit, delete (with confirm)
- [ ] **Services** — delete with backend forced to 500: modal **stays open**, toast shown
- [ ] **Services** — Plex form helpers: "Use Plex token", "Auto-detect machineId"
- [ ] **Plugins installed** — load, toggle, uninstall (with inline confirm), view update link when available
- [ ] **Plugins discover** — load registry, install a plugin (consent → confirm → toast → flips to Installed)
- [ ] **Plugins discover** — install with backend forced to 500: consent modal **stays open**, error toast visible when admin closes it
- [ ] **Plugins** — Reload server button + restart overlay + poll-until-back
- [ ] **Plugins** — Manual install (Terminal icon) modal with the two shell commands + copy buttons
- [ ] **Plugins** — Docs button modal

Parent: #145