### PR TITLE
fix: routing rules service mapping when quality is selected

### DIFF
--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -152,8 +152,13 @@ export async function resolveServiceContext(
     const mapping = await prisma.qualityMapping.findFirst({
       where: {
         qualityOptionId,
+        // When a folder rule matched a service, look up the quality mapping on THAT service;
+        // otherwise (serviceId undefined = ignored) fall back to the first enabled service. The
+        // enabled/type filter stays on both branches so a matched-but-disabled service yields no
+        // mapping and falls back to the default profile, instead of applying a profile id that is
+        // only valid on another instance.
         serviceId: targetServiceId ?? undefined,
-        service: targetServiceId ? undefined : { type: serviceType, enabled: true },
+        service: { type: serviceType, enabled: true },
       },
       include: { service: true },
     });

--- a/packages/backend/src/services/requestService.ts
+++ b/packages/backend/src/services/requestService.ts
@@ -152,7 +152,8 @@ export async function resolveServiceContext(
     const mapping = await prisma.qualityMapping.findFirst({
       where: {
         qualityOptionId,
-        service: { type: serviceType, enabled: true },
+        serviceId: targetServiceId ?? undefined,
+        service: targetServiceId ? undefined : { type: serviceType, enabled: true },
       },
       include: { service: true },
     });


### PR DESCRIPTION
**Problem**
When requesting media:

1. If a request is made without selecting a quality option, the routing rules work correctly, dispatching the request to the target service and folder path set in the matched FolderRule.
2. However, if a request is made with a quality option selected, the request gets routed to the default (first available) service and folder path instead of the one specified by the folder rules.

**Cause**
In resolveServiceContext (requestService.ts), the QualityMapping query was unconstrained by the already resolved targetServiceId:

typescript
```
const mapping = await prisma.qualityMapping.findFirst({
  where: {
    qualityOptionId,
    service: { type: serviceType, enabled: true },
  },
  include: { service: true },
});
```
This always returned the first available service's mapping (typically the default instance) and overwrote targetServiceId, bypassing the custom service chosen by the folder rules.

**Solution**
Restricted the QualityMapping query to look up the quality profile on the specifically matched service (targetServiceId) if one was set by the folder rules. If no service was matched by the rules, it falls back to the original behavior:

typescript
```
const mapping = await prisma.qualityMapping.findFirst({
  where: {
    qualityOptionId,
    serviceId: targetServiceId ?? undefined,
    service: targetServiceId ? undefined : { type: serviceType, enabled: true },
  },
  include: { service: true },
});
```

- If a folder rule matched a specific service: It now fetches the mapped quality profile ID for that service.
- If no folder rule matched a service: It falls back to the first available enabled service matching the quality option.

**Testing / Verification**
Tested in a setup with multiple Radarr/Sonarr instances (e.g., standard vs. 4K/Anime instances):

- Requesting media with a specific quality option now successfully respects the target service and folder path configured in the matching folder rules.