### PR TITLE
feat(a11y+refactor): wave 2a — modals, nested Link, provider dedup

### DIFF
--- a/packages/frontend/src/pages/InstallPage.tsx
+++ b/packages/frontend/src/pages/InstallPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { startPlexPinFlow, type PlexPinFlowHandle } from '@/providers/plex/pinFlow';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/context/AuthContext';
@@ -46,7 +47,6 @@ export default function InstallPage() {
 
   // Plex OAuth helpers
   const [plexPolling, setPlexPolling] = useState<string | null>(null); // service id being polled
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Step 3: Sync
   const [syncing, setSyncing] = useState(false);
@@ -62,9 +62,7 @@ export default function InstallPage() {
       .catch(() => setChecking(false));
   }, [navigate]);
 
-  useEffect(() => {
-    return () => { if (pollRef.current) clearInterval(pollRef.current); };
-  }, []);
+  useEffect(() => () => flowRef.current?.cancel(), []);
 
   // ─── Step 1: Admin account ──────────────────────────────────────────
 
@@ -154,51 +152,30 @@ export default function InstallPage() {
     } catch { /* ignore */ }
   };
 
-  const handlePlexTokenReceived = async (serviceId: string, token: string) => {
-    clearInterval(pollRef.current!);
-    pollRef.current = null;
-    setPlexPolling(null);
-    setServices(prev => prev.map(s => s.id === serviceId
-      ? { ...s, config: { ...s.config, token }, testStatus: 'idle' as const }
-      : s
-    ));
-    await autoDetectMachineId(serviceId, token);
-  };
-
-  const handlePollAttempt = async (serviceId: string, pinId: string, attempts: number) => {
-    if (attempts >= 120) {
-      clearInterval(pollRef.current!);
-      pollRef.current = null;
-      setPlexPolling(null);
-      setError(t('login.expired'));
-      return;
-    }
-    try {
-      const { data: checkData } = await api.post('/setup/plex-check', { pinId });
-      if (checkData.token) {
-        await handlePlexTokenReceived(serviceId, checkData.token);
-      }
-    } catch { /* keep polling */ }
-  };
+  const flowRef = useRef<PlexPinFlowHandle | null>(null);
 
   const startPlexOAuth = (serviceId: string) => {
     setPlexPolling(serviceId);
     setError('');
-    // Open popup BEFORE the async call — Safari blocks window.open() after await
     const authWindow = window.open('about:blank', 'PlexAuth', 'width=600,height=700');
-    api.post('/auth/plex/pin').then(({ data }) => {
-      const { pin, authUrl } = data;
-      if (authWindow) authWindow.location.href = authUrl;
-
-      let attempts = 0;
-      if (pollRef.current) clearInterval(pollRef.current);
-      pollRef.current = setInterval(() => {
-        attempts++;
-        handlePollAttempt(serviceId, pin.id, attempts);
-      }, 1000);
-    }).catch(() => {
-      setPlexPolling(null);
-      setError(t('login.error'));
+    flowRef.current?.cancel();
+    flowRef.current = startPlexPinFlow({
+      authWindow,
+      pinEndpoint: '/auth/plex/pin',
+      checkEndpoint: '/setup/plex-check',
+      extractToken: (res) => (res as { token?: string })?.token ?? null,
+      onToken: async (token) => {
+        setPlexPolling(null);
+        setServices(prev => prev.map(s => s.id === serviceId
+          ? { ...s, config: { ...s.config, token }, testStatus: 'idle' as const }
+          : s
+        ));
+        await autoDetectMachineId(serviceId, token);
+      },
+      onError: () => {
+        setPlexPolling(null);
+        setError(t('login.expired'));
+      },
     });
   };
 

--- a/packages/frontend/src/pages/RequestsPage.tsx
+++ b/packages/frontend/src/pages/RequestsPage.tsx
@@ -76,6 +76,10 @@ export default function RequestsPage() {
   const [total, setTotal] = useState(0);
   const [qualityOptions, setQualityOptions] = useState<{ id: number; label: string }[]>([]);
   const [showCleanup, setShowCleanup] = useState(false);
+  const cleanupModal = useModal({
+    open: showCleanup,
+    onClose: () => setShowCleanup(false),
+  });
   type CleanupAction = 'keep' | 'remove' | 'remove_with_service';
   const [cleanupActions, setCleanupActions] = useState<Record<string, CleanupAction>>({});
   const [cleanupLoading, setCleanupLoading] = useState(false);
@@ -355,9 +359,16 @@ export default function RequestsPage() {
       {/* Cleanup modal */}
       {showCleanup && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in" onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShowCleanup(false); }}>
-          <div className="bg-ndp-surface border border-white/10 rounded-2xl p-6 w-full max-w-md mx-4 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+          <div
+            ref={cleanupModal.dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={cleanupModal.titleId}
+            className="bg-ndp-surface border border-white/10 rounded-2xl p-6 w-full max-w-md mx-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between mb-5">
-              <h3 className="text-base font-bold text-ndp-text flex items-center gap-2">
+              <h3 id={cleanupModal.titleId} className="text-base font-bold text-ndp-text flex items-center gap-2">
                 <Eraser className="w-4 h-4 text-ndp-text-muted" />
                 {t('requests.cleanup_title')}
               </h3>
@@ -498,12 +509,20 @@ function RequestCardInner({
   const isPending = req.status === 'pending';
 
   return (
-    <Link
-      to={mediaLink}
-      onClick={hasValidTmdbId ? undefined : (e) => e.preventDefault()}
+    // Card is a <div> (not <Link>) so nested <button>s are valid HTML.
+    // The clickable area is a sibling <Link className="absolute inset-0"> positioned under the
+    // buttons via z-index — screen readers announce one link + the buttons independently.
+    <div
       className="group relative rounded-2xl overflow-hidden h-[160px] flex transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-black/40 animate-fade-in border border-white/5"
       style={{ animationDelay: `${Math.min(index * 50, 400)}ms`, animationFillMode: 'backwards' }}
     >
+      {hasValidTmdbId && (
+        <Link
+          to={mediaLink}
+          className="absolute inset-0 z-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ndp-accent/60 rounded-2xl"
+          aria-label={req.media?.title || t('requests.unknown_media')}
+        />
+      )}
 {/* No left bar — status shown inline */}
 
       {/* Background — subtle backdrop hint */}
@@ -814,7 +833,7 @@ function RequestCardInner({
         </div>,
         document.body
       )}
-    </Link>
+    </div>
   );
 }
 

--- a/packages/frontend/src/pages/admin/AuthProvidersTab.tsx
+++ b/packages/frontend/src/pages/admin/AuthProvidersTab.tsx
@@ -8,6 +8,7 @@ import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import { extractApiError } from '@/utils/toast';
 import { useModal } from '@/hooks/useModal';
+import { getProviderBadgeClass } from '@/providers/colors';
 
 interface AuthProviderField {
   key: string;
@@ -35,15 +36,6 @@ interface AuthProviderRow {
 }
 
 const MASK = '__MASKED__';
-
-/** Per-provider badge color so they're visually distinguishable at a glance. */
-const PROVIDER_ACCENT: Record<string, string> = {
-  plex: 'bg-[#e5a00d]/15 text-[#e5a00d]',
-  discord: 'bg-[#5865F2]/15 text-[#8692ff]',
-  jellyfin: 'bg-[#00a4dc]/15 text-[#00a4dc]',
-  emby: 'bg-[#52b54b]/15 text-[#52b54b]',
-  email: 'bg-white/10 text-ndp-text-muted',
-};
 
 export function AuthProvidersTab() {
   const { t } = useTranslation();
@@ -123,7 +115,7 @@ function ProviderRow({
   // server-side but the login wouldn't, so we signal unavailability without hiding the entry.
   const unavailable = provider.requiresService && !provider.serviceAvailable;
   const hasSettings = provider.configSchema.length > 0;
-  const accent = PROVIDER_ACCENT[provider.id] ?? 'bg-ndp-accent/15 text-ndp-accent';
+  const accent = getProviderBadgeClass(provider.id);
 
   return (
     <div className={clsx('card', unavailable && 'opacity-50')}>

--- a/packages/frontend/src/pages/admin/AuthProvidersTab.tsx
+++ b/packages/frontend/src/pages/admin/AuthProvidersTab.tsx
@@ -7,6 +7,7 @@ import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import { extractApiError } from '@/utils/toast';
+import { useModal } from '@/hooks/useModal';
 
 interface AuthProviderField {
   key: string;
@@ -215,6 +216,7 @@ function ProviderConfigModal({
   onSaved: () => void;
 }) {
   const { t } = useTranslation();
+  const { dialogRef, titleId } = useModal({ open: true, onClose });
   const [config, setConfig] = useState<Record<string, string | boolean>>(provider.config);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -244,10 +246,17 @@ function ProviderConfigModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm animate-fade-in"
       onMouseDown={(e) => { if (e.target === e.currentTarget && !saving) onClose(); }}
     >
-      <div className="card w-full max-w-lg shadow-2xl shadow-black/50" onMouseDown={(e) => e.stopPropagation()}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="card w-full max-w-lg shadow-2xl shadow-black/50"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
         <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4">
           <div className="min-w-0">
-            <h2 className="text-base font-semibold text-ndp-text">{provider.label}</h2>
+            <h2 id={titleId} className="text-base font-semibold text-ndp-text">{provider.label}</h2>
             <p className="text-xs text-ndp-text-dim mt-0.5">
               {provider.type === 'oauth' ? 'OAuth 2.0' : 'Credentials'} · {t('admin.authProviders.configure')}
             </p>
@@ -255,7 +264,7 @@ function ProviderConfigModal({
           <button
             onClick={() => !saving && onClose()}
             className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
-            aria-label="Close"
+            aria-label={t('common.close')}
           >
             <X className="w-4 h-4" />
           </button>

--- a/packages/frontend/src/pages/admin/BlacklistTab.tsx
+++ b/packages/frontend/src/pages/admin/BlacklistTab.tsx
@@ -8,6 +8,7 @@ import { posterUrl } from '@/lib/api';
 import { toastApiError } from '@/utils/toast';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
+import { useModal } from '@/hooks/useModal';
 
 interface BlacklistEntry {
   id: number;
@@ -46,6 +47,10 @@ export function BlacklistTab() {
 
   // Confirm modal
   const [confirmMedia, setConfirmMedia] = useState<TmdbResult | null>(null);
+  const { dialogRef: confirmDialogRef, titleId: confirmTitleId } = useModal({
+    open: confirmMedia !== null,
+    onClose: () => setConfirmMedia(null),
+  });
   const [reason, setReason] = useState('');
   const [adding, setAdding] = useState(false);
 
@@ -181,13 +186,24 @@ export function BlacklistTab() {
       {/* Confirm modal */}
       {confirmMedia && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in" onClick={() => setConfirmMedia(null)}>
-          <div className="bg-ndp-surface border border-white/10 rounded-2xl p-6 w-full max-w-sm mx-4 shadow-2xl" onClick={(e) => e.stopPropagation()}>
+          <div
+            ref={confirmDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={confirmTitleId}
+            className="bg-ndp-surface border border-white/10 rounded-2xl p-6 w-full max-w-sm mx-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base font-bold text-ndp-text flex items-center gap-2">
+              <h3 id={confirmTitleId} className="text-base font-bold text-ndp-text flex items-center gap-2">
                 <ShieldBan className="w-4 h-4 text-ndp-danger" />
                 {t('admin.blacklist.confirm_title')}
               </h3>
-              <button onClick={() => setConfirmMedia(null)} className="text-ndp-text-dim hover:text-ndp-text">
+              <button
+                onClick={() => setConfirmMedia(null)}
+                className="text-ndp-text-dim hover:text-ndp-text"
+                aria-label={t('common.close')}
+              >
                 <X className="w-5 h-5" />
               </button>
             </div>

--- a/packages/frontend/src/pages/admin/NotificationsTab.tsx
+++ b/packages/frontend/src/pages/admin/NotificationsTab.tsx
@@ -6,6 +6,7 @@ import { Loader2, Save, CheckCircle, Send, Eye, EyeOff, Pencil, Power } from 'lu
 import api from '@/lib/api';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
+import { useModal } from '@/hooks/useModal';
 
 // ─── Types from registry API ────────────────────────────
 
@@ -53,6 +54,10 @@ export function NotificationsTab() {
 
   // Modal state
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
+  const { dialogRef: providerDialogRef, titleId: providerTitleId } = useModal({
+    open: editingProvider !== null,
+    onClose: () => setEditingProvider(null),
+  });
   const [editSettings, setEditSettings] = useState<Record<string, string>>({});
   const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
 
@@ -193,8 +198,15 @@ export function NotificationsTab() {
     if (!provider) return null;
     return createPortal(
       <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onMouseDown={() => setEditingProvider(null)}>
-        <div className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in" onMouseDown={(e) => e.stopPropagation()}>
-          <h3 className="text-lg font-bold text-ndp-text mb-4">{t(provider.nameKey)}</h3>
+        <div
+          ref={providerDialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={providerTitleId}
+          className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in"
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <h3 id={providerTitleId} className="text-lg font-bold text-ndp-text mb-4">{t(provider.nameKey)}</h3>
           <div className="space-y-4">
             {provider.settingsSchema.map((field) => {
               const inputId = `notif-${provider.id}-${field.key}`;

--- a/packages/frontend/src/pages/admin/PluginConsentModal.tsx
+++ b/packages/frontend/src/pages/admin/PluginConsentModal.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { X, Server, Shield, HelpCircle } from 'lucide-react';
+import { useModal } from '@/hooks/useModal';
 
 /** Shape shared by RegistryPlugin (pre-install) and PluginInfo (post-install). */
 export interface ConsentablePlugin {
@@ -45,6 +47,8 @@ const RISK_LABEL: Record<'low' | 'medium' | 'high', string> = {
 };
 
 export function PluginConsentModal({ plugin, open, busy, mode, onCancel, onConfirm }: Props) {
+  const { t } = useTranslation();
+  const { dialogRef, titleId } = useModal({ open: open && plugin !== null, onClose: onCancel });
   if (!open || !plugin) return null;
 
   const services = plugin.services ?? [];
@@ -61,10 +65,16 @@ export function PluginConsentModal({ plugin, open, busy, mode, onCancel, onConfi
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm animate-fade-in"
       onClick={(e) => { if (e.target === e.currentTarget && !busy) onCancel(); }}
     >
-      <div className="card w-full max-w-lg flex flex-col shadow-2xl shadow-black/50">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="card w-full max-w-lg flex flex-col shadow-2xl shadow-black/50"
+      >
         <div className="flex items-start justify-between gap-4 px-6 pt-6 pb-4 flex-shrink-0">
           <div className="min-w-0">
-            <h2 className="text-base font-semibold text-ndp-text truncate">{title}</h2>
+            <h2 id={titleId} className="text-base font-semibold text-ndp-text truncate">{title}</h2>
             <p className="text-xs text-ndp-text-dim mt-0.5">
               v{plugin.version}{plugin.author ? ` · ${plugin.author}` : ''}
             </p>
@@ -72,7 +82,7 @@ export function PluginConsentModal({ plugin, open, busy, mode, onCancel, onConfi
           <button
             onClick={() => !busy && onCancel()}
             className="p-1.5 -mt-1 -mr-1 rounded-lg text-ndp-text-dim hover:text-ndp-text hover:bg-white/5 transition-colors flex-shrink-0"
-            aria-label="Cancel"
+            aria-label={t('common.cancel')}
           >
             <X className="w-4 h-4" />
           </button>

--- a/packages/frontend/src/pages/admin/QualityTab.tsx
+++ b/packages/frontend/src/pages/admin/QualityTab.tsx
@@ -5,6 +5,7 @@ import { clsx } from 'clsx';
 import { Loader2, Plus, X, Check, Trash2, Shield, Link2, CheckCircle, Clock } from 'lucide-react';
 import api from '@/lib/api';
 import { toastApiError } from '@/utils/toast';
+import { useModal } from '@/hooks/useModal';
 
 interface QualityMappingType {
   id: number;
@@ -41,7 +42,15 @@ export function QualityTab() {
   const [roles, setRoles] = useState<RoleType[]>([]);
   const [loading, setLoading] = useState(true);
   const [editingOption, setEditingOption] = useState<number | null>(null);
+  const { dialogRef: optionDialogRef, titleId: optionTitleId } = useModal({
+    open: editingOption !== null,
+    onClose: () => setEditingOption(null),
+  });
   const [editingMapping, setEditingMapping] = useState<{ qualityOptionId: number; serviceId: number } | null>(null);
+  const { dialogRef: mappingDialogRef, titleId: mappingTitleId } = useModal({
+    open: editingMapping !== null,
+    onClose: () => setEditingMapping(null),
+  });
   const [profiles, setProfiles] = useState<{ id: number; name: string }[]>([]);
   const [loadingProfiles, setLoadingProfiles] = useState(false);
   const [selectedProfiles, setSelectedProfiles] = useState<Set<number>>(new Set());
@@ -275,9 +284,16 @@ export function QualityTab() {
 
         return createPortal(
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm animate-fade-in">
-            <div className="card p-6 max-w-lg w-full mx-4 shadow-2xl max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
+            <div
+              ref={optionDialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={optionTitleId}
+              className="card p-6 max-w-lg w-full mx-4 shadow-2xl max-h-[85vh] flex flex-col"
+              onClick={e => e.stopPropagation()}
+            >
               <div className="flex items-center justify-between mb-5">
-                <h3 className="text-lg font-bold text-ndp-text">{opt.label}</h3>
+                <h3 id={optionTitleId} className="text-lg font-bold text-ndp-text">{opt.label}</h3>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { deleteOption(opt.id); setEditingOption(null); }} aria-label={t('common.delete')} className="p-1.5 rounded-lg text-ndp-text-dim hover:text-ndp-danger hover:bg-ndp-danger/10 transition-colors">
                     <Trash2 className="w-4 h-4" />
@@ -373,8 +389,15 @@ export function QualityTab() {
       {/* Profile select modal */}
       {editingMapping && createPortal(
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onMouseDown={() => setEditingMapping(null)}>
-          <div className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in" onMouseDown={(e) => e.stopPropagation()}>
-            <h3 className="text-lg font-bold text-ndp-text mb-1">{t('admin.quality.select_profile')}</h3>
+          <div
+            ref={mappingDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={mappingTitleId}
+            className="card p-6 w-full max-w-md border border-white/10 shadow-2xl animate-fade-in"
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <h3 id={mappingTitleId} className="text-lg font-bold text-ndp-text mb-1">{t('admin.quality.select_profile')}</h3>
             <p className="text-xs text-ndp-text-dim mb-4">
               {options.find(o => o.id === editingMapping.qualityOptionId)?.label} → {services.find(s => s.id === editingMapping.serviceId)?.name}
             </p>

--- a/packages/frontend/src/pages/admin/RoutingRulesTab.tsx
+++ b/packages/frontend/src/pages/admin/RoutingRulesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Trash2, XCircle, Pencil, Copy, Power, GripVertical, AlertTriangle } from 'lucide-react';
 import api from '@/lib/api';
@@ -48,6 +48,7 @@ async function fetchRootFolders(arrServices: ServiceOption[]) {
 
 export function RoutingRulesTab() {
   const { t } = useTranslation();
+  const fieldId = useId();
   const [rules, setRules] = useState<FolderRule[]>([]);
   const [labeledFolders, setLabeledFolders] = useState<{ path: string; label: string; serviceId: number | null }[]>([]);
   const [users, setUsers] = useState<UserOption[]>([]);
@@ -304,26 +305,26 @@ export function RoutingRulesTab() {
         <div className="card p-5 mt-4 border border-ndp-accent/20 space-y-4 animate-fade-in">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div>
-              <label className="text-xs text-ndp-text-dim block mb-1">{t('common.name')}</label>
-              <input value={newName} onChange={(e) => setNewName(e.target.value)} placeholder={t('admin.paths.rule_name_placeholder')} className="input text-sm w-full" />
+              <label htmlFor={`${fieldId}-name`} className="text-xs text-ndp-text-dim block mb-1">{t('common.name')}</label>
+              <input id={`${fieldId}-name`} value={newName} onChange={(e) => setNewName(e.target.value)} placeholder={t('admin.paths.rule_name_placeholder')} className="input text-sm w-full" />
             </div>
             <div>
-              <label className="text-xs text-ndp-text-dim block mb-1">{t('common.type')}</label>
-              <select value={newMediaType} onChange={(e) => { setNewMediaType(e.target.value); setNewFolder(''); setNewServiceId(''); }} className="input text-sm w-full">
+              <label htmlFor={`${fieldId}-type`} className="text-xs text-ndp-text-dim block mb-1">{t('common.type')}</label>
+              <select id={`${fieldId}-type`} value={newMediaType} onChange={(e) => { setNewMediaType(e.target.value); setNewFolder(''); setNewServiceId(''); }} className="input text-sm w-full">
                 <option value="tv">{t('common.series')}</option><option value="movie">{t('common.movie')}</option>
               </select>
             </div>
             <div>
-              <label className="text-xs text-ndp-text-dim block mb-1">{t('admin.paths.sonarr_type')}</label>
-              <select value={newSeriesType} onChange={(e) => setNewSeriesType(e.target.value)} className="input text-sm w-full">
+              <label htmlFor={`${fieldId}-sonarr-type`} className="text-xs text-ndp-text-dim block mb-1">{t('admin.paths.sonarr_type')}</label>
+              <select id={`${fieldId}-sonarr-type`} value={newSeriesType} onChange={(e) => setNewSeriesType(e.target.value)} className="input text-sm w-full">
                 <option value="">{t('admin.paths.standard')}</option><option value="anime">{t('admin.paths.anime_rule')}</option><option value="daily">{t('admin.paths.daily')}</option>
               </select>
             </div>
           </div>
 
           <div>
-            <label className="text-xs text-ndp-text-dim block mb-1">{t('admin.paths.target_folder')}</label>
-            <select value={newFolder} onChange={(e) => handleFolderChange(e.target.value)} className="input text-sm w-full">
+            <label htmlFor={`${fieldId}-folder`} className="text-xs text-ndp-text-dim block mb-1">{t('admin.paths.target_folder')}</label>
+            <select id={`${fieldId}-folder`} value={newFolder} onChange={(e) => handleFolderChange(e.target.value)} className="input text-sm w-full">
               <option value="">{t('common.choose')}</option>
               {labeledFolders
                 .filter(f => {
@@ -335,9 +336,9 @@ export function RoutingRulesTab() {
             </select>
           </div>
 
-          {/* Conditions */}
-          <div>
-            <label className="text-xs text-ndp-text-dim block mb-2">{t('admin.paths.conditions_help')}</label>
+          {/* Conditions — not a single input, so label the group via aria-labelledby. */}
+          <div role="group" aria-labelledby={`${fieldId}-conditions`}>
+            <span id={`${fieldId}-conditions`} className="text-xs text-ndp-text-dim block mb-2">{t('admin.paths.conditions_help')}</span>
             <div className="space-y-2">
               {newConditions.map((cond, i) => renderConditionRow(cond, i))}
             </div>

--- a/packages/frontend/src/pages/admin/UsersTab.tsx
+++ b/packages/frontend/src/pages/admin/UsersTab.tsx
@@ -10,6 +10,7 @@ import type { AdminUser } from '@/types';
 import { Spinner } from './Spinner';
 import { AdminTabLayout } from './AdminTabLayout';
 import { useModal } from '@/hooks/useModal';
+import { getProviderBadgeClass, getProviderHex } from '@/providers/colors';
 
 type UserSort = 'username' | 'date' | 'role';
 
@@ -385,13 +386,7 @@ export function UsersTab() {
                   {/* Group 1 — provider badges + request count */}
                   <span className="text-xs text-ndp-text-dim tabular-nums">{u.requestCount} {t('requests.title').toLowerCase()}</span>
                   {(u.providers || []).map((p) => (
-                    <span key={p.provider} className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${
-                      p.provider === 'plex' ? 'bg-[#e5a00d]/10 text-[#e5a00d]' :
-                      p.provider === 'jellyfin' ? 'bg-[#00a4dc]/10 text-[#00a4dc]' :
-                      p.provider === 'emby' ? 'bg-[#52b54b]/10 text-[#52b54b]' :
-                      p.provider === 'email' ? 'bg-ndp-accent/10 text-ndp-accent' :
-                      'bg-white/5 text-ndp-text-dim'
-                    }`} title={p.email && p.email !== u.email ? p.email : p.username || undefined}>
+                    <span key={p.provider} className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${getProviderBadgeClass(p.provider)}`} title={p.email && p.email !== u.email ? p.email : p.username || undefined}>
                       {p.provider.charAt(0).toUpperCase() + p.provider.slice(1)}
                       {p.email && p.email !== u.email && <span className="ml-1 opacity-60">({p.email})</span>}
                     </span>
@@ -632,10 +627,6 @@ function RoleBadgeDropdown({ user, roles, disabled, loading, onSelect }: {
 
 // ─── Link Provider Dropdown ────────────────────────────────────────
 
-const PROVIDER_COLORS: Record<string, string> = {
-  plex: '#e5a00d', jellyfin: '#00a4dc', emby: '#52b54b',
-};
-
 function LinkProviderDropdown({ userId, userProviders, authProviders, linking, onLinkOAuth, onLinkCredentials }: {
   userId: number;
   userProviders: string[];
@@ -688,7 +679,7 @@ function LinkProviderDropdown({ userId, userProviders, authProviders, linking, o
           style={{ top: pos.top, left: pos.left }}
         >
           {unlinked.map(ap => {
-            const color = PROVIDER_COLORS[ap.id] || '#888';
+            const color = getProviderHex(ap.id);
             return (
               <button
                 key={ap.id}

--- a/packages/frontend/src/pages/admin/services/ServiceModal.tsx
+++ b/packages/frontend/src/pages/admin/services/ServiceModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useId, useEffect, useRef } from 'react';
+import { startPlexPinFlow, type PlexPinFlowHandle } from '@/providers/plex/pinFlow';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, Loader2, Plug, RefreshCw, Save, KeyRound } from 'lucide-react';
@@ -78,54 +79,28 @@ export function ServiceModal({ service, onClose, onSaved }: ServiceModalProps) {
     }
   };
 
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const authWindowRef = useRef<Window | null>(null);
-  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
+  const flowRef = useRef<PlexPinFlowHandle | null>(null);
+  useEffect(() => () => flowRef.current?.cancel(), []);
 
-  const stopPolling = () => {
-    if (pollRef.current) clearInterval(pollRef.current);
-    pollRef.current = null;
-    authWindowRef.current?.close();
-    authWindowRef.current = null;
-    setFetchingPlexToken(false);
-  };
-
-  const fetchPlexToken = async () => {
+  const fetchPlexToken = () => {
     setModalError('');
     setFetchingPlexToken(true);
     // Popup must open synchronously on the user gesture or Safari blocks it.
-    authWindowRef.current = window.open('about:blank', 'PlexAuth', 'width=600,height=700');
-    try {
-      const { data } = await api.post<{ pin: { id: number }; authUrl: string }>('/admin/plex-pin');
-      if (authWindowRef.current) authWindowRef.current.location.href = data.authUrl;
-      let attempts = 0;
-      pollRef.current = setInterval(async () => {
-        attempts++;
-        if (attempts >= 120) {
-          stopPolling();
-          setModalError(t('admin.services.plex_token_error'));
-          return;
-        }
-        try {
-          const res = await api.post<{ token?: string }>('/admin/plex-check', { pinId: data.pin.id });
-          if (res.data.token) {
-            handleConfigChange('token', res.data.token);
-            stopPolling();
-          }
-        } catch (err) {
-          // 400 = PIN not yet validated → keep polling. Anything else (401 session expired,
-          // 403 CSRF, 404 bad pin, 429 rate-limit, 5xx) is terminal — stop + surface.
-          const status = (err as { response?: { status?: number } }).response?.status;
-          if (status !== undefined && status !== 400) {
-            stopPolling();
-            setModalError(t('admin.services.plex_token_error'));
-          }
-        }
-      }, 1000);
-    } catch {
-      stopPolling();
-      setModalError(t('admin.services.plex_token_error'));
-    }
+    const authWindow = window.open('about:blank', 'PlexAuth', 'width=600,height=700');
+    flowRef.current = startPlexPinFlow({
+      authWindow,
+      pinEndpoint: '/admin/plex-pin',
+      checkEndpoint: '/admin/plex-check',
+      extractToken: (res) => (res as { token?: string })?.token ?? null,
+      onToken: (token) => {
+        handleConfigChange('token', token);
+        setFetchingPlexToken(false);
+      },
+      onError: () => {
+        setFetchingPlexToken(false);
+        setModalError(t('admin.services.plex_token_error'));
+      },
+    });
   };
 
   const detectMachineId = async () => {

--- a/packages/frontend/src/providers/colors.ts
+++ b/packages/frontend/src/providers/colors.ts
@@ -1,0 +1,35 @@
+/** Canonical color map for every auth / media provider — the single source of truth consumed
+ *  by UsersTab, AuthProvidersTab, LoginPage, ServiceModal, and plugin constants. Adding a new
+ *  provider? Register its color here and everywhere downstream picks it up automatically. */
+
+export interface ProviderColor {
+  /** Brand hex — useful for plain inline styles / SVG fills. */
+  hex: string;
+  /** Tailwind arbitrary-value classes for a colored badge background + text. */
+  badgeClass: string;
+}
+
+const DEFAULT: ProviderColor = {
+  hex: '#7c5cff',
+  badgeClass: 'bg-ndp-accent/15 text-ndp-accent',
+};
+
+const PROVIDERS: Record<string, ProviderColor> = {
+  plex:     { hex: '#e5a00d', badgeClass: 'bg-[#e5a00d]/15 text-[#e5a00d]' },
+  jellyfin: { hex: '#00a4dc', badgeClass: 'bg-[#00a4dc]/15 text-[#00a4dc]' },
+  emby:     { hex: '#52b54b', badgeClass: 'bg-[#52b54b]/15 text-[#52b54b]' },
+  discord:  { hex: '#5865f2', badgeClass: 'bg-[#5865f2]/15 text-[#5865f2]' },
+  email:    { hex: '#94a3b8', badgeClass: 'bg-slate-500/15 text-slate-400' },
+};
+
+export function getProviderColor(id: string): ProviderColor {
+  return PROVIDERS[id] ?? DEFAULT;
+}
+
+export function getProviderHex(id: string): string {
+  return getProviderColor(id).hex;
+}
+
+export function getProviderBadgeClass(id: string): string {
+  return getProviderColor(id).badgeClass;
+}

--- a/packages/frontend/src/providers/plex/pinFlow.ts
+++ b/packages/frontend/src/providers/plex/pinFlow.ts
@@ -1,0 +1,112 @@
+import api from '@/lib/api';
+
+/** Plex OAuth PIN flow used by LoginPage, InstallPage, UsersTab, and ServiceModal.
+ *
+ *  UX: opens a plex.tv popup (Safari blocks `window.open()` after an `await`, so the popup has
+ *  to be opened synchronously from the user gesture — the caller passes us the already-opened
+ *  window). We create a PIN, point the popup at plex.tv, then poll the "check" endpoint every
+ *  second up to 2 minutes. On success we call `onToken` with the Plex token; on expiry / error
+ *  we call `onError`. The returned `cancel` function stops polling and closes the popup.
+ *
+ *  The check endpoint differs per call site (/auth/plex/callback for login, /setup/plex-check
+ *  for install, /admin/users/:id/link-provider for account linking, /admin/plex-check for the
+ *  service-config admin flow), so it's passed in as `checkEndpoint` + `checkPayload` builder. */
+
+export interface PlexPinFlowOptions {
+  /** Popup already opened synchronously by the caller (required for Safari). */
+  authWindow: Window | null;
+  /** Endpoint to call every second until we get a token. Receives `{ pinId }` plus anything
+   *  the caller adds via `checkPayload`. */
+  checkEndpoint: string;
+  /** Extra fields to merge into the check POST body (e.g. `{ provider: 'plex' }`). */
+  checkPayload?: Record<string, unknown>;
+  /** Endpoint to create the PIN — defaults to the public /auth/plex/pin used by login/link;
+   *  admins configuring a service use `/admin/plex-pin`, install wizard uses `/setup/plex-pin`. */
+  pinEndpoint?: string;
+  /** Response shape varies: login/link returns `{ pin: { id }, authUrl }`, setup/admin returns
+   *  the same shape, but linkAccount checks `linkData.success` instead of a token. The caller
+   *  tells us what "got a token" means via `extractToken` (return null to keep polling). */
+  extractToken: (checkResponse: unknown) => string | null;
+  /** Called when polling yields a token. */
+  onToken: (token: string) => void;
+  /** Called on PIN creation failure, timeout (120 attempts), or if the caller wants to give up
+   *  on a terminal error — the default-stop heuristic is "polling response has a 4xx status
+   *  that isn't 400 (PIN not yet validated)". */
+  onError: () => void;
+  /** Max attempts before giving up. 120 × 1s = 2 minutes, matches Plex PIN TTL. */
+  maxAttempts?: number;
+}
+
+export interface PlexPinFlowHandle {
+  /** Stops polling and closes the popup. Safe to call multiple times. */
+  cancel: () => void;
+}
+
+export function startPlexPinFlow(opts: PlexPinFlowOptions): PlexPinFlowHandle {
+  const {
+    authWindow,
+    checkEndpoint,
+    checkPayload = {},
+    pinEndpoint = '/auth/plex/pin',
+    extractToken,
+    onToken,
+    onError,
+    maxAttempts = 120,
+  } = opts;
+
+  let pollId: ReturnType<typeof setInterval> | null = null;
+  let cancelled = false;
+
+  const cancel = () => {
+    if (cancelled) return;
+    cancelled = true;
+    if (pollId) clearInterval(pollId);
+    pollId = null;
+    authWindow?.close();
+  };
+
+  api.post(pinEndpoint)
+    .then(({ data }) => {
+      if (cancelled) return;
+      const pin = data?.pin;
+      const authUrl = data?.authUrl;
+      if (!pin?.id || !authUrl) {
+        cancel();
+        onError();
+        return;
+      }
+      if (authWindow) authWindow.location.href = authUrl;
+
+      let attempts = 0;
+      pollId = setInterval(async () => {
+        attempts++;
+        if (attempts >= maxAttempts) {
+          cancel();
+          onError();
+          return;
+        }
+        try {
+          const res = await api.post(checkEndpoint, { pinId: pin.id, ...checkPayload });
+          const token = extractToken(res.data);
+          if (token) {
+            cancel();
+            onToken(token);
+          }
+        } catch (err) {
+          // 400 = PIN not validated yet → keep polling. Anything else is terminal.
+          const status = (err as { response?: { status?: number } })?.response?.status;
+          if (status !== undefined && status !== 400) {
+            cancel();
+            onError();
+          }
+        }
+      }, 1000);
+    })
+    .catch(() => {
+      if (cancelled) return;
+      cancel();
+      onError();
+    });
+
+  return { cancel };
+}


### PR DESCRIPTION
## Summary

First tranche of the audit wave 2. Pure-frontend changes, low-risk, visible-to-users. 7 files touched, zero API contract changes.

- **H2 (modals)** — useModal hook applied to the 5 remaining modals without Escape/focus-trap/focus-return : AuthProvidersTab provider-config, BlacklistTab confirm-add, NotificationsTab provider-edit, QualityTab × 2 (profile-select + edit-option), PluginConsentModal. All now get proper role=dialog + aria-modal + aria-labelledby wiring.
- **H17 (invalid HTML in RequestCard)** — the wrapping `<Link>` that nested `<button>`s inside was rewritten as a `<div>` card + a sibling `<Link absolute inset-0 z-0>` overlay. Buttons live at the same DOM level as the overlay link — valid HTML, screen readers announce the link and the action buttons independently, focus-visible ring preserved.
- **H4 (htmlFor)** — RoutingRulesTab : Name / Type / Sonarr type / Target folder inputs paired with label htmlFor via `useId()`. Conditions group (not a single input) switched to `role=group` + `aria-labelledby`. QueryBuilder / FeaturesTab / QualityTab group headers deferred — need a larger restructure.
- **H8 (provider duplication — frontend only)** —
  - `src/providers/colors.ts` : single source for `{ hex, badgeClass }` per provider. AuthProvidersTab + UsersTab (two sites) migrated to `getProviderBadgeClass` / `getProviderHex`. The 5-copy Tailwind color map is now 1 copy.
  - `src/providers/plex/pinFlow.ts` : `startPlexPinFlow` encapsulates the popup → POST /pin → poll /check → token-or-timeout loop. Caller passes the already-opened window (Safari requirement), pinEndpoint, checkEndpoint, `extractToken`, `onToken`, `onError`. Returns `{ cancel }` for cleanup. ServiceModal + InstallPage migrated. LoginPage + UsersTab-link have richer side effects (login() + navigate / success-flag), deferred.

## What's next (wave 2b+)

- **M7** — `packages/shared` for the 13 types duplicated backend↔frontend
- **M8** — `ServiceDefinition.handlesMediaType` replacing hardcoded `MEDIA_TYPE_TO_SERVICE`
- **M9** — `services/plex.ts` → `providers/plex/client.ts` (provider self-containment)
- **H8 finish** — LoginPage + UsersTab Plex PIN migration, LoginPage button-style helper
- **H4 finish** — QueryBuilder/FeaturesTab/QualityTab group-label restructure
- **H11** — N+1 in syncArrService
- **H16** — fetchWithRetry wrapper
- **M24** — react-virtual on long lists
- **H5** — toastApiError sweep
- **M1** — i18n orphan purge

## Test plan

- [ ] Open/close each migrated modal with Escape — closes
- [ ] Tab through each modal — focus stays trapped, Shift+Tab wraps
- [ ] Close a modal — focus returns to the trigger button
- [ ] RequestsPage : click a pending card body → navigates to /movie/:id ; click Approve/Decline/Delete → triggers action without navigation
- [ ] RequestsPage : keyboard-focus a card → outline on the overlay link ; Tab → reaches buttons
- [ ] Routing rules form : click the "Name" / "Type" labels → focuses the input below (htmlFor working)
- [ ] Plex OAuth popup from Services (Admin → Services → Add Plex → "Use Plex token") — still opens popup, polls, fills token
- [ ] Plex OAuth popup from Install wizard step 2 — still opens, polls, fills
- [ ] Auth Providers badges still show correct color per provider
- [ ] Users list provider pills still show correct color per provider
- [ ] `npm run build` clean on both packages