### PR TITLE
fix: restore manual installation builds for 0.9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,10 @@ jobs:
 
       - run: npm ci
 
-      - name: Generate Prisma client
-        run: npx prisma generate --schema=packages/backend/prisma/schema.prisma
-
-      # backend + frontend both import from @oscarr/shared; its package.json main/types point to
-      # dist/, so the shared package has to be built before either side can typecheck.
-      - name: Build shared package
-        run: npm run build --workspace=packages/shared
-
-      - name: Typecheck backend
-        run: npx tsc --noEmit --project packages/backend/tsconfig.json
-
-      - name: Typecheck frontend
-        run: npx tsc --noEmit --project packages/frontend/tsconfig.json
+      # Exercise the documented clean-install build, including Prisma generation and typechecks
+      # for shared, backend and frontend. Preparing Prisma separately would hide build failures.
+      - name: Build all workspaces
+        run: npm run build
 
       # Applies the real migrations to a throwaway SQLite file and generates its own secrets, so
       # it needs no service container and no repository secret.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.9.0-6366f1?style=flat-square" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.9.1-6366f1?style=flat-square" alt="Version" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="License" />
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square" alt="PRs Welcome" />
   <a href="https://discord.gg/vB25SNTqCS"><img src="https://img.shields.io/badge/Discord-join-5865F2?style=flat-square&amp;logo=discord&amp;logoColor=white" alt="Discord" /></a>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,8 +4,8 @@ The recommended way to run Oscarr is with Docker — see the README's *Quick Sta
 
 ## Prerequisites
 
-- Node.js 20+
-- npm 9+
+- Node.js 22 LTS (22.19.0 or newer in the 22.x series, as used by CI and Docker)
+- npm 11
 - A media server (Plex, Jellyfin, or Emby — optional, can be added later)
 - A TMDB API key (optional — a built-in read-access token is provided)
 
@@ -13,13 +13,15 @@ The recommended way to run Oscarr is with Docker — see the README's *Quick Sta
 
 ```bash
 git clone https://github.com/arediss/Oscarr.git
-cd Oscarr/app
-npm install --legacy-peer-deps
+cd Oscarr
+npm ci
 ```
 
 ## Configuration
 
-Create a `.env` file at `app/.env`. `OSCARR_SECRET_KEY`, `JWT_SECRET` and `SETUP_SECRET` are
+Run all commands in this guide from the repository root (the directory containing `package.json`).
+
+Create a `.env` file at the repository root. `OSCARR_SECRET_KEY`, `JWT_SECRET` and `SETUP_SECRET` are
 required — Oscarr refuses to start on a placeholder or a value under 16 characters. Generate them
 with `openssl rand -hex 32` for the first and `openssl rand -base64 32` for the other two:
 
@@ -73,6 +75,13 @@ Starts the frontend (`:5173`) and backend (`:3456`) concurrently.
 npm run build
 NODE_ENV=production node packages/backend/dist/index.js
 ```
+
+The build generates Prisma Client automatically before checking and compiling the backend. It does
+not connect to or modify your database. Keep the repository's TypeScript configuration; disabling
+strict checks does not fix missing generated types and can introduce additional errors.
+
+After updating Oscarr, run `npm ci` and `npm run build` again before restarting it. Keep your existing
+`.env`, secrets, database and install state.
 
 ## First launch
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oscarr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oscarr",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "workspaces": [
         "packages/*"
       ],
@@ -11662,7 +11662,7 @@
     },
     "packages/backend": {
       "name": "@oscarr/backend",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.0.1",
@@ -11721,7 +11721,7 @@
     },
     "packages/frontend": {
       "name": "@oscarr/frontend",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@dicebear/avataaars": "^9.4.2",
         "@dicebear/core": "^9.4.2",
@@ -11758,7 +11758,7 @@
     },
     "packages/shared": {
       "name": "@oscarr/shared",
-      "version": "0.9.0"
+      "version": "0.9.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oscarr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/backend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "npm run db:generate && tsc --strict",
     "build:bundle": "node esbuild.config.mjs",
     "start": "node dist/index.js",
     "db:generate": "dotenv -e ../../.env -- prisma generate",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/frontend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscarr/shared",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "latest": "0.9.0",
+  "latest": "0.9.1",
   "releaseUrl": "https://github.com/arediss/Oscarr/pkgs/container/oscarr"
 }


### PR DESCRIPTION
A clean `npm ci` leaves Prisma Client without Oscarr's generated model types, so `npm run build` fails with 136 backend TypeScript errors. The backend build now generates the client before compiling and explicitly retains strict type checking. No database migration or application logic changes are involved.

CI now runs the same full build as a manual installation, without a separate Prisma preparation step hiding this failure. The installation guide uses the current repository layout, locked dependencies and the Node 22 LTS baseline used by CI and Docker.

A separate release commit aligns the workspace versions, lockfile, README badge and update manifest at 0.9.1.

Validation:
- Reproduced the clean-install failure on Node 24.14.0 and Node 26.8.1 with npm 11.9.0 and TypeScript 6.0.3.
- Reproduced the reported `unknown` properties and `CreateRequestResult` errors exactly with an ungenerated client and `strict: false`.
- Full build passes on Node 26.8.1 after the change, without a `.env` file or database.
- Backend build also passes with `strict: false` in the local configuration because the build explicitly enables strict checking.
- The clean build and existing backend/frontend test suites passed in CI on Node 22 for the fix commit.
- A fresh `npm ci`, full 0.9.1 build and backend production bundle pass on Node 26.8.1.
