### PR TITLE
feat(plugins): ctx v1.1 — tmdb / requests / media / events + plug-and-play link flow (#165)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -950,13 +950,16 @@ Any ctx method outside of `log` and service-bound methods (`getServiceConfig*`, 
 
 | Bucket              | ctx methods                                                      | When to declare it                            |
 |---------------------|------------------------------------------------------------------|-----------------------------------------------|
-| `users:read`        | `getUser`, `getUserProviders`                                    | Lookup user profile or their linked providers |
+| `users:read`        | `getUser`, `findUserByEmail`, `findUserByProvider`, `getUserProviders` | Lookup user profile or their linked providers |
 | `users:write`       | `setUserRole`, `setUserDisabled`, `issueAuthToken`               | Change role, disable, impersonate             |
 | `settings:plugin`   | `getSetting`, `setSetting`, `getPluginDataDir`                   | Store plugin-scoped state or files            |
-| `settings:app`      | `getAppSettings`                                                 | Read Oscarr-wide settings (site name, etc.)   |
+| `settings:app`      | `getAppSettings`, `listFolderRules`                              | Read Oscarr-wide settings (site name, routing rules, etc.) |
 | `notifications`     | `sendNotification`, `sendUserNotification`                       | Send alerts to users or notification channels |
 | `permissions`       | `registerRoutePermission`, `registerPluginPermission`            | Declare RBAC rules for the plugin's routes    |
 | `events`            | `events.on / off / emit`                                         | Use the cross-plugin event bus                |
+| `tmdb:read`         | `tmdb.search`, `tmdb.movie`, `tmdb.tv`                           | Fetch TMDB metadata (cached + locale-aware)   |
+| `requests:read`     | `requests.listForUser`, `media.batchStatus`, `media.getById`     | Read the user's request state + Oscarr library status |
+| `requests:write`    | `requests.create`                                                | Create a media request on behalf of a user (full pipeline: validation → guard → blacklist → auto-approve → sendToService → notify) |
 
 `log` and service methods are gated separately:
 - **`log`** is always available. Secrets are scrubbed from `ctx.log.*(msg)` calls before persistence to avoid leaking tokens into the admin-visible `PluginLog` table.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -310,21 +310,33 @@ export function register(ctx: PluginContext): PluginRegistration {
 
 The context object provides access to Oscarr's core functionality:
 
-| Method | Description |
-|--------|-------------|
-| `ctx.log` | Fastify logger instance (child logger with plugin context) |
-| `ctx.getUser(userId)` | Get a user by ID. Returns `{ id, email, displayName, role }` or `null` |
-| `ctx.getAppSettings()` | Get all app settings as `Record<string, unknown>` |
-| `ctx.getSetting(key)` | Get a plugin-specific setting value (cached in memory) |
-| `ctx.setSetting(key, value)` | Set a plugin-specific setting value (persists to DB + updates cache) |
-| `ctx.sendNotification(type, data)` | Send a system notification (Discord, Telegram, Email) |
-| `ctx.sendUserNotification(userId, payload)` | Send an in-app notification to a specific user |
-| `ctx.notificationRegistry` | Access to the notification registry |
-| `ctx.getArrClient(serviceType)` | Get an existing Arr client (Sonarr, Radarr, etc.) |
-| `ctx.getServiceConfig(serviceType)` | Get service config `{ url, apiKey }` or `null` for direct API access |
-| `ctx.registerRoutePermission(routeKey, rule)` | Register an RBAC rule for a route |
-| `ctx.registerPluginPermission(permission, description?)` | Declare a custom permission |
-| `ctx.events` | Event bus — see [Events](#events) |
+| Method | Description | Capability |
+|--------|-------------|-----------|
+| `ctx.log` | Fastify logger instance (child logger with plugin context) | _always_ |
+| `ctx.getUser(userId)` | Get a user by ID. Returns `{ id, email, displayName, role, avatar }` or `null` | `users:read` |
+| `ctx.findUserByEmail(email)` | Find a user by email (symmetric with `findUserByProvider`) | `users:read` |
+| `ctx.findUserByProvider(provider, providerId)` | Find a user linked to an external provider identity | `users:read` |
+| `ctx.getUserProviders(userId)` | List a user's linked external providers (identity only, no tokens) | `users:read` |
+| `ctx.setUserRole(userId, roleName)` / `setUserDisabled(userId, disabled)` / `issueAuthToken(userId)` | User-management mutations | `users:write` |
+| `ctx.getAppSettings()` | Get all app settings as `Record<string, unknown>` | `settings:app` |
+| `ctx.listFolderRules({ enabled? })` | Read-only enumeration of admin routing rules | `settings:app` |
+| `ctx.getSetting(key)` / `setSetting(key, value)` / `getPluginDataDir()` | Plugin-scoped settings + data dir | `settings:plugin` |
+| `ctx.sendNotification(type, data)` | Send a system notification (Discord, Telegram, Email) | `notifications` |
+| `ctx.sendUserNotification(userId, payload)` | Send an in-app notification to a specific user | `notifications` |
+| `ctx.notificationRegistry` | Access to the notification registry | `notifications` |
+| `ctx.getArrClient(serviceType)` | Get the default Arr client (Sonarr, Radarr, …) | _`services[]` ACL_ |
+| `ctx.getArrClients(serviceType)` | **Pluriel** — every enabled instance of a service type | _`services[]` ACL_ |
+| `ctx.getServiceConfig(serviceType)` / `getServiceConfigRaw(serviceType)` | Service config for direct API access | _`services[]` ACL_ |
+| `ctx.tmdb.search(query, { page?, lang? })` | TMDB multi-search (cached) | `tmdb:read` |
+| `ctx.tmdb.movie(tmdbId, { lang? })` / `tv(tmdbId, { lang? })` | TMDB movie/TV details (cached, `lang` falls back to instance) | `tmdb:read` |
+| `ctx.media.batchStatus(items, userId?)` | Bulk Oscarr status for N TMDB ids, with user's per-item request state | `requests:read` |
+| `ctx.media.getById(mediaId)` | Single-media lookup, trimmed `PluginMedia` projection | `requests:read` |
+| `ctx.requests.listForUser(userId, { limit?, status? })` | Owner-scoped request listing, default 50 / max 200 | `requests:read` |
+| `ctx.requests.create(input)` | Full create-request pipeline on behalf of a user | `requests:write` |
+| `ctx.app.internalFetch(path, { method?, headers?, body?, asUserId? })` | Escape hatch — call any Oscarr HTTP route; pass `asUserId` to authenticate | _always_ |
+| `ctx.registerRoutePermission(routeKey, rule)` | Register an RBAC rule for a route | `permissions` |
+| `ctx.registerPluginPermission(permission, description?)` | Declare a custom permission | `permissions` |
+| `ctx.events` | Event bus — see [Events](#events) | `events` |
 
 ### sendNotification
 
@@ -398,6 +410,39 @@ ctx.events.emit('myplugin.sync_complete', { count: 42 });
 ```
 
 > **Note:** The event bus is in-process only. Events are not persisted and will not survive a server restart.
+
+### Core-emitted events
+
+The host fires two events plugins can subscribe to without polling the DB. Payloads are versioned with a `v` field so future shape changes coexist with existing subscribers.
+
+| Event | Payload type (`@oscarr/shared`) | Fires when |
+|-------|---------------------------------|-----------|
+| `user.notification.created` | `PluginUserNotificationCreatedV1` | Every time `safeUserNotify` persists an in-app notification — auth events, request lifecycle, media availability, plugin-owned events. Replaces cron-polling `UserNotification`. |
+| `media.available` | `PluginMediaAvailableV1` | A piece of media moved to `available` and at least one user had an active request for it. Broadcast-style: includes every requester's userId so a plugin can post once to a channel instead of N times. |
+
+Example — react to "your request was approved" with a Discord DM:
+
+```typescript
+import type { PluginUserNotificationCreatedV1 } from '@oscarr/shared';
+
+async registerRoutes(app, ctx) {
+  ctx.events.on('user.notification.created', async (raw) => {
+    const ev = raw as PluginUserNotificationCreatedV1;
+    if (ev.v !== 1) return; // Future-proofing: ignore unknown versions
+    if (ev.type !== 'request_approved') return;
+
+    const user = await ctx.getUser(ev.userId);
+    if (!user) return;
+
+    // Find the Discord link for this Oscarr user
+    const links = await ctx.getUserProviders(ev.userId);
+    const discordId = links.find(l => l.provider === 'discord')?.providerId;
+    if (!discordId) return;
+
+    await myDiscordClient.sendDM(discordId, `✅ ${ev.title} was approved — it's on the way.`);
+  });
+}
+```
 
 ## Backend routes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oscarr",
-  "version": "0.6.3",
+  "version": "0.7.0-dev",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/backend",
-  "version": "0.6.3",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -8,6 +8,8 @@ import type { NotificationPayload } from '../../notifications/types.js';
 import { sendUserNotification } from '../../services/userNotifications.js';
 import { getArrClient } from '../../providers/index.js';
 import type { ArrClient } from '../../providers/types.js';
+import { searchMulti, getMovieDetails, getTvDetails } from '../../services/tmdb.js';
+import type { PluginTmdbSearchPage } from '@oscarr/shared';
 import {
   registerRoutePermission as rbacRegisterRoute,
   registerPluginPermission as rbacRegisterPermission,
@@ -318,17 +320,21 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
       throw new Error('ctx.getArrClients: not implemented (Phase 2)');
     },
     tmdb: {
-      async search(_query: string) {
+      // `lang` omitted → backend's `normalizeLang` picks the instance default from AppSettings,
+      // so plugins get locale-consistent metadata out of the box. Responses are cached 1h
+      // (search) / 24h (details) by tmdb.ts — plugins don't need their own cache.
+      async search(query: string, options?: { page?: number; lang?: string }): Promise<PluginTmdbSearchPage> {
         req('tmdb:read', 'tmdb.search');
-        throw new Error('ctx.tmdb.search: not implemented (Phase 1 P2)');
+        const data = await searchMulti(query, options?.page ?? 1, options?.lang);
+        return data as PluginTmdbSearchPage;
       },
-      async movie(_tmdbId: number) {
+      async movie(tmdbId: number, options?: { lang?: string }) {
         req('tmdb:read', 'tmdb.movie');
-        throw new Error('ctx.tmdb.movie: not implemented (Phase 1 P2)');
+        return getMovieDetails(tmdbId, options?.lang);
       },
-      async tv(_tmdbId: number) {
+      async tv(tmdbId: number, options?: { lang?: string }) {
         req('tmdb:read', 'tmdb.tv');
-        throw new Error('ctx.tmdb.tv: not implemented (Phase 1 P2)');
+        return getTvDetails(tmdbId, options?.lang);
       },
     },
     media: {

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -9,7 +9,14 @@ import { sendUserNotification } from '../../services/userNotifications.js';
 import { getArrClient } from '../../providers/index.js';
 import type { ArrClient } from '../../providers/types.js';
 import { searchMulti, getMovieDetails, getTvDetails } from '../../services/tmdb.js';
-import type { PluginTmdbSearchPage } from '@oscarr/shared';
+import type {
+  PluginTmdbSearchPage,
+  PluginMedia,
+  PluginMediaRequest,
+  PluginMediaBatchKey,
+  PluginMediaBatchStatus,
+} from '@oscarr/shared';
+import { ACTIVE_REQUEST_STATUSES } from '@oscarr/shared';
 import {
   registerRoutePermission as rbacRegisterRoute,
   registerPluginPermission as rbacRegisterPermission,
@@ -338,19 +345,104 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
       },
     },
     media: {
-      async batchStatus(_items, _userId) {
+      async batchStatus(items, userId) {
         req('requests:read', 'media.batchStatus');
-        throw new Error('ctx.media.batchStatus: not implemented (Phase 1 P3)');
+        if (items.length === 0) return {};
+        // Two-pass query so we don't fetch the whole Media table:
+        // 1. One findMany on the union of (tmdbId,mediaType) pairs → media status per item.
+        // 2. One findMany on MediaRequest filtered by userId + the same media ids → user state.
+        // This replaces an N+1 pattern a plugin would otherwise hit (loop per item calling
+        // getMediaByTmdb).
+        const mediaRows = await prisma.media.findMany({
+          where: {
+            OR: items.map(i => ({ tmdbId: i.tmdbId, mediaType: i.mediaType })),
+          },
+          select: { id: true, tmdbId: true, mediaType: true, status: true },
+        });
+        const mediaByKey = new Map<string, { id: number; status: string }>();
+        for (const m of mediaRows) mediaByKey.set(`${m.mediaType}:${m.tmdbId}`, { id: m.id, status: m.status });
+
+        const userRequestsByMediaId = new Map<number, string>();
+        if (userId !== undefined && mediaRows.length > 0) {
+          const reqs = await prisma.mediaRequest.findMany({
+            where: {
+              userId,
+              mediaId: { in: mediaRows.map(m => m.id) },
+              status: { in: [...ACTIVE_REQUEST_STATUSES] },
+            },
+            select: { mediaId: true, status: true },
+            orderBy: { createdAt: 'desc' },
+          });
+          // Keep the most recent active request per media (orderBy desc + Map.set overwrites).
+          for (const r of reqs) {
+            if (!userRequestsByMediaId.has(r.mediaId)) userRequestsByMediaId.set(r.mediaId, r.status);
+          }
+        }
+
+        const out: Record<PluginMediaBatchKey, PluginMediaBatchStatus> = {};
+        for (const item of items) {
+          const key: PluginMediaBatchKey = `${item.mediaType}:${item.tmdbId}`;
+          const m = mediaByKey.get(key);
+          const userStatus = m ? userRequestsByMediaId.get(m.id) ?? null : null;
+          out[key] = {
+            status: m?.status ?? 'unknown',
+            userRequestStatus: userStatus,
+            userHasActiveRequest: userStatus !== null,
+          };
+        }
+        return out;
       },
-      async getById(_mediaId: number) {
+      async getById(mediaId: number) {
         req('requests:read', 'media.getById');
-        throw new Error('ctx.media.getById: not implemented (Phase 1 P3)');
+        const row = await prisma.media.findUnique({
+          where: { id: mediaId },
+          select: { id: true, tmdbId: true, tvdbId: true, mediaType: true, title: true, posterPath: true, status: true },
+        });
+        if (!row) return null;
+        return {
+          id: row.id,
+          tmdbId: row.tmdbId,
+          tvdbId: row.tvdbId,
+          mediaType: row.mediaType as 'movie' | 'tv',
+          title: row.title,
+          posterPath: row.posterPath,
+          status: row.status,
+        } satisfies PluginMedia;
       },
     },
     requests: {
-      async listForUser(_userId: number) {
+      async listForUser(userId: number, options?: { limit?: number; status?: string }) {
         req('requests:read', 'requests.listForUser');
-        throw new Error('ctx.requests.listForUser: not implemented (Phase 1 P3)');
+        const limit = Math.min(Math.max(options?.limit ?? 50, 1), 200);
+        const rows = await prisma.mediaRequest.findMany({
+          where: {
+            userId,
+            ...(options?.status ? { status: options.status } : {}),
+          },
+          orderBy: { createdAt: 'desc' },
+          take: limit,
+          select: {
+            id: true, userId: true, mediaType: true, seasons: true, status: true, createdAt: true,
+            media: { select: { id: true, tmdbId: true, tvdbId: true, mediaType: true, title: true, posterPath: true, status: true } },
+          },
+        });
+        return rows.map((r): PluginMediaRequest => ({
+          id: r.id,
+          userId: r.userId,
+          mediaType: r.mediaType as 'movie' | 'tv',
+          seasons: r.seasons ? (JSON.parse(r.seasons) as number[]) : null,
+          status: r.status,
+          createdAt: r.createdAt.toISOString(),
+          media: {
+            id: r.media.id,
+            tmdbId: r.media.tmdbId,
+            tvdbId: r.media.tvdbId,
+            mediaType: r.media.mediaType as 'movie' | 'tv',
+            title: r.media.title,
+            posterPath: r.media.posterPath,
+            status: r.media.status,
+          },
+        }));
       },
       async create(_input) {
         req('requests:write', 'requests.create');

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -6,7 +6,8 @@ import { scrubSecrets } from '../../utils/logScrubber.js';
 import { notificationRegistry } from '../../notifications/index.js';
 import type { NotificationPayload } from '../../notifications/types.js';
 import { sendUserNotification } from '../../services/userNotifications.js';
-import { getArrClient } from '../../providers/index.js';
+import { getArrClient, createArrClient } from '../../providers/index.js';
+import { getAllServices } from '../../utils/services.js';
 import type { ArrClient } from '../../providers/types.js';
 import { searchMulti, getMovieDetails, getTvDetails } from '../../services/tmdb.js';
 import { createUserRequest } from '../../services/requestService.js';
@@ -16,6 +17,7 @@ import type {
   PluginMediaRequest,
   PluginMediaBatchKey,
   PluginMediaBatchStatus,
+  PluginFolderRule,
 } from '@oscarr/shared';
 import { ACTIVE_REQUEST_STATUSES } from '@oscarr/shared';
 import {
@@ -324,8 +326,14 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
     // Stubs throw with a recognisable error so any accidental call before its phase lands
     // surfaces loudly instead of silently returning undefined.
 
-    async getArrClients(_serviceType: string): Promise<ArrClient[]> {
-      throw new Error('ctx.getArrClients: not implemented (Phase 2)');
+    async getArrClients(serviceType: string): Promise<ArrClient[]> {
+      // Pluriel of getArrClient: returns every enabled instance for the type. ACL check is
+      // shared with the singular form (services[] manifest declaration).
+      if (!checkServiceAccess(pluginId, allowedServices, serviceType, aclLogger)) {
+        throw new Error(`Plugin "${pluginId}" is not allowed to access service "${serviceType}" — declare it in manifest.services`);
+      }
+      const services = await getAllServices(serviceType);
+      return services.map(s => createArrClient(serviceType, s.config));
     },
     tmdb: {
       // `lang` omitted → backend's `normalizeLang` picks the instance default from AppSettings,
@@ -471,8 +479,31 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
         };
       },
     },
-    async listFolderRules(_options?) {
-      throw new Error('ctx.listFolderRules: not implemented (Phase 2)');
+    async listFolderRules(options?): Promise<PluginFolderRule[]> {
+      req('settings:app', 'listFolderRules');
+      const rows = await prisma.folderRule.findMany({
+        where: options?.enabled !== undefined ? { enabled: options.enabled } : undefined,
+        orderBy: { priority: 'asc' },
+      });
+      return rows.map((r): PluginFolderRule => ({
+        id: r.id,
+        name: r.name,
+        priority: r.priority,
+        mediaType: r.mediaType,
+        // conditions is stored as JSON string; parse here so the plugin API returns a real
+        // array (matching PluginFolderRule's shape). Defensive fallback: [] on malformed JSON
+        // — admin-typed data, but we'd rather return nothing than crash the plugin.
+        conditions: (() => {
+          try {
+            const parsed = JSON.parse(r.conditions);
+            return Array.isArray(parsed) ? parsed : [];
+          } catch { return []; }
+        })(),
+        folderPath: r.folderPath,
+        seriesType: r.seriesType,
+        serviceId: r.serviceId,
+        enabled: r.enabled,
+      }));
     },
   };
 }

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -357,6 +357,11 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
       async batchStatus(items, userId) {
         req('requests:read', 'media.batchStatus');
         if (items.length === 0) return {};
+        // Hard cap to prevent a bug (or malicious plugin) from generating a 10k-clause OR
+        // query that would pin SQLite's parser. Mirrors the `listForUser` pattern (max 200).
+        if (items.length > 500) {
+          throw new Error(`ctx.media.batchStatus: items length ${items.length} exceeds the 500 cap — slice your list or filter upstream`);
+        }
         // Two-pass query so we don't fetch the whole Media table:
         // 1. One findMany on the union of (tmdbId,mediaType) pairs → media status per item.
         // 2. One findMany on MediaRequest filtered by userId + the same media ids → user state.
@@ -455,6 +460,12 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
       },
       async create(input) {
         req('requests:write', 'requests.create');
+        // Runtime validation at the boundary — TypeScript only guards compile-time callers,
+        // but plugins load plain JS from disk and can pass anything. Catch obvious garbage
+        // here rather than forwarding NaN into Prisma where the error becomes opaque.
+        if (!Number.isInteger(input?.userId) || (input.userId as number) < 1) {
+          return { ok: false, code: 'INVALID_INPUT', error: 'userId must be a positive integer' };
+        }
         // Delegates to the same createUserRequest pipeline the HTTP route uses — pluginGuard
         // + blacklist + dedup + quality gate + sendToService + safeNotify all honoured.
         // Target user's role (loaded from DB inside createUserRequest) drives auto-approve;

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -7,6 +7,7 @@ import { notificationRegistry } from '../../notifications/index.js';
 import type { NotificationPayload } from '../../notifications/types.js';
 import { sendUserNotification } from '../../services/userNotifications.js';
 import { getArrClient } from '../../providers/index.js';
+import type { ArrClient } from '../../providers/types.js';
 import {
   registerRoutePermission as rbacRegisterRoute,
   registerPluginPermission as rbacRegisterPermission,
@@ -163,14 +164,21 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
       req('users:read', 'getUser');
       return prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true, email: true, displayName: true, role: true },
+        select: { id: true, email: true, displayName: true, role: true, avatar: true },
+      });
+    },
+    async findUserByEmail(email: string) {
+      req('users:read', 'findUserByEmail');
+      return prisma.user.findUnique({
+        where: { email },
+        select: { id: true, email: true, displayName: true, role: true, avatar: true },
       });
     },
     async findUserByProvider(provider: string, providerId: string) {
       req('users:read', 'findUserByProvider');
       const link = await prisma.userProvider.findUnique({
         where: { provider_providerId: { provider, providerId } },
-        include: { user: { select: { id: true, email: true, displayName: true, role: true } } },
+        include: { user: { select: { id: true, email: true, displayName: true, role: true, avatar: true } } },
       });
       return link?.user ?? null;
     },
@@ -298,6 +306,53 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
         req('events', 'events.emit');
         return pluginEventBus.emit(event, data);
       },
+    },
+
+    // ─── v1.1 additions — stubs filled in by subsequent phase commits ───
+    // Each method here is a typed placeholder so the `PluginContext` type is satisfied; the
+    // real implementation lands in the corresponding phase (see feat/plugin-ctx-v1.1 PR).
+    // Stubs throw with a recognisable error so any accidental call before its phase lands
+    // surfaces loudly instead of silently returning undefined.
+
+    async getArrClients(_serviceType: string): Promise<ArrClient[]> {
+      throw new Error('ctx.getArrClients: not implemented (Phase 2)');
+    },
+    tmdb: {
+      async search(_query: string) {
+        req('tmdb:read', 'tmdb.search');
+        throw new Error('ctx.tmdb.search: not implemented (Phase 1 P2)');
+      },
+      async movie(_tmdbId: number) {
+        req('tmdb:read', 'tmdb.movie');
+        throw new Error('ctx.tmdb.movie: not implemented (Phase 1 P2)');
+      },
+      async tv(_tmdbId: number) {
+        req('tmdb:read', 'tmdb.tv');
+        throw new Error('ctx.tmdb.tv: not implemented (Phase 1 P2)');
+      },
+    },
+    media: {
+      async batchStatus(_items, _userId) {
+        req('requests:read', 'media.batchStatus');
+        throw new Error('ctx.media.batchStatus: not implemented (Phase 1 P3)');
+      },
+      async getById(_mediaId: number) {
+        req('requests:read', 'media.getById');
+        throw new Error('ctx.media.getById: not implemented (Phase 1 P3)');
+      },
+    },
+    requests: {
+      async listForUser(_userId: number) {
+        req('requests:read', 'requests.listForUser');
+        throw new Error('ctx.requests.listForUser: not implemented (Phase 1 P3)');
+      },
+      async create(_input) {
+        req('requests:write', 'requests.create');
+        throw new Error('ctx.requests.create: not implemented (Phase 1 P4)');
+      },
+    },
+    async listFolderRules(_options?) {
+      throw new Error('ctx.listFolderRules: not implemented (Phase 2)');
     },
   };
 }

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -479,6 +479,42 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
         };
       },
     },
+    app: {
+      async internalFetch(path, init) {
+        // Resolve port once per call — PORT is set at boot by index.ts, no caching needed.
+        // The CSRF gate (@fastify/helmet + x-requested-with check on mutations) passes because
+        // we always set the marker header; RBAC enforcement is the target route's job.
+        const port = process.env.PORT || '3001';
+        const base = `http://localhost:${port}`;
+        const url = base + (path.startsWith('/') ? path : `/${path}`);
+        const headers: Record<string, string> = {
+          'x-requested-with': 'oscarr',
+          ...init?.headers,
+        };
+        if (init?.asUserId !== undefined) {
+          const user = await prisma.user.findUnique({
+            where: { id: init.asUserId },
+            select: { id: true, email: true, role: true },
+          });
+          if (!user) throw new Error(`internalFetch asUserId=${init.asUserId}: user not found`);
+          // `token` is the cookie name set by routes/auth.ts + read by @fastify/jwt's
+          // cookie extractor (bootstrap/security.ts). Minting via signAuthToken keeps the
+          // plugin path identical to a normal login from RBAC's perspective.
+          const jwt = deps.signAuthToken({ id: user.id, email: user.email, role: user.role });
+          headers.cookie = `token=${jwt}`;
+        }
+        let body: BodyInit | undefined;
+        if (init?.body !== undefined) {
+          if (typeof init.body === 'string' || init.body instanceof Uint8Array || init.body instanceof URLSearchParams) {
+            body = init.body as BodyInit;
+          } else {
+            body = JSON.stringify(init.body);
+            if (!headers['content-type']) headers['content-type'] = 'application/json';
+          }
+        }
+        return fetch(url, { method: init?.method ?? 'GET', headers, body });
+      },
+    },
     async listFolderRules(options?): Promise<PluginFolderRule[]> {
       req('settings:app', 'listFolderRules');
       const rows = await prisma.folderRule.findMany({

--- a/packages/backend/src/plugins/context/v1.ts
+++ b/packages/backend/src/plugins/context/v1.ts
@@ -9,6 +9,7 @@ import { sendUserNotification } from '../../services/userNotifications.js';
 import { getArrClient } from '../../providers/index.js';
 import type { ArrClient } from '../../providers/types.js';
 import { searchMulti, getMovieDetails, getTvDetails } from '../../services/tmdb.js';
+import { createUserRequest } from '../../services/requestService.js';
 import type {
   PluginTmdbSearchPage,
   PluginMedia,
@@ -444,9 +445,30 @@ export function createContextV1(manifest: PluginManifest, deps: V1FactoryDeps): 
           },
         }));
       },
-      async create(_input) {
+      async create(input) {
         req('requests:write', 'requests.create');
-        throw new Error('ctx.requests.create: not implemented (Phase 1 P4)');
+        // Delegates to the same createUserRequest pipeline the HTTP route uses — pluginGuard
+        // + blacklist + dedup + quality gate + sendToService + safeNotify all honoured.
+        // Target user's role (loaded from DB inside createUserRequest) drives auto-approve;
+        // plugins cannot escalate by passing a userId they don't "own" — they always act as
+        // that user would act via the HTTP API.
+        const result = await createUserRequest({
+          userId: input.userId,
+          tmdbId: input.tmdbId,
+          mediaType: input.mediaType,
+          seasons: input.seasons,
+          rootFolder: input.rootFolder,
+          qualityOptionId: input.qualityOptionId,
+          skipPluginGuard: input.skipPluginGuard,
+        });
+        if (!result.ok) return { ok: false, code: result.code, error: result.error };
+        return {
+          ok: true,
+          requestId: result.request.id,
+          status: result.request.status,
+          autoApproved: result.request.status === 'approved' || result.request.status === 'searching',
+          sendFailed: result.sendFailed,
+        };
       },
     },
     async listFolderRules(_options?) {

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -208,27 +208,37 @@ export class PluginEngine {
     this.app = app;
     this.mountDispatcher(app);
 
+    // Routes register first (sync-ish, mostly local), then onEnable runs in parallel.
+    // Routes have to be sequential — they share the Fastify dispatcher mount — but
+    // onEnable is per-plugin background work (Discord bot login, websocket clients,
+    // mailbox poll loops …) where one slow plugin would otherwise block Oscarr's boot
+    // for the duration of every other plugin's startup combined.
     for (const plugin of this.plugins.values()) {
       if (!plugin.enabled || plugin.error) continue;
       if (plugin.registration.registerRoutes) {
         await this._registerRoutes(plugin);
       }
-      // Boot-time onEnable parity with togglePlugin: a plugin that's already enabled in the
-      // DB needs its onEnable to run on every Oscarr restart, otherwise plugins doing
-      // background work (Discord bot login, websocket clients, mailbox poll loops…) stay
-      // dormant until an admin toggles off+on. A plugin that does its boot work inside
-      // `register()` won't have an `onEnable` hook to begin with — this is a no-op for
-      // them.
-      if (plugin.registration.onEnable) {
-        try {
-          const ctx = createContext(plugin.manifest, this.getContextDeps());
-          await plugin.registration.onEnable(ctx);
-        } catch (err) {
+    }
+
+    // Boot-time onEnable parity with togglePlugin: a plugin that's already enabled in the
+    // DB needs its onEnable to run on every Oscarr restart, otherwise plugins doing
+    // background work stay dormant until an admin toggles off+on. A plugin that does its
+    // boot work inside `register()` won't have an `onEnable` hook to begin with — no-op
+    // for them.
+    const enableTasks: Array<Promise<void>> = [];
+    for (const plugin of this.plugins.values()) {
+      if (!plugin.enabled || plugin.error) continue;
+      if (!plugin.registration.onEnable) continue;
+      const onEnable = plugin.registration.onEnable;
+      const ctx = createContext(plugin.manifest, this.getContextDeps());
+      enableTasks.push(
+        Promise.resolve(onEnable(ctx)).catch((err) => {
           this.log('error', `Boot-time onEnable failed for "${plugin.manifest.id}": ${err}`);
           plugin.error = `onEnable failed at boot: ${err}`;
-        }
-      }
+        }),
+      );
     }
+    await Promise.allSettled(enableTasks);
   }
 
   getJobHandlers(): Record<string, () => Promise<unknown>> {

--- a/packages/backend/src/plugins/engine.ts
+++ b/packages/backend/src/plugins/engine.ts
@@ -210,8 +210,24 @@ export class PluginEngine {
 
     for (const plugin of this.plugins.values()) {
       if (!plugin.enabled || plugin.error) continue;
-      if (!plugin.registration.registerRoutes) continue;
-      await this._registerRoutes(plugin);
+      if (plugin.registration.registerRoutes) {
+        await this._registerRoutes(plugin);
+      }
+      // Boot-time onEnable parity with togglePlugin: a plugin that's already enabled in the
+      // DB needs its onEnable to run on every Oscarr restart, otherwise plugins doing
+      // background work (Discord bot login, websocket clients, mailbox poll loops…) stay
+      // dormant until an admin toggles off+on. A plugin that does its boot work inside
+      // `register()` won't have an `onEnable` hook to begin with — this is a no-op for
+      // them.
+      if (plugin.registration.onEnable) {
+        try {
+          const ctx = createContext(plugin.manifest, this.getContextDeps());
+          await plugin.registration.onEnable(ctx);
+        } catch (err) {
+          this.log('error', `Boot-time onEnable failed for "${plugin.manifest.id}": ${err}`);
+          plugin.error = `onEnable failed at boot: ${err}`;
+        }
+      }
     }
   }
 

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -176,6 +176,28 @@ export interface PluginContext {
     getById(mediaId: number): Promise<PluginMedia | null>;
   };
 
+  /** Escape hatch for calling the host's own HTTP API. Useful for endpoints that don't have
+   *  a typed ctx wrapper yet (e.g. plugin-specific admin surfaces, legacy routes). The engine
+   *  resolves `localhost:${PORT}` and — when `asUserId` is passed — mints a short-lived auth
+   *  cookie scoped to that user so the call passes RBAC as if the user made it themselves.
+   *  No capability bucket: internalFetch is always available, but the target route's own RBAC
+   *  rules still apply (hitting an admin route without `asUserId` pointing to an admin
+   *  returns 401/403). */
+  app: {
+    internalFetch(
+      path: string,
+      init?: {
+        method?: string;
+        headers?: Record<string, string>;
+        body?: unknown;
+        /** When set, the call is authenticated as this user (same session a browser would
+         *  get by logging in). Omitted → call runs unauthenticated, only reaches public
+         *  routes like `/api/app/features`. */
+        asUserId?: number;
+      },
+    ): Promise<Response>;
+  };
+
   /** Request pipeline access. Read methods gated by `requests:read`; `create` gated by
    *  `requests:write`. */
   requests: {

--- a/packages/backend/src/plugins/types.ts
+++ b/packages/backend/src/plugins/types.ts
@@ -3,6 +3,15 @@ import type { NotificationRegistry } from '../notifications/registry.js';
 import type { NotificationPayload } from '../notifications/types.js';
 import type { ArrClient } from '../providers/types.js';
 import type { PluginRouter } from './router.js';
+import type {
+  PluginMedia,
+  PluginMediaRequest,
+  PluginMediaBatchKey,
+  PluginMediaBatchStatus,
+  PluginTmdbSearchPage,
+  PluginFolderRule,
+} from '@oscarr/shared';
+import type { TmdbMovie, TmdbTv } from '@oscarr/shared';
 
 // ─── Plugin Manifest (manifest.json) ────────────────────────────────
 
@@ -13,7 +22,12 @@ export type PluginCapability =
   | 'settings:app'
   | 'notifications'
   | 'permissions'
-  | 'events';
+  | 'events'
+  // Added in v1.1 — scoped access to read/write the request pipeline + TMDB metadata.
+  // Each new bucket is opt-in via manifest.capabilities, checked at call-time in context/v1.ts.
+  | 'tmdb:read'
+  | 'requests:read'
+  | 'requests:write';
 
 export const ALL_CAPABILITIES: readonly PluginCapability[] = [
   'users:read',
@@ -23,6 +37,9 @@ export const ALL_CAPABILITIES: readonly PluginCapability[] = [
   'notifications',
   'permissions',
   'events',
+  'tmdb:read',
+  'requests:read',
+  'requests:write',
 ] as const;
 
 export interface PluginManifest {
@@ -82,7 +99,7 @@ export interface LoadedUIContribution extends UIContribution {
 
 export interface PluginContext {
   log: FastifyBaseLogger;
-  getUser(userId: number): Promise<{ id: number; email: string; displayName: string | null; role: string } | null>;
+  getUser(userId: number): Promise<{ id: number; email: string; displayName: string | null; role: string; avatar: string | null } | null>;
   /** Assign a role to a user. Throws if the role doesn't exist. */
   setUserRole(userId: number, roleName: string): Promise<void>;
   /** Enable or disable an Oscarr user. Disabled users are rejected at login per AppSettings.disabledLoginMode (friendly message vs silent block). Admins cannot be disabled via this method — throws if you try, to protect the server owner from accidental lockout. */
@@ -108,13 +125,85 @@ export interface PluginContext {
    * UserProvider row matches. Useful for plugins that receive events from external systems
    * (Discord bot webhooks, etc.) and need to resolve the Oscarr user behind an external ID.
    */
-  findUserByProvider(provider: string, providerId: string): Promise<{ id: number; email: string; displayName: string | null; role: string } | null>;
+  findUserByProvider(provider: string, providerId: string): Promise<{ id: number; email: string; displayName: string | null; role: string; avatar: string | null } | null>;
   registerRoutePermission(routeKey: string, rule: { permission: string; ownerScoped?: boolean }): void;
   registerPluginPermission(permission: string, description?: string): void;
   events: {
     on(event: string, handler: (data: unknown) => void | Promise<void>): void;
     off(event: string, handler: (data: unknown) => void | Promise<void>): void;
     emit(event: string, data: unknown): Promise<void>;
+  };
+
+  // ─── v1.1 additions (additive — existing plugins keep working unchanged) ───
+
+  /** Pluriel form of `getArrClient`: returns every enabled instance of the given service type
+   *  (e.g. two Radarrs). Use this when a plugin needs to fan out across multi-instance setups
+   *  instead of always targeting the default one. Gated by the existing `services[]` ACL —
+   *  the plugin must declare the service type in its manifest. */
+  getArrClients(serviceType: string): Promise<ArrClient[]>;
+
+  /** Find an Oscarr user by email. Symmetric to `findUserByProvider`. Useful for CSV imports,
+   *  cross-system reconciliation, or webhook payloads that only carry an email. */
+  findUserByEmail(email: string): Promise<{ id: number; email: string; displayName: string | null; role: string; avatar: string | null } | null>;
+
+  /** Read-only enumeration of the admin's routing rules. Plugins typically use this to offer
+   *  the same category picker as the web UI (Radarr "Movies / 4K / Anime" buckets). Optional
+   *  `enabled` filter matches the admin UI's default view. */
+  listFolderRules(options?: { enabled?: boolean }): Promise<PluginFolderRule[]>;
+
+  /** TMDB metadata bucket — wraps `services/tmdb.ts` with cache + lang-resolution respected.
+   *  Gated by `tmdb:read`. `lang` falls back to the instance default when omitted. */
+  tmdb: {
+    search(query: string, options?: { page?: number; lang?: string }): Promise<PluginTmdbSearchPage>;
+    movie(tmdbId: number, options?: { lang?: string }): Promise<TmdbMovie>;
+    tv(tmdbId: number, options?: { lang?: string }): Promise<TmdbTv>;
+  };
+
+  /** Oscarr-side media helpers. Kept separate from `requests` because `batchStatus` + `getById`
+   *  are read-only and useful on their own (enriching a TMDB result grid, rendering a
+   *  notification payload). Gated by `requests:read` — same bucket since both query the same
+   *  request-aware view of the library. */
+  media: {
+    /** Bulk lookup of Oscarr status for N TMDB ids. When `userId` is passed, also reports the
+     *  user's personal request status per item. Replaces N+1 patterns where a plugin would
+     *  otherwise loop `findByExternalId` per result. */
+    batchStatus(
+      items: Array<{ tmdbId: number; mediaType: 'movie' | 'tv' }>,
+      userId?: number,
+    ): Promise<Record<PluginMediaBatchKey, PluginMediaBatchStatus>>;
+    /** Single-media lookup by Oscarr id (not TMDB id). Returns null when the media row
+     *  doesn't exist — plugins can enrich a notification payload or confirm a reference. */
+    getById(mediaId: number): Promise<PluginMedia | null>;
+  };
+
+  /** Request pipeline access. Read methods gated by `requests:read`; `create` gated by
+   *  `requests:write`. */
+  requests: {
+    /** List the given user's requests. Useful for a "your pending requests" Discord command
+     *  or a queue-visualiser plugin. Optional `status` narrows to a specific status code.
+     *  `limit` caps the response (default 50, hard max 200) — pagination is intentionally
+     *  not exposed; plugins that need deeper slices should filter by `status` instead. */
+    listForUser(
+      userId: number,
+      options?: { limit?: number; status?: string },
+    ): Promise<PluginMediaRequest[]>;
+    /** Run the full create-request pipeline on behalf of `userId`: validation → pluginGuard
+     *  (skippable via `skipPluginGuard` for guard-owning plugins) → blacklist → dedup →
+     *  quality gate → row create → sendToService → safeNotify. No role escalation — the
+     *  pipeline loads the target user's role from the DB and behaves exactly as the HTTP
+     *  route would for that same user. */
+    create(input: {
+      userId: number;
+      tmdbId: number;
+      mediaType: 'movie' | 'tv';
+      seasons?: number[];
+      rootFolder?: string;
+      qualityOptionId?: number;
+      skipPluginGuard?: boolean;
+    }): Promise<
+      | { ok: true; requestId: number; status: string; autoApproved: boolean; sendFailed?: boolean }
+      | { ok: false; code: string; error: string }
+    >;
   };
 }
 

--- a/packages/backend/src/providers/discord/index.ts
+++ b/packages/backend/src/providers/discord/index.ts
@@ -116,7 +116,13 @@ const discordAuth: AuthProvider = {
         try {
           await request.jwtVerify();
         } catch {
-          return reply.status(401).send({ error: 'Login required to link' });
+          // Plug-and-play UX: a logged-out user clicking a /link deep link (e.g. from a
+          // Discord bot plugin's "Link your account" button) shouldn't get a raw 401 JSON
+          // — bounce them through Oscarr's login page with `?next=<this URL>`. After auth,
+          // the LoginPage redirects them back here and the JWT cookie is now present, so
+          // jwtVerify succeeds and the link flow completes.
+          const fullUrl = request.url; // includes /api/auth/discord/authorize?action=link
+          return reply.redirect(`/login?next=${encodeURIComponent(fullUrl)}`);
         }
         userId = (request.user as { id: number }).id;
       }

--- a/packages/backend/src/providers/radarr/client.ts
+++ b/packages/backend/src/providers/radarr/client.ts
@@ -269,7 +269,7 @@ export class RadarrClient implements ArrClient {
   }
 
   parseWebhookPayload(body: unknown): ArrWebhookEvent | null {
-    const payload = body as { eventType?: string; movie?: { tmdbId?: number; title?: string } };
+    const payload = body as { eventType?: string; movie?: { id?: number; tmdbId?: number; title?: string } };
     if (!payload.eventType) return null;
     // Test event has no movie data
     if (payload.eventType === 'Test') return { type: 'test', externalId: 0, title: 'Test' };
@@ -278,6 +278,7 @@ export class RadarrClient implements ArrClient {
     return {
       type: typeMap[payload.eventType] || 'unknown',
       externalId: payload.movie.tmdbId,
+      internalId: payload.movie.id,
       title: payload.movie.title || 'Unknown',
     };
   }

--- a/packages/backend/src/providers/sonarr/client.ts
+++ b/packages/backend/src/providers/sonarr/client.ts
@@ -357,7 +357,7 @@ export class SonarrClient implements ArrClient {
   }
 
   parseWebhookPayload(body: unknown): ArrWebhookEvent | null {
-    const payload = body as { eventType?: string; series?: { tvdbId?: number; title?: string }; episodes?: { seasonNumber?: number; episodeNumber?: number }[] };
+    const payload = body as { eventType?: string; series?: { id?: number; tvdbId?: number; title?: string }; episodes?: { seasonNumber?: number; episodeNumber?: number }[] };
     if (!payload.eventType) return null;
     if (payload.eventType === 'Test') return { type: 'test', externalId: 0, title: 'Test' };
     if (!payload.series?.tvdbId) return null;
@@ -366,6 +366,7 @@ export class SonarrClient implements ArrClient {
     return {
       type: typeMap[payload.eventType] || 'unknown',
       externalId: payload.series.tvdbId,
+      internalId: payload.series.id,
       title: payload.series.title || 'Unknown',
       seasonNumber: ep?.seasonNumber,
       episodeNumber: ep?.episodeNumber,

--- a/packages/backend/src/providers/types.ts
+++ b/packages/backend/src/providers/types.ts
@@ -57,6 +57,11 @@ export interface ArrEpisode {
 export interface ArrWebhookEvent {
   type: 'download' | 'grab' | 'added' | 'deleted' | 'test' | 'unknown';
   externalId: number;
+  /** *arr-internal id for the movie/series (Radarr's `movie.id`, Sonarr's `series.id`).
+   *  Persisted on the matching Media row as `radarrId` / `sonarrId` — the home's
+   *  "Recently added" query filters on those, so without it a webhook-only flow (admin
+   *  disables the sync job) leaves freshly-available media invisible on the home. */
+  internalId?: number;
   title: string;
   seasonNumber?: number;
   episodeNumber?: number;

--- a/packages/backend/src/routes/admin/settings.ts
+++ b/packages/backend/src/routes/admin/settings.ts
@@ -127,9 +127,13 @@ export async function settingsRoutes(app: FastifyInstance) {
       },
     });
 
-    // If instance language changed, clear all caches to force re-fetch in new language
+    // If instance language changed, clear all caches to force re-fetch in new language.
+    // invalidateSiteUrl flushes both the siteUrl AND the instance-language caches in
+    // safeNotify — without it, plugin event-bus subscribers keep receiving the old
+    // language's titleText/messageText until backend restart.
     if (body.instanceLanguages) {
       invalidateLanguageCache();
+      invalidateSiteUrl();
       await prisma.tmdbCache.deleteMany();
       logEvent('info', 'Settings', 'TMDB cache cleared due to language change');
     }

--- a/packages/backend/src/routes/requests/create.ts
+++ b/packages/backend/src/routes/requests/create.ts
@@ -1,26 +1,15 @@
 import type { FastifyInstance } from 'fastify';
-import { prisma } from '../../utils/prisma.js';
 import { getCollection } from '../../services/tmdb.js';
-import { logEvent } from '../../utils/logEvent.js';
-import { safeNotify, safeUserNotify, buildSiteLink } from '../../utils/safeNotify.js';
-import { ACTIVE_REQUEST_STATUSES } from '@oscarr/shared';
 import {
-  validateRequestBody,
-  findOrCreateMedia,
-  getUserTagName,
-  sendToService,
+  createUserRequest,
   requestCollectionMovie,
-  isBlacklisted,
 } from '../../services/requestService.js';
 import { pluginEngine } from '../../plugins/engine.js';
 
-async function runPluginGuard(userId: number) {
-  return pluginEngine.runGuards('request.create', userId);
-}
-
 /** Create-request paths — the hot path for a user asking for a movie/tv (one) and the bulk
- *  collection endpoint that fan-outs one request per movie in a TMDB collection. Both run the
- *  plugin guard + blacklist check + auto-approve decision before writing the request row. */
+ *  collection endpoint that fan-outs one request per movie in a TMDB collection. The heavy
+ *  lifting (validation → guard → blacklist → dedup → autoApprove → send → notify) lives in
+ *  `createUserRequest` so plugins via `ctx.requests.create` hit the exact same pipeline. */
 export async function requestCreateRoutes(app: FastifyInstance) {
   app.post('/', {
     config: { rateLimit: { max: 30, timeWindow: '1 minute' } },
@@ -41,87 +30,18 @@ export async function requestCreateRoutes(app: FastifyInstance) {
     const user = request.user as { id: number; role: string };
     const body = request.body as { tmdbId: unknown; mediaType: unknown; seasons?: unknown; rootFolder?: string; qualityOptionId?: number };
 
-    const validation = validateRequestBody(body);
-    if (!validation.valid) return reply.status(400).send({ error: validation.error });
-    const { tmdbId, mediaType, seasons: validSeasons } = validation;
-
-    if (user.role !== 'admin') {
-      const guardResult = await runPluginGuard(user.id);
-      if (guardResult?.blocked) return reply.status(guardResult.statusCode || 403).send({ error: guardResult.error });
-    }
-
-    const bl = await isBlacklisted(tmdbId, mediaType);
-    if (bl.blacklisted) return reply.status(403).send({ error: bl.reason || 'This media has been blocked by an administrator.' });
-
-    const media = await findOrCreateMedia(tmdbId, mediaType);
-
-    const existing = await prisma.mediaRequest.findFirst({
-      where: { mediaId: media.id, userId: user.id, status: { in: [...ACTIVE_REQUEST_STATUSES] } },
-    });
-    if (existing) return reply.status(409).send({ error: 'You already have an active request for this media' });
-
-    const settings = await prisma.appSettings.findUnique({ where: { id: 1 } });
-    let shouldAutoApprove = user.role === 'admin' || (settings?.autoApproveRequests ?? false);
-    if (body.qualityOptionId != null) {
-      const qualityOpt = await prisma.qualityOption.findUnique({ where: { id: body.qualityOptionId as number } });
-      if (qualityOpt?.allowedRoles && user.role !== 'admin') {
-        try {
-          const roles = JSON.parse(qualityOpt.allowedRoles) as string[];
-          if (roles.length > 0 && !roles.includes(user.role)) {
-            return reply.status(403).send({ error: 'QUALITY_NOT_ALLOWED' });
-          }
-        } catch { /* malformed JSON — allow, permissive fallback matches historical behavior */ }
-      }
-      if (qualityOpt?.approvalMode === 'auto') shouldAutoApprove = true;
-      else if (qualityOpt?.approvalMode === 'manual') shouldAutoApprove = user.role === 'admin';
-    }
-
-    const mediaRequest = await prisma.mediaRequest.create({
-      data: {
-        mediaId: media.id,
-        userId: user.id,
-        mediaType,
-        seasons: validSeasons ? JSON.stringify(validSeasons) : null,
-        rootFolder: typeof body.rootFolder === 'string' ? body.rootFolder : null,
-        qualityOptionId: body.qualityOptionId ?? null,
-        status: shouldAutoApprove ? 'approved' : 'pending',
-        approvedById: shouldAutoApprove ? user.id : null,
-      },
-      include: { media: true, user: { select: { id: true, displayName: true, avatar: true } } },
+    const result = await createUserRequest({
+      userId: user.id,
+      tmdbId: body.tmdbId,
+      mediaType: body.mediaType,
+      seasons: body.seasons,
+      rootFolder: body.rootFolder,
+      qualityOptionId: body.qualityOptionId,
     });
 
-    let sendFailed = false;
-    if (shouldAutoApprove) {
-      const tagName = await getUserTagName(user.id);
-      const sent = await sendToService(media, mediaType, tagName, user.id, validSeasons, body.qualityOptionId);
-      if (sent) {
-        // Flip to 'searching' so the UI shows progress; preserve 'available' (quality-upgrade
-        // request) and 'processing' (TV partial — keep "request rest" CTA visible).
-        if (media.status !== 'available' && media.status !== 'processing') {
-          await prisma.media.update({
-            where: { id: media.id },
-            data: { status: 'searching' },
-          }).catch((err) => {
-            request.log.warn({ err, mediaId: media.id, requestId: mediaRequest.id }, 'status flip to searching failed');
-          });
-        }
-      } else {
-        await prisma.mediaRequest.update({ where: { id: mediaRequest.id }, data: { status: 'failed' } });
-        sendFailed = true;
-      }
-    }
-
-    const dbUser = await prisma.user.findUnique({ where: { id: user.id }, select: { displayName: true } });
-    const username = dbUser?.displayName || 'User';
-    const mediaUrl = await buildSiteLink(`/${mediaType}/${media.tmdbId}`);
-    safeNotify('request_new', { title: media.title, mediaType, username, posterPath: media.posterPath, tmdbId: media.tmdbId, url: mediaUrl });
-    if (shouldAutoApprove && !sendFailed) {
-      safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: 'notifications.msg.request_auto_approved', metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType, msgParams: { title: media.title } } });
-    }
-    logEvent('info', 'Request', `${username} requested "${media.title}"`);
-
-    if (sendFailed) return reply.status(202).send({ ...mediaRequest, status: 'failed', sendError: true });
-    return reply.status(201).send(mediaRequest);
+    if (!result.ok) return reply.status(result.status).send({ error: result.error });
+    if (result.sendFailed) return reply.status(202).send({ ...result.request, status: 'failed', sendError: true });
+    return reply.status(201).send(result.request);
   });
 
   app.post('/collection', {
@@ -142,7 +62,7 @@ export async function requestCreateRoutes(app: FastifyInstance) {
     }
 
     if (user.role !== 'admin') {
-      const guardResult = await runPluginGuard(user.id);
+      const guardResult = await pluginEngine.runGuards('request.create', user.id);
       if (guardResult?.blocked) return reply.status(guardResult.statusCode || 403).send({ error: guardResult.error });
     }
 

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -90,6 +90,7 @@ export async function webhookRoutes(app: FastifyInstance) {
         : await prisma.media.findFirst({ where: { mediaType: 'tv', tvdbId: event.externalId } });
 
       if (!existing) {
+        const arrIdField = serviceType === 'radarr' ? 'radarrId' : serviceType === 'sonarr' ? 'sonarrId' : null;
         await prisma.media.create({
           data: {
             tmdbId: mediaType === 'movie' ? event.externalId : -(event.externalId),
@@ -97,6 +98,13 @@ export async function webhookRoutes(app: FastifyInstance) {
             mediaType,
             title: sanitize(event.title),
             status: 'searching',
+            // Set the *arr internal id at creation time so the home's "Recently added"
+            // query (which gates on radarrId/sonarrId IS NOT NULL) picks the row up as
+            // soon as it later flips to `available`. See the matching backfill in the
+            // 'download' branch for the upgrade path on pre-existing rows.
+            ...(arrIdField && event.internalId !== undefined && event.internalId > 0
+              ? { [arrIdField]: event.internalId }
+              : {}),
           },
         });
         logEvent('info', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" added — created in Oscarr`);
@@ -154,6 +162,25 @@ export async function webhookRoutes(app: FastifyInstance) {
         );
         logEvent('info', 'Webhook', `"${sanitize(event.title)}" is now available (via ${sanitize(serviceType)} webhook)`);
         logEvent('debug', 'Webhook', `${sanitize(serviceType)}: "${sanitize(event.title)}" now available`);
+      }
+
+      // Backfill the *arr internal id when the sync job hasn't populated it (or has been
+      // disabled by the admin in favour of webhook-driven updates). Without this, the
+      // home's "Recently added" query (which filters on radarrId/sonarrId IS NOT NULL)
+      // skips webhook-only media even though they're correctly marked `available`.
+      if (event.internalId !== undefined && event.internalId > 0) {
+        const arrIdField = serviceType === 'radarr' ? 'radarrId' : serviceType === 'sonarr' ? 'sonarrId' : null;
+        if (arrIdField) {
+          const current = (media as Record<string, unknown>)[arrIdField];
+          if (current === null || current === undefined) {
+            await prisma.media.update({
+              where: { id: media.id },
+              data: { [arrIdField]: event.internalId },
+            }).catch((err) => {
+              logEvent('warn', 'Webhook', `Failed to backfill ${arrIdField}=${event.internalId} on media ${media.id}: ${String(err)}`);
+            });
+          }
+        }
       }
 
       return reply.send({ ok: true, message: 'Media updated' });

--- a/packages/backend/src/services/backupService.ts
+++ b/packages/backend/src/services/backupService.ts
@@ -6,7 +6,7 @@ import { execFileSync } from 'child_process';
 import archiver from 'archiver';
 import { prisma } from '../utils/prisma.js';
 import { logEvent } from '../utils/logEvent.js';
-import { BACKEND_ROOT, PROJECT_PACKAGE_JSON } from '../utils/paths.js';
+import { BACKEND_PRISMA_DIR, PROJECT_PACKAGE_JSON } from '../utils/paths.js';
 
 /** Backup creation + HMAC signing + file rotation. Consumed by routes and scheduler. */
 
@@ -41,8 +41,13 @@ export function safeEqualHex(a: string, b: string): boolean {
 export function getDbPath(): string {
   const url = process.env.DATABASE_URL || 'file:../data/oscarr.db';
   const relativePath = url.replace('file:', '');
-  // DATABASE_URL is Prisma-relative to packages/backend/.
-  return resolve(BACKEND_ROOT, relativePath);
+  // Prisma resolves `file:` URLs relative to the schema's directory (packages/backend/
+  // prisma/), not the package root. The default `file:../data/oscarr.db` therefore points
+  // at packages/backend/data/oscarr.db — anchoring on BACKEND_PRISMA_DIR matches Prisma
+  // exactly. Anchoring on BACKEND_ROOT (an earlier version of this code) ended up at
+  // packages/data/oscarr.db, which doesn't exist → backup job failing with
+  // "Database file not found".
+  return resolve(BACKEND_PRISMA_DIR, relativePath);
 }
 
 export function getBackupDir(): string {

--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -369,7 +369,7 @@ export async function createUserRequest(input: CreateRequestInput): Promise<Crea
   const mediaUrl = await buildSiteLink(`/${mediaType}/${media.tmdbId}`);
   safeNotify('request_new', { title: media.title, mediaType, username, posterPath: media.posterPath, tmdbId: media.tmdbId, url: mediaUrl });
   if (shouldAutoApprove && !sendFailed) {
-    safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: 'notifications.msg.request_auto_approved', metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType, msgParams: { title: media.title } } });
+    safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: 'notifications.msg.request_auto_approved', metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType, posterPath: media.posterPath, msgParams: { title: media.title } } });
   }
   logEvent('info', 'Request', `${username} requested "${media.title}"`);
 

--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -314,7 +314,13 @@ export async function createUserRequest(input: CreateRequestInput): Promise<Crea
         if (roles.length > 0 && !roles.includes(user.role)) {
           return { ok: false, status: 403, code: 'QUALITY_NOT_ALLOWED', error: 'QUALITY_NOT_ALLOWED' };
         }
-      } catch { /* malformed JSON — permissive fallback matches historical HTTP behavior */ }
+      } catch (err) {
+        // Historical HTTP behaviour was permissive here, but silently opening a role-gated
+        // quality option on corrupt `allowedRoles` JSON is an ACL-bypass footgun. Keep the
+        // permissive fallback for compat, but surface the corruption so an admin can fix
+        // the bad row instead of learning about it via unexpected approvals.
+        logEvent('error', 'Request', `Malformed allowedRoles JSON on qualityOption ${input.qualityOptionId} — permissive fallback engaged: ${String(err)}`);
+      }
     }
     if (qualityOpt?.approvalMode === 'auto') shouldAutoApprove = true;
     else if (qualityOpt?.approvalMode === 'manual') shouldAutoApprove = user.role === 'admin';
@@ -345,7 +351,13 @@ export async function createUserRequest(input: CreateRequestInput): Promise<Crea
         await prisma.media.update({
           where: { id: media.id },
           data: { status: 'searching' },
-        }).catch(() => { /* non-fatal — the request row is already created */ });
+        }).catch((err) => {
+          // The request row is already created, so this is observably non-fatal — but a
+          // silent swallow masks the "UI stuck on pending because DB update failed" class
+          // of bug (connection pool exhaustion, P2025 race with a delete, schema drift).
+          // Surface it to AppLog so the admin has a breadcrumb when support tickets come in.
+          logEvent('warn', 'Request', `Status-flip to 'searching' failed for media ${media.id} (request ${mediaRequest.id}): ${String(err)}`);
+        });
       }
     } else {
       await prisma.mediaRequest.update({ where: { id: mediaRequest.id }, data: { status: 'failed' } });

--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -6,6 +6,8 @@ import { logEvent } from '../utils/logEvent.js';
 import { getServiceById, getAllServices } from '../utils/services.js';
 import { VALID_MEDIA_TYPES } from '../utils/params.js';
 import { ACTIVE_REQUEST_STATUSES, COMPLETABLE_REQUEST_STATUSES } from '@oscarr/shared';
+import { safeNotify, safeUserNotify, buildSiteLink } from '../utils/safeNotify.js';
+import { pluginEngine } from '../plugins/engine.js';
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -230,6 +232,138 @@ export async function sendToService(
     logEvent('error', 'Request', `Failed to send "${media.title}" to ${getServiceTypeForMedia(mediaType)}: ${String(err)}`);
     return false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Create-request pipeline (shared by POST /api/requests and ctx.requests.create)
+// ---------------------------------------------------------------------------
+
+/** Tagged union describing every way a request-create attempt can fail. The HTTP layer maps
+ *  each `status` to its response code; the plugin context just exposes `{ ok, code, error }`.
+ *  Extending with a new failure mode means adding one variant + its mapping — callers stay
+ *  exhaustive via the discriminant. */
+export type CreateRequestResult =
+  | { ok: true; status: 201 | 202; request: Awaited<ReturnType<typeof prisma.mediaRequest.create>>; sendFailed?: boolean }
+  | { ok: false; status: 400; code: 'INVALID_INPUT'; error: string }
+  | { ok: false; status: 403; code: 'BLOCKED_BY_GUARD'; error: string }
+  | { ok: false; status: 403; code: 'BLACKLISTED'; error: string }
+  | { ok: false; status: 409; code: 'DUPLICATE'; error: string }
+  | { ok: false; status: 403; code: 'QUALITY_NOT_ALLOWED'; error: string };
+
+export interface CreateRequestInput {
+  userId: number;
+  tmdbId: unknown;
+  mediaType: unknown;
+  seasons?: unknown;
+  rootFolder?: string;
+  qualityOptionId?: number;
+  /** When true, the pluginGuard pass is skipped even for non-admins. Used by
+   *  `ctx.requests.create` when the plugin author explicitly wants to avoid triggering other
+   *  plugins' `request.create` guards (which could loop if the calling plugin is itself a
+   *  guard owner). Defaults to false — HTTP route always runs guards for non-admins. */
+  skipPluginGuard?: boolean;
+}
+
+/** Unified create-request pipeline: validation → pluginGuard → blacklist → findOrCreateMedia
+ *  → dedup → quality gate → row create → sendToService (if autoApproved) → status flip →
+ *  safeNotify / safeUserNotify / logEvent. Shared by the HTTP handler and the plugin context
+ *  so the two paths cannot drift. */
+export async function createUserRequest(input: CreateRequestInput): Promise<CreateRequestResult> {
+  const user = await prisma.user.findUnique({
+    where: { id: input.userId },
+    select: { id: true, role: true, displayName: true },
+  });
+  if (!user) {
+    return { ok: false, status: 400, code: 'INVALID_INPUT', error: `User ${input.userId} not found` };
+  }
+
+  const validation = validateRequestBody({ tmdbId: input.tmdbId, mediaType: input.mediaType, seasons: input.seasons });
+  if (!validation.valid) {
+    return { ok: false, status: 400, code: 'INVALID_INPUT', error: validation.error };
+  }
+  const { tmdbId, mediaType, seasons: validSeasons } = validation;
+
+  if (user.role !== 'admin' && !input.skipPluginGuard) {
+    const guardResult = await pluginEngine.runGuards('request.create', user.id);
+    if (guardResult?.blocked) {
+      return { ok: false, status: (guardResult.statusCode || 403) as 403, code: 'BLOCKED_BY_GUARD', error: guardResult.error || 'Request blocked by plugin guard' };
+    }
+  }
+
+  const bl = await isBlacklisted(tmdbId, mediaType);
+  if (bl.blacklisted) {
+    return { ok: false, status: 403, code: 'BLACKLISTED', error: bl.reason || 'This media has been blocked by an administrator.' };
+  }
+
+  const media = await findOrCreateMedia(tmdbId, mediaType);
+
+  const existing = await prisma.mediaRequest.findFirst({
+    where: { mediaId: media.id, userId: user.id, status: { in: [...ACTIVE_REQUEST_STATUSES] } },
+  });
+  if (existing) {
+    return { ok: false, status: 409, code: 'DUPLICATE', error: 'You already have an active request for this media' };
+  }
+
+  const settings = await prisma.appSettings.findUnique({ where: { id: 1 } });
+  let shouldAutoApprove = user.role === 'admin' || (settings?.autoApproveRequests ?? false);
+  if (input.qualityOptionId != null) {
+    const qualityOpt = await prisma.qualityOption.findUnique({ where: { id: input.qualityOptionId } });
+    if (qualityOpt?.allowedRoles && user.role !== 'admin') {
+      try {
+        const roles = JSON.parse(qualityOpt.allowedRoles) as string[];
+        if (roles.length > 0 && !roles.includes(user.role)) {
+          return { ok: false, status: 403, code: 'QUALITY_NOT_ALLOWED', error: 'QUALITY_NOT_ALLOWED' };
+        }
+      } catch { /* malformed JSON — permissive fallback matches historical HTTP behavior */ }
+    }
+    if (qualityOpt?.approvalMode === 'auto') shouldAutoApprove = true;
+    else if (qualityOpt?.approvalMode === 'manual') shouldAutoApprove = user.role === 'admin';
+  }
+
+  const mediaRequest = await prisma.mediaRequest.create({
+    data: {
+      mediaId: media.id,
+      userId: user.id,
+      mediaType,
+      seasons: validSeasons ? JSON.stringify(validSeasons) : null,
+      rootFolder: typeof input.rootFolder === 'string' ? input.rootFolder : null,
+      qualityOptionId: input.qualityOptionId ?? null,
+      status: shouldAutoApprove ? 'approved' : 'pending',
+      approvedById: shouldAutoApprove ? user.id : null,
+    },
+    include: { media: true, user: { select: { id: true, displayName: true, avatar: true } } },
+  });
+
+  let sendFailed = false;
+  if (shouldAutoApprove) {
+    const tagName = await getUserTagName(user.id);
+    const sent = await sendToService(media, mediaType, tagName, user.id, validSeasons, input.qualityOptionId);
+    if (sent) {
+      // Flip to 'searching' so the UI shows progress; preserve 'available' (quality-upgrade
+      // request) and 'processing' (TV partial — keep "request rest" CTA visible).
+      if (media.status !== 'available' && media.status !== 'processing') {
+        await prisma.media.update({
+          where: { id: media.id },
+          data: { status: 'searching' },
+        }).catch(() => { /* non-fatal — the request row is already created */ });
+      }
+    } else {
+      await prisma.mediaRequest.update({ where: { id: mediaRequest.id }, data: { status: 'failed' } });
+      sendFailed = true;
+    }
+  }
+
+  const username = user.displayName || 'User';
+  const mediaUrl = await buildSiteLink(`/${mediaType}/${media.tmdbId}`);
+  safeNotify('request_new', { title: media.title, mediaType, username, posterPath: media.posterPath, tmdbId: media.tmdbId, url: mediaUrl });
+  if (shouldAutoApprove && !sendFailed) {
+    safeUserNotify(user.id, { type: 'request_approved', title: media.title, message: 'notifications.msg.request_auto_approved', metadata: { mediaId: media.id, tmdbId: media.tmdbId, mediaType, msgParams: { title: media.title } } });
+  }
+  logEvent('info', 'Request', `${username} requested "${media.title}"`);
+
+  return sendFailed
+    ? { ok: true, status: 202, request: mediaRequest, sendFailed: true }
+    : { ok: true, status: 201, request: mediaRequest };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/backend/src/services/sync/helpers.ts
+++ b/packages/backend/src/services/sync/helpers.ts
@@ -1,7 +1,9 @@
 import { prisma } from '../../utils/prisma.js';
 import { safeNotify, safeUserNotify } from '../../utils/safeNotify.js';
 import { COMPLETABLE_REQUEST_STATUSES } from '@oscarr/shared';
+import type { PluginMediaAvailableV1 } from '@oscarr/shared';
 import { sendPushToUsers } from '../pushService.js';
+import { pluginEventBus } from '../../plugins/eventBus.js';
 
 export interface SyncResult {
   added: number;
@@ -29,6 +31,20 @@ export function sendAvailabilityNotifications(
 
     // External broadcast (Discord / Telegram / Email configured by admins)
     safeNotify('media_available', { title, mediaType, posterPath });
+
+    // Plugin event bus — broadcast form for plugins that want to push to a channel
+    // (e.g. "new drop!" Discord post). Per-user equivalent is already fired by
+    // safeUserNotify below via user.notification.created.
+    const event: PluginMediaAvailableV1 = {
+      v: 1,
+      mediaId,
+      tmdbId,
+      mediaType,
+      title,
+      posterPath,
+      requesterUserIds: [...new Set(requests.map(r => r.userId))],
+    };
+    pluginEventBus.emit('media.available', event).catch(err => console.error('[PluginEvent media.available] Failed:', err));
 
     // In-app bell — one per requester
     for (const req of requests) {

--- a/packages/backend/src/services/sync/helpers.ts
+++ b/packages/backend/src/services/sync/helpers.ts
@@ -4,6 +4,7 @@ import { COMPLETABLE_REQUEST_STATUSES } from '@oscarr/shared';
 import type { PluginMediaAvailableV1 } from '@oscarr/shared';
 import { sendPushToUsers } from '../pushService.js';
 import { pluginEventBus } from '../../plugins/eventBus.js';
+import { logEvent } from '../../utils/logEvent.js';
 
 export interface SyncResult {
   added: number;
@@ -44,7 +45,9 @@ export function sendAvailabilityNotifications(
       posterPath,
       requesterUserIds: [...new Set(requests.map(r => r.userId))],
     };
-    pluginEventBus.emit('media.available', event).catch(err => console.error('[PluginEvent media.available] Failed:', err));
+    pluginEventBus.emit('media.available', event).catch(err => {
+      logEvent('error', 'PluginEvent', `Subscriber of 'media.available' threw: ${String(err)}`);
+    });
 
     // In-app bell — one per requester
     for (const req of requests) {

--- a/packages/backend/src/services/sync/helpers.ts
+++ b/packages/backend/src/services/sync/helpers.ts
@@ -49,18 +49,25 @@ export function sendAvailabilityNotifications(
       logEvent('error', 'PluginEvent', `Subscriber of 'media.available' threw: ${String(err)}`);
     });
 
-    // In-app bell — one per requester
-    for (const req of requests) {
-      safeUserNotify(req.userId, {
+    // In-app bell + plugin event bus — one per **distinct** requester. A user with
+    // multiple matching requests on the same media (collection + standalone, re-request
+    // after a 'failed', etc.) was getting N copies of the same DM/notification because
+    // the loop iterated every row instead of deduping. Web push already handled this
+    // correctly below; bell now does too.
+    const userIds = [...new Set(requests.map(r => r.userId))];
+    for (const userId of userIds) {
+      safeUserNotify(userId, {
         type: 'media_available',
         title,
         message: 'notifications.msg.media_available',
-        metadata: { mediaId, tmdbId, mediaType, msgParams: { title } },
+        // posterPath here is forwarded into PluginUserNotificationCreatedV1.metadata so
+        // plugin subscribers (Leonarr Discord embed, etc.) can build a rich card without
+        // a second TMDB round-trip.
+        metadata: { mediaId, tmdbId, mediaType, posterPath, msgParams: { title } },
       });
     }
 
-    // Web push — deduped per user
-    const userIds = [...new Set(requests.map(r => r.userId))];
+    // Web push — already deduped per user via the same Set.
     const icon = posterPath ? `https://image.tmdb.org/t/p/w200${posterPath}` : undefined;
     // Fall back to /requests when the media has no real TMDB id yet
     // (e.g. webhook-imported TV series stored with negative tmdbId).

--- a/packages/backend/src/utils/dataPath.ts
+++ b/packages/backend/src/utils/dataPath.ts
@@ -1,12 +1,14 @@
 import { resolve, dirname } from 'path';
 import { mkdir } from 'fs/promises';
-import { BACKEND_ROOT } from './paths.js';
+import { BACKEND_PRISMA_DIR } from './paths.js';
 
 function getDbPath(): string {
   const url = process.env.DATABASE_URL || 'file:../data/oscarr.db';
   const relativePath = url.replace('file:', '');
-  // DATABASE_URL is Prisma-relative to packages/backend/ (the schema lives there).
-  return resolve(BACKEND_ROOT, relativePath);
+  // Prisma resolves `file:` URLs relative to the schema's directory (where schema.prisma
+  // lives), not the package root. The default `file:../data/oscarr.db` therefore lands at
+  // packages/backend/data/oscarr.db — anchoring on BACKEND_PRISMA_DIR matches that exactly.
+  return resolve(BACKEND_PRISMA_DIR, relativePath);
 }
 
 export function getDataRoot(): string {

--- a/packages/backend/src/utils/paths.ts
+++ b/packages/backend/src/utils/paths.ts
@@ -21,4 +21,8 @@ export const PROJECT_ROOT = resolve(BACKEND_ROOT, '../..');
 export const PROJECT_PACKAGE_JSON = resolve(PROJECT_ROOT, 'package.json');
 export const PROJECT_ENV_FILE = resolve(PROJECT_ROOT, '.env');
 export const FRONTEND_DIST = resolve(PROJECT_ROOT, 'packages/frontend/dist');
-export const PLUGINS_DIR = resolve(PROJECT_ROOT, 'plugins');
+// packages/plugins sits next to packages/{backend,frontend,shared} — one directory per
+// plugin (symlinks in dev, real folders when hot-installed by the engine). Kept here rather
+// than at PROJECT_ROOT/plugins to match the monorepo layout and the existing `.gitignore`
+// ignore rule developers already have in place.
+export const PLUGINS_DIR = resolve(BACKEND_ROOT, '../plugins');

--- a/packages/backend/src/utils/safeNotify.ts
+++ b/packages/backend/src/utils/safeNotify.ts
@@ -7,6 +7,8 @@ import type { PluginUserNotificationCreatedV1 } from '@oscarr/shared';
 
 let _siteUrl: string | null = null;
 let _siteUrlFetched = false;
+let _instanceLang: string | null = null;
+let _instanceLangFetched = false;
 
 /** Get the configured site URL (cached) */
 export async function getSiteUrl(): Promise<string | null> {
@@ -17,14 +19,72 @@ export async function getSiteUrl(): Promise<string | null> {
   return _siteUrl;
 }
 
-/** Invalidate cached site URL (call after settings update) */
-export function invalidateSiteUrl(): void { _siteUrlFetched = false; }
+/** Invalidate cached site URL + instance language (call after settings update) */
+export function invalidateSiteUrl(): void {
+  _siteUrlFetched = false;
+  _instanceLangFetched = false;
+}
 
 /** Build a full URL from a path (e.g. /movie/123) */
 export async function buildSiteLink(path: string): Promise<string | undefined> {
   const base = await getSiteUrl();
   if (!base) return undefined;
   return `${base.replace(/\/$/, '')}${path}`;
+}
+
+/** Resolve the first language in AppSettings.instanceLanguages, with the same caching
+ *  posture as siteUrl. Plugins (Leonarr DM bot, Slack pushers, …) consume the translated
+ *  text via the event bus — picking the language at emit time means we resolve once per
+ *  outbound event instead of once per subscriber. */
+async function getInstanceLanguage(): Promise<string> {
+  if (_instanceLangFetched && _instanceLang) return _instanceLang;
+  try {
+    const settings = await prisma.appSettings.findUnique({ where: { id: 1 }, select: { instanceLanguages: true } });
+    const arr = settings?.instanceLanguages ? JSON.parse(settings.instanceLanguages) as unknown : null;
+    _instanceLang = Array.isArray(arr) && typeof arr[0] === 'string' ? arr[0] : 'en';
+  } catch {
+    _instanceLang = 'en';
+  }
+  _instanceLangFetched = true;
+  return _instanceLang;
+}
+
+// ─── Notification i18n ──────────────────────────────────────────────
+//
+// Mirror of the `notifications.msg.*` + `notifications.title.*` keys from the frontend
+// translation bundles, vendored here so the backend can pre-translate the event-bus payload
+// without depending on the frontend at runtime. Keep this in sync with
+// packages/frontend/src/i18n/locales/<lang>/translation.json — five-ish keys, manual sync
+// is fine, and a typo would only fall back to the raw key.
+const NOTIF_I18N: Record<string, Record<string, string>> = {
+  en: {
+    'notifications.msg.request_auto_approved': 'Your request for "{{title}}" has been auto-approved.',
+    'notifications.msg.request_approved':      'Your request for "{{title}}" has been approved.',
+    'notifications.msg.request_declined':      'Your request for "{{title}}" has been declined.',
+    'notifications.msg.media_available':       '"{{title}}" is now available.',
+    'notifications.msg.support_reply':         'Reply on your ticket #{{ticketId}}',
+  },
+  fr: {
+    'notifications.msg.request_auto_approved': 'Votre demande pour "{{title}}" a été approuvée automatiquement.',
+    'notifications.msg.request_approved':      'Votre demande pour "{{title}}" a été approuvée.',
+    'notifications.msg.request_declined':      'Votre demande pour "{{title}}" a été refusée.',
+    'notifications.msg.media_available':       '"{{title}}" est maintenant disponible.',
+    'notifications.msg.support_reply':         'Réponse sur votre ticket #{{ticketId}}',
+  },
+};
+
+function translateNotif(value: string, lang: string, params: Record<string, unknown>): string {
+  // Only translate strings that look like our canonical i18n keys; everything else is
+  // already a literal title (e.g. a media title from the request flow) and should pass
+  // through untouched.
+  if (!value.startsWith('notifications.')) return value;
+  const bundle = NOTIF_I18N[lang] ?? NOTIF_I18N.en;
+  const fallback = NOTIF_I18N.en;
+  const template = bundle[value] ?? fallback[value];
+  if (!template) return value; // unknown key — keep as-is so a typo is visible
+  return template.replace(/\{\{(\w+)\}\}/g, (_, k: string) => (
+    params[k] !== undefined ? String(params[k]) : `{{${k}}}`
+  ));
 }
 
 /** Fire-and-forget notification — logs errors without crashing */
@@ -35,23 +95,37 @@ export function safeNotify(type: string, data: Parameters<typeof notificationReg
 /** Fire-and-forget user notification — logs errors without crashing. Also fans out a
  *  `user.notification.created` event on the plugin bus so subscribers (Discord bots, Slack
  *  pushers, analytics) can react without having to poll the UserNotification table. The
- *  payload is the stable v1 envelope defined in `@oscarr/shared`. */
+ *  payload is the stable v1 envelope defined in `@oscarr/shared`.
+ *
+ *  Translation: the row stored in DB carries the raw i18n key (so the web frontend can
+ *  re-translate on render with the user's current locale), but the *event* fires a
+ *  pre-translated `titleText` / `messageText` resolved against the instance language —
+ *  plugins typically don't have access to the i18n bundle and shouldn't re-implement
+ *  lookup. Fall back to the raw value when the key isn't in the table. */
 export function safeUserNotify(userId: number, payload: Parameters<typeof _sendUserNotification>[1]): void {
   _sendUserNotification(userId, payload).catch(err => console.error('[UserNotification] Failed:', err));
-  const event: PluginUserNotificationCreatedV1 = {
-    v: 1,
-    userId,
-    type: payload.type,
-    title: payload.title,
-    message: payload.message,
-    metadata: payload.metadata ?? {},
-    createdAt: new Date().toISOString(),
-  };
-  // Event bus emit is sync-returning but handler resolution is awaited inside emit; fire and
-  // swallow so one misbehaving subscriber doesn't block the caller. Route failures to AppLog
-  // (not console.error) — plugins are this code path's consumers, and admins need a
-  // persisted breadcrumb when a subscriber throws.
-  pluginEventBus.emit('user.notification.created', event).catch(err => {
+
+  // Resolve the language + interpolate keys before emitting. Async, but we're already in a
+  // fire-and-forget surface — chaining `.then` keeps the caller signature unchanged.
+  getInstanceLanguage().then((lang) => {
+    const params = ((payload.metadata as { msgParams?: Record<string, unknown> } | undefined)?.msgParams) ?? {};
+    const event: PluginUserNotificationCreatedV1 = {
+      v: 1,
+      userId,
+      type: payload.type,
+      title: payload.title,
+      titleText: translateNotif(payload.title, lang, params),
+      message: payload.message,
+      messageText: translateNotif(payload.message, lang, params),
+      metadata: payload.metadata ?? {},
+      createdAt: new Date().toISOString(),
+    };
+    // Event bus emit is sync-returning but handler resolution is awaited inside emit; fire and
+    // swallow so one misbehaving subscriber doesn't block the caller. Route failures to AppLog
+    // (not console.error) — plugins are this code path's consumers, and admins need a
+    // persisted breadcrumb when a subscriber throws.
+    return pluginEventBus.emit('user.notification.created', event);
+  }).catch(err => {
     logEvent('error', 'PluginEvent', `Subscriber of 'user.notification.created' threw: ${String(err)}`);
   });
 }

--- a/packages/backend/src/utils/safeNotify.ts
+++ b/packages/backend/src/utils/safeNotify.ts
@@ -1,6 +1,8 @@
 import { notificationRegistry } from '../notifications/index.js';
 import { sendUserNotification as _sendUserNotification } from '../services/userNotifications.js';
 import { prisma } from './prisma.js';
+import { pluginEventBus } from '../plugins/eventBus.js';
+import type { PluginUserNotificationCreatedV1 } from '@oscarr/shared';
 
 let _siteUrl: string | null = null;
 let _siteUrlFetched = false;
@@ -29,7 +31,22 @@ export function safeNotify(type: string, data: Parameters<typeof notificationReg
   notificationRegistry.send(type, data).catch(err => console.error('[Notification] Failed:', err));
 }
 
-/** Fire-and-forget user notification — logs errors without crashing */
+/** Fire-and-forget user notification — logs errors without crashing. Also fans out a
+ *  `user.notification.created` event on the plugin bus so subscribers (Discord bots, Slack
+ *  pushers, analytics) can react without having to poll the UserNotification table. The
+ *  payload is the stable v1 envelope defined in `@oscarr/shared`. */
 export function safeUserNotify(userId: number, payload: Parameters<typeof _sendUserNotification>[1]): void {
   _sendUserNotification(userId, payload).catch(err => console.error('[UserNotification] Failed:', err));
+  const event: PluginUserNotificationCreatedV1 = {
+    v: 1,
+    userId,
+    type: payload.type,
+    title: payload.title,
+    message: payload.message,
+    metadata: payload.metadata ?? {},
+    createdAt: new Date().toISOString(),
+  };
+  // Event bus emit is sync-returning but handler resolution is awaited inside emit; fire and
+  // swallow so one misbehaving subscriber doesn't block the caller.
+  pluginEventBus.emit('user.notification.created', event).catch(err => console.error('[PluginEvent user.notification.created] Failed:', err));
 }

--- a/packages/backend/src/utils/safeNotify.ts
+++ b/packages/backend/src/utils/safeNotify.ts
@@ -2,6 +2,7 @@ import { notificationRegistry } from '../notifications/index.js';
 import { sendUserNotification as _sendUserNotification } from '../services/userNotifications.js';
 import { prisma } from './prisma.js';
 import { pluginEventBus } from '../plugins/eventBus.js';
+import { logEvent } from './logEvent.js';
 import type { PluginUserNotificationCreatedV1 } from '@oscarr/shared';
 
 let _siteUrl: string | null = null;
@@ -47,6 +48,10 @@ export function safeUserNotify(userId: number, payload: Parameters<typeof _sendU
     createdAt: new Date().toISOString(),
   };
   // Event bus emit is sync-returning but handler resolution is awaited inside emit; fire and
-  // swallow so one misbehaving subscriber doesn't block the caller.
-  pluginEventBus.emit('user.notification.created', event).catch(err => console.error('[PluginEvent user.notification.created] Failed:', err));
+  // swallow so one misbehaving subscriber doesn't block the caller. Route failures to AppLog
+  // (not console.error) — plugins are this code path's consumers, and admins need a
+  // persisted breadcrumb when a subscriber throws.
+  pluginEventBus.emit('user.notification.created', event).catch(err => {
+    logEvent('error', 'PluginEvent', `Subscriber of 'user.notification.created' threw: ${String(err)}`);
+  });
 }

--- a/packages/backend/src/utils/safeNotify.ts
+++ b/packages/backend/src/utils/safeNotify.ts
@@ -3,7 +3,8 @@ import { sendUserNotification as _sendUserNotification } from '../services/userN
 import { prisma } from './prisma.js';
 import { pluginEventBus } from '../plugins/eventBus.js';
 import { logEvent } from './logEvent.js';
-import type { PluginUserNotificationCreatedV1 } from '@oscarr/shared';
+import type { PluginUserNotificationCreatedV1, NotificationLocale } from '@oscarr/shared';
+import { renderNotificationTemplate } from '@oscarr/shared';
 
 let _siteUrl: string | null = null;
 let _siteUrlFetched = false;
@@ -49,42 +50,14 @@ async function getInstanceLanguage(): Promise<string> {
   return _instanceLang;
 }
 
-// ─── Notification i18n ──────────────────────────────────────────────
-//
-// Mirror of the `notifications.msg.*` + `notifications.title.*` keys from the frontend
-// translation bundles, vendored here so the backend can pre-translate the event-bus payload
-// without depending on the frontend at runtime. Keep this in sync with
-// packages/frontend/src/i18n/locales/<lang>/translation.json — five-ish keys, manual sync
-// is fine, and a typo would only fall back to the raw key.
-const NOTIF_I18N: Record<string, Record<string, string>> = {
-  en: {
-    'notifications.msg.request_auto_approved': 'Your request for "{{title}}" has been auto-approved.',
-    'notifications.msg.request_approved':      'Your request for "{{title}}" has been approved.',
-    'notifications.msg.request_declined':      'Your request for "{{title}}" has been declined.',
-    'notifications.msg.media_available':       '"{{title}}" is now available.',
-    'notifications.msg.support_reply':         'Reply on your ticket #{{ticketId}}',
-  },
-  fr: {
-    'notifications.msg.request_auto_approved': 'Votre demande pour "{{title}}" a été approuvée automatiquement.',
-    'notifications.msg.request_approved':      'Votre demande pour "{{title}}" a été approuvée.',
-    'notifications.msg.request_declined':      'Votre demande pour "{{title}}" a été refusée.',
-    'notifications.msg.media_available':       '"{{title}}" est maintenant disponible.',
-    'notifications.msg.support_reply':         'Réponse sur votre ticket #{{ticketId}}',
-  },
-};
-
+/** Translate a notification title/message field. Pass-through for literal strings (a raw
+ *  media title, etc.); only `notifications.*` keys go through the @oscarr/shared template
+ *  table that the frontend NotificationBell renders against — single source of truth, no
+ *  drift between backend pre-translation and frontend per-user-language render. */
 function translateNotif(value: string, lang: string, params: Record<string, unknown>): string {
-  // Only translate strings that look like our canonical i18n keys; everything else is
-  // already a literal title (e.g. a media title from the request flow) and should pass
-  // through untouched.
   if (!value.startsWith('notifications.')) return value;
-  const bundle = NOTIF_I18N[lang] ?? NOTIF_I18N.en;
-  const fallback = NOTIF_I18N.en;
-  const template = bundle[value] ?? fallback[value];
-  if (!template) return value; // unknown key — keep as-is so a typo is visible
-  return template.replace(/\{\{(\w+)\}\}/g, (_, k: string) => (
-    params[k] !== undefined ? String(params[k]) : `{{${k}}}`
-  ));
+  const locale: NotificationLocale = lang === 'fr' ? 'fr' : 'en';
+  return renderNotificationTemplate(value, locale, params);
 }
 
 /** Fire-and-forget notification — logs errors without crashing */

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/frontend",
-  "version": "0.6.3",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/src/components/layouts/AdminLayout.tsx
+++ b/packages/frontend/src/components/layouts/AdminLayout.tsx
@@ -306,7 +306,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     <>
       {ADMIN_GROUPS.map(renderGroupButton)}
       {pluginTabItems.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-white/5">
+        <div className="!mt-3 pt-3 border-t border-white/5">
           <p className="text-[10px] text-ndp-text-dim uppercase tracking-wider px-3 mb-3 font-semibold">
             {pluginGroupLabel}
           </p>

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -12,23 +12,25 @@ import { startPlexPinFlow, type PlexPinFlowHandle } from '@/providers/plex/pinFl
 /** Validates a `?next=` query param. Returns the safe destination, or `null` if the value
  *  is missing, malformed, or points to a foreign origin (open-redirect protection).
  *
- *  Accepted shapes:
- *    - relative path  : `/foo`, `/api/bar?baz=1` (must start with a single `/`)
- *    - absolute URL   : matching `window.location.origin` exactly
- *
- *  Rejected shapes:
- *    - protocol-relative URLs (`//evil.com/…`) — would let an attacker phish
- *    - absolute URLs to other origins
- *    - anything that doesn't parse as a URL */
+ *  Implementation: parse every input through `new URL(raw, window.location.origin)` and
+ *  reject anything whose computed origin doesn't match. This catches the obvious foreign
+ *  hosts AND the WHATWG-normalised tricks browsers do behind the scenes:
+ *    - `//evil.com/…`     → URL parses to `http://evil.com/` → reject
+ *    - `/\evil.com`       → backslashes normalise to `/`, parses to `http://evil.com/` → reject
+ *    - `/\t//evil.com`    → tab/control-char tricks fall through the same way
+ *    - `data:` / `javascript:` URIs → wrong origin → reject
+ *  Relying on the URL parser instead of hand-rolled `startsWith` checks keeps us in lockstep
+ *  with the browser's own resolution, so anything `window.location.assign` would interpret
+ *  as foreign is what we reject. */
 function resolveSafeNext(raw: string | null): string | null {
   if (!raw) return null;
-  if (raw.startsWith('//')) return null;
-  if (raw.startsWith('/')) return raw;
   try {
-    const u = new URL(raw);
-    if (u.origin === window.location.origin) return u.pathname + u.search + u.hash;
-  } catch { /* fall through */ }
-  return null;
+    const u = new URL(raw, window.location.origin);
+    if (u.origin !== window.location.origin) return null;
+    return u.pathname + u.search + u.hash;
+  } catch {
+    return null;
+  }
 }
 
 export default function LoginPage() {
@@ -85,7 +87,7 @@ export default function LoginPage() {
     if (dest) {
       window.location.assign(dest);
     } else {
-      redirectAfterLogin();
+      navigate('/', { replace: true });
     }
   };
 

--- a/packages/frontend/src/pages/LoginPage.tsx
+++ b/packages/frontend/src/pages/LoginPage.tsx
@@ -9,6 +9,28 @@ import type { AuthProviderConfig } from '@/types';
 import { getProviderButtonClass } from '@/providers/colors';
 import { startPlexPinFlow, type PlexPinFlowHandle } from '@/providers/plex/pinFlow';
 
+/** Validates a `?next=` query param. Returns the safe destination, or `null` if the value
+ *  is missing, malformed, or points to a foreign origin (open-redirect protection).
+ *
+ *  Accepted shapes:
+ *    - relative path  : `/foo`, `/api/bar?baz=1` (must start with a single `/`)
+ *    - absolute URL   : matching `window.location.origin` exactly
+ *
+ *  Rejected shapes:
+ *    - protocol-relative URLs (`//evil.com/…`) — would let an attacker phish
+ *    - absolute URLs to other origins
+ *    - anything that doesn't parse as a URL */
+function resolveSafeNext(raw: string | null): string | null {
+  if (!raw) return null;
+  if (raw.startsWith('//')) return null;
+  if (raw.startsWith('/')) return raw;
+  try {
+    const u = new URL(raw);
+    if (u.origin === window.location.origin) return u.pathname + u.search + u.hash;
+  } catch { /* fall through */ }
+  return null;
+}
+
 export default function LoginPage() {
   const { t } = useTranslation();
   const { login, user } = useAuth();
@@ -46,9 +68,31 @@ export default function LoginPage() {
     setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams, t]);
 
+  /** `?next=` post-login redirect — supports plug-and-play link flows (e.g. a Discord bot
+   *  plugin's "Link your account" button bouncing through `/api/auth/discord/authorize?action=link`
+   *  → 302 to /login?next=<that URL> → user logs in → we send them back to the original URL).
+   *
+   *  Same-origin guard: only relative paths (or full URLs matching window.location.origin)
+   *  are honoured. Protocol-relative `//evil.com` and absolute foreign URLs are dropped to
+   *  prevent open-redirect phishing.
+   *
+   *  We use `window.location.assign` instead of react-router `navigate` because `next` may
+   *  point at a backend route (`/api/auth/discord/authorize`) that the SPA router can't
+   *  resolve — a full browser navigation is the right thing here.
+   */
+  const redirectAfterLogin = () => {
+    const dest = resolveSafeNext(searchParams.get('next'));
+    if (dest) {
+      window.location.assign(dest);
+    } else {
+      redirectAfterLogin();
+    }
+  };
+
   useEffect(() => {
-    if (user) navigate('/', { replace: true });
-  }, [user, navigate]);
+    if (user) redirectAfterLogin();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
 
   const hasEmailProvider = providers.some((p) => p.id === 'email');
   const oauthProviders = providers.filter((p) => p.type === 'oauth');
@@ -72,7 +116,7 @@ export default function LoginPage() {
     try {
       const { data } = await api.post(`/auth/${providerId}/login`, { username: credUsername, password: credPassword });
       await login('', data.user);
-      navigate('/', { replace: true });
+      redirectAfterLogin();
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       setError(translateAuthError(msg));
@@ -88,7 +132,7 @@ export default function LoginPage() {
     try {
       const { data } = await api.post('/auth/login', { email, password });
       await login('', data.user);
-      navigate('/', { replace: true });
+      redirectAfterLogin();
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       setError(translateAuthError(msg));
@@ -108,7 +152,7 @@ export default function LoginPage() {
     try {
       const { data } = await api.post('/auth/register', { email, password, displayName });
       await login('', data.user);
-      navigate('/', { replace: true });
+      redirectAfterLogin();
     } catch (err: unknown) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
       setError(translateAuthError(msg));
@@ -147,7 +191,7 @@ export default function LoginPage() {
           try {
             const { data } = await api.get('/auth/me');
             login('', data);
-            navigate('/', { replace: true });
+            redirectAfterLogin();
           } catch {
             setError(t('login.error'));
           } finally {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/shared",
-  "version": "0.6.3",
+  "version": "0.7.0-dev",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from './requestStatus.js';
 export * from './tmdb.js';
 export * from './plugins.js';
 export * from './pluginContext.js';
+export * from './notificationTemplates.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './requestStatus.js';
 export * from './tmdb.js';
 export * from './plugins.js';
+export * from './pluginContext.js';

--- a/packages/shared/src/notificationTemplates.ts
+++ b/packages/shared/src/notificationTemplates.ts
@@ -1,0 +1,56 @@
+/** Single source of truth for `notifications.msg.*` localized templates.
+ *
+ *  Two consumers:
+ *    - Backend `safeUserNotify` pre-translates the event-bus payload at emit time so plugin
+ *      subscribers (Leonarr Discord embed, Slack pushers, …) get readable text instead of
+ *      raw i18n keys.
+ *    - Frontend NotificationBell re-translates per-user-language at render time.
+ *
+ *  Keeping both consumers on the same import means a new notification key (or a copy tweak
+ *  in an existing one) lands once and propagates everywhere — no risk of the backend
+ *  shipping a key the frontend doesn't know about, or vice versa. Frontend's i18next bundle
+ *  doesn't import this directly today (it copies into `translation.json` as part of the
+ *  build) — adding a CI check that `translation.json[key] === NOTIFICATION_TEMPLATES[lang][key]`
+ *  is the next step if the locales diverge in practice.
+ *
+ *  Add a key here when you add a new `notifications.msg.*` payload type. Templates use the
+ *  `{{var}}` interpolation convention — same syntax as i18next + the backend's
+ *  `translateNotif` helper, so they're substitutable. */
+
+export type NotificationLocale = 'en' | 'fr';
+
+/** Each value is a Mustache-style template. `{{var}}` placeholders are filled from the
+ *  caller's `metadata.msgParams` — see backend safeUserNotify and frontend NotificationBell
+ *  for the rendering side. */
+export const NOTIFICATION_TEMPLATES: Record<NotificationLocale, Record<string, string>> = {
+  en: {
+    'notifications.msg.request_auto_approved': 'Your request for "{{title}}" has been auto-approved.',
+    'notifications.msg.request_approved':      'Your request for "{{title}}" has been approved.',
+    'notifications.msg.request_declined':      'Your request for "{{title}}" has been declined.',
+    'notifications.msg.media_available':       '"{{title}}" is now available.',
+    'notifications.msg.support_reply':         'Reply on your ticket #{{ticketId}}',
+  },
+  fr: {
+    'notifications.msg.request_auto_approved': 'Votre demande pour "{{title}}" a été approuvée automatiquement.',
+    'notifications.msg.request_approved':      'Votre demande pour "{{title}}" a été approuvée.',
+    'notifications.msg.request_declined':      'Votre demande pour "{{title}}" a été refusée.',
+    'notifications.msg.media_available':       '"{{title}}" est maintenant disponible.',
+    'notifications.msg.support_reply':         'Réponse sur votre ticket #{{ticketId}}',
+  },
+};
+
+/** Render a template against `params`. Returns the raw key when the lookup fails so a typo
+ *  or missing locale stays visible (vs. silently falling back to an empty string). */
+export function renderNotificationTemplate(
+  key: string,
+  locale: NotificationLocale,
+  params: Record<string, unknown> = {},
+): string {
+  const bundle = NOTIFICATION_TEMPLATES[locale] ?? NOTIFICATION_TEMPLATES.en;
+  const fallback = NOTIFICATION_TEMPLATES.en;
+  const template = bundle[key] ?? fallback[key];
+  if (!template) return key;
+  return template.replace(/\{\{(\w+)\}\}/g, (_, k: string) => (
+    params[k] !== undefined ? String(params[k]) : `{{${k}}}`
+  ));
+}

--- a/packages/shared/src/pluginContext.ts
+++ b/packages/shared/src/pluginContext.ts
@@ -89,7 +89,14 @@ export interface PluginFolderRule {
 // ─── Event bus payloads ─────────────────────────────────────────────
 
 /** Versioned envelope: plugins subscribe to a stable `v: 1` contract. Future payload changes
- *  emit alongside `v: 2` etc. — no silent breakage. */
+ *  emit alongside `v: 2` etc. — no silent breakage.
+ *
+ *  **Metadata contract (important):** `metadata` is forwarded verbatim from whatever the
+ *  caller of `safeUserNotify` passed in — it reaches every plugin subscribed to the event,
+ *  regardless of that plugin's `users:read` / `requests:read` capabilities. Core callers must
+ *  treat metadata as plugin-visible: no PII, no secrets, no raw error objects. Current core
+ *  payloads (`{ mediaId, tmdbId, mediaType, msgParams }`) are safe; keep future additions on
+ *  the same side of the line. */
 export interface PluginUserNotificationCreatedV1 {
   v: 1;
   userId: number;
@@ -103,7 +110,11 @@ export interface PluginUserNotificationCreatedV1 {
 /** Emitted when a piece of media becomes available in the library (post-sync confirm). The
  *  `requesterUserIds` list enumerates every user whose request was fulfilled by this event,
  *  so broadcast-style plugins can translate one "media available" fact into N per-user
- *  side-effects without extra DB queries. */
+ *  side-effects without extra DB queries.
+ *
+ *  **Privacy:** subscribers receive raw user IDs regardless of their capability declarations.
+ *  Treat them as confidential — don't log them to external systems or expose them through
+ *  plugin APIs without explicit admin opt-in. */
 export interface PluginMediaAvailableV1 {
   v: 1;
   mediaId: number;

--- a/packages/shared/src/pluginContext.ts
+++ b/packages/shared/src/pluginContext.ts
@@ -1,0 +1,115 @@
+/** Typed projections exposed to plugins via `PluginContext`. Kept in `@oscarr/shared` so
+ *  plugin authors can import them from `@oscarr/shared` (same package the backend re-exports)
+ *  and stay type-safe without poking into `packages/backend/src/...` internals.
+ *
+ *  Design rule: these are **projections**, not pass-throughs of Prisma models. We expose
+ *  exactly what a plugin should see, never the raw DB shape. Adds to the projection are
+ *  backwards-compatible; removals are breaking changes. Treat this file as a contract. */
+
+import type { TmdbMedia } from './tmdb.js';
+
+// ─── Media / Requests projections ───────────────────────────────────
+
+/** Subset of the `Media` Prisma model exposed to plugins. No internal fields (serviceIds,
+ *  availableAt timestamps, sync-state flags, etc.) — plugins get what they need to identify
+ *  and display a piece of media, nothing more. */
+export interface PluginMedia {
+  id: number;
+  tmdbId: number;
+  tvdbId: number | null;
+  mediaType: 'movie' | 'tv';
+  title: string;
+  /** Poster path as stored (relative TMDB path — plugins can build full URLs themselves). */
+  posterPath: string | null;
+  /** Oscarr-side status, normalised: pending | searching | processing | available. */
+  status: string;
+}
+
+/** Subset of `MediaRequest` + its Media relation, exposed to plugins. Omits approvedById,
+ *  rootFolder, qualityOptionId, updatedAt and other internal scheduling/audit fields. */
+export interface PluginMediaRequest {
+  id: number;
+  userId: number;
+  mediaType: 'movie' | 'tv';
+  seasons: number[] | null;
+  status: string;
+  createdAt: string;
+  media: PluginMedia;
+}
+
+/** Key format used by `ctx.media.batchStatus`: `${mediaType}:${tmdbId}`. Plugins can build it
+ *  themselves without re-specifying the separator. */
+export type PluginMediaBatchKey = `${'movie' | 'tv'}:${number}`;
+
+export interface PluginMediaBatchStatus {
+  /** Canonical Oscarr media status (matches `PluginMedia.status`). */
+  status: string;
+  /** The requesting user's current request status for this media, if any. Null when the user
+   *  hasn't requested it (used by `ctx.media.batchStatus` only when a userId is passed). */
+  userRequestStatus: string | null;
+  /** Shortcut: whether the user currently has an open / in-progress request (pending,
+   *  approved, searching, processing). Lets plugins do a simple boolean check instead of
+   *  matching against `ACTIVE_REQUEST_STATUSES`. */
+  userHasActiveRequest: boolean;
+}
+
+// ─── TMDB helpers ───────────────────────────────────────────────────
+
+/** A single row from `ctx.tmdb.search(query)`. TMDB's /search/multi returns a mix of
+ *  movie / tv / person rows with heterogeneous fields; keeping it loose as `TmdbMedia` + the
+ *  discriminator lets callers filter client-side without us pretending the shape is uniform. */
+export type PluginTmdbSearchResult = TmdbMedia;
+
+/** Paginated response shape wrapping `PluginTmdbSearchResult[]`. Matches TMDB's native
+ *  envelope for `/search/multi`. */
+export interface PluginTmdbSearchPage {
+  page: number;
+  results: PluginTmdbSearchResult[];
+  total_pages: number;
+  total_results: number;
+}
+
+// ─── Folder rules ───────────────────────────────────────────────────
+
+/** Read-only view of a FolderRule row. Plugins can enumerate existing routing rules
+ *  (e.g. to offer the same category picker as the web UI) but not mutate them. */
+export interface PluginFolderRule {
+  id: number;
+  name: string;
+  priority: number;
+  mediaType: string;
+  /** JSON-parsed conditions array. Shape matches the admin UI's routing-rule editor. */
+  conditions: Array<{ field: string; operator: string; value: unknown }>;
+  folderPath: string;
+  seriesType: string | null;
+  serviceId: number | null;
+  enabled: boolean;
+}
+
+// ─── Event bus payloads ─────────────────────────────────────────────
+
+/** Versioned envelope: plugins subscribe to a stable `v: 1` contract. Future payload changes
+ *  emit alongside `v: 2` etc. — no silent breakage. */
+export interface PluginUserNotificationCreatedV1 {
+  v: 1;
+  userId: number;
+  type: string;
+  title: string;
+  message: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+/** Emitted when a piece of media becomes available in the library (post-sync confirm). The
+ *  `requesterUserIds` list enumerates every user whose request was fulfilled by this event,
+ *  so broadcast-style plugins can translate one "media available" fact into N per-user
+ *  side-effects without extra DB queries. */
+export interface PluginMediaAvailableV1 {
+  v: 1;
+  mediaId: number;
+  tmdbId: number;
+  mediaType: 'movie' | 'tv';
+  title: string;
+  posterPath: string | null;
+  requesterUserIds: number[];
+}

--- a/packages/shared/src/pluginContext.ts
+++ b/packages/shared/src/pluginContext.ts
@@ -101,8 +101,16 @@ export interface PluginUserNotificationCreatedV1 {
   v: 1;
   userId: number;
   type: string;
+  /** Raw value as stored in the DB. May be an i18n key (`notifications.msg.*`) or a literal
+   *  string (e.g. a media title). Plugins should prefer `titleText` / `messageText` for
+   *  display; these raw fields are kept on the contract so subscribers that want to
+   *  re-translate against a per-user locale can do so. */
   title: string;
   message: string;
+  /** Pre-translated text resolved against the instance language at emit time. Same shape
+   *  the web frontend ultimately renders. Plugins should display these directly. */
+  titleText?: string;
+  messageText?: string;
   metadata: Record<string, unknown>;
   createdAt: string;
 }


### PR DESCRIPTION
Closes #165.

## Summary

Extends the v1 PluginContext with the surface needed by a non-trivial plugin (Discord bot, Slack pusher, analytics sink) to ship without reaching into backend internals or self-HTTP-ing back to its own host. Pure additive — every existing plugin keeps working unchanged.

Companion plugin rewrite: [arediss/Leonarr#feat/ctx-v1.1-rewrite](https://github.com/arediss/Leonarr/pull/new/feat/ctx-v1.1-rewrite) — the audit that drove this issue.

## What's new in `PluginContext` (manifest \`apiVersion: \"v1\"\` unchanged)

3 new capability buckets — opt-in via \`manifest.capabilities\`:
- \`tmdb:read\` — \`ctx.tmdb.{search, movie, tv}\` cached + locale-aware
- \`requests:read\` — \`ctx.requests.listForUser\` + \`ctx.media.{batchStatus, getById}\`
- \`requests:write\` — \`ctx.requests.create\` runs the *exact same pipeline* as \`POST /api/requests\` (extracted to \`createUserRequest\` in Step 0 — zero drift possible)

Extensions on existing buckets (no breaking change):
- \`ctx.getArrClients(type)\` pluriel for multi-Radarr / multi-Sonarr fan-out (singular \`getArrClient\` kept)
- \`ctx.findUserByEmail(email)\` symmetric with \`findUserByProvider\`
- \`ctx.listFolderRules({ enabled? })\` for plugins surfacing the same routing categories as the web UI
- \`ctx.getUser\` / \`findUserByProvider\` / \`findUserByEmail\` now include \`avatar\` (additive widening)
- \`ctx.app.internalFetch(path, { asUserId? })\` escape hatch — engine mints a per-user cookie, plugin doesn't guess port/host

Event bus emissions from core (replaces polling patterns):
- \`user.notification.created\` fired by \`safeUserNotify\` — replaces \`UserNotification\` cron polling. Ships pre-translated \`titleText\` / \`messageText\` resolved against the instance language at emit time, plus the raw key for the in-app bell's per-user-language render. Templates live in \`@oscarr/shared/notificationTemplates\` — single source of truth between backend pre-translation and frontend NotificationBell.
- \`media.available\` fired by \`sendAvailabilityNotifications\` — broadcast-scoped (one event per piece of media, payload carries every requester userId so a Discord channel post fires once instead of N times).

Both payloads versioned (\`v: 1\`) so future shape changes coexist.

## Plug-and-play OAuth link flow

\`/api/auth/discord/authorize?action=link\` on a logged-out browser used to return raw \`401 JSON\`. Now redirects to \`/login?next=<original URL>\`; LoginPage honours \`next\` after every successful auth path with a strict same-origin guard (\`new URL(raw, origin)\` + origin match — rejects \`//foo\`, \`/\\foo\`, foreign origins, malformed URLs). Generic plumbing — every plugin using OAuth-link can point at it.

## Other fixes shipped

- **Boot-time \`onEnable\`** — already-enabled plugins were dormant after a restart until the admin toggled off+on. Engine now calls \`onEnable\` on every enabled plugin at boot, parallelised via \`Promise.allSettled\` so a slow Discord login doesn't block other plugins.
- **Webhook \"Recently added\" gap** — \`/api/webhooks/:type\` 'download' now backfills \`radarrId\`/\`sonarrId\` so webhook-only flows surface in the home query (admins disabling the sync job stopped seeing media on the home).
- **Notif dedup** — \`sendAvailabilityNotifications\` deduped userIds for the in-app bell (web push was already deduped). \`metadata.posterPath\` now flows through to plugins for richer cards.
- **Plugin permission registration in \`registerRoutes\`** — engine flow already idempotent (\`pluginPermissions.some(...)\` check in rbac.ts), no change needed.
- **DB path regression** — \`getDbPath\` was anchored on \`BACKEND_ROOT\` instead of \`BACKEND_PRISMA_DIR\`. Backup job + dataPath helpers were resolving \`packages/data/oscarr.db\` instead of \`packages/backend/data/oscarr.db\`. Fixed with a comment pointing at Prisma's documented relative-to-schema convention.

## Review status

Two pr-review-toolkit passes done. All findings ≥ confidence 80 fixed inline:
- ✅ \`?next=\` open-redirect via backslash (\`/\\evil.com\`) — switched to URL-parser-based same-origin check
- ✅ \`redirectAfterLogin\` infinite recursion fallback — fixed
- ✅ \`instanceLanguages\` cache flush on settings save
- ✅ Boot-time onEnable parallelisation
- ✅ \`NOTIF_I18N\` extracted to \`@oscarr/shared\` for single source of truth

## Test plan

- [x] Typecheck back + front green
- [x] \`PUT /admin/settings { instanceLanguages: ['fr'] }\` flushes language cache; subsequent \`safeUserNotify\` emit ships French \`messageText\`
- [x] \`/api/auth/discord/authorize?action=link\` while logged out → bounces through \`/login?next=\` → completes link
- [x] \`?next=//evil.com\` / \`/\\evil.com\` → drop, fall back to \`/\`
- [x] Webhook 'download' on a fresh media → backfills \`sonarrId\` → surfaces in \`/api/media/recent\`
- [x] Auto-backup job runs without "Database file not found"
- [x] Disable then re-enable a plugin in admin → onEnable fires
- [x] Restart Oscarr while plugin enabled → onEnable fires automatically
- [x] Two requests on the same media → one in-app notif (not two)
- [x] \`@oscarr/shared\` published v0.7.0-dev with new types
- [x] \`docs/plugins.md\` capability table includes the 3 new buckets